### PR TITLE
fix: 4 server.log bugs + cancel/shortlist handling

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3247,7 +3247,9 @@ class AppController {
           document.querySelectorAll('.pixel-btn.hire').forEach(b => { b.disabled = false; b.textContent = 'Hire'; });
         } else {
           this.logEntry('CEO', `⏳ Onboarding ${data.name || candidate.name} in background...`, 'ceo');
+          this._batchHired = true;
           this.closeCandidateModal();
+          this._batchHired = false;
           this.closeInterviewModal();
         }
       })

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3038,11 +3038,15 @@ class AppController {
 
     this.logEntry('CEO', `Batch hiring ${selections.length} candidate(s)...`, 'ceo');
 
+    // Mark as hired so closeCandidateModal won't dismiss
+    this._batchHired = true;
+
     // Show onboarding progress modal
     this._showOnboardingProgress(selections);
 
     // Close candidate modal
     this.closeCandidateModal();
+    this._batchHired = false;
 
     fetch('/api/candidates/batch-hire', {
       method: 'POST',
@@ -3203,9 +3207,23 @@ class AppController {
   }
 
   closeCandidateModal() {
-    document.getElementById('candidate-modal').classList.add('hidden');
+    const modal = document.getElementById('candidate-modal');
+    const wasVisible = !modal.classList.contains('hidden');
+    modal.classList.add('hidden');
+
+    // If modal was visible and no candidates were hired, dismiss the shortlist
+    if (wasVisible && this._candidateBatchId && (!this._batchHired)) {
+      fetch('/api/candidates/dismiss', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ batch_id: this._candidateBatchId }),
+      }).catch(() => {});
+      this.logEntry('CEO', '🚫 Shortlist dismissed — this recruitment round is cancelled.', 'ceo');
+    }
+
     this._interviewingCandidate = null;
     this._selectedCandidates = new Map();
+    this._candidateBatchId = null;
   }
 
   hireCandidate(candidate) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.233"
+version = "0.2.234"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.235"
+version = "0.2.236"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.236"
+version = "0.2.237"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.234"
+version = "0.2.235"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -1032,14 +1032,14 @@ def update_project_team(members: list[dict]) -> dict:
     Returns:
         Confirmation with count of added members.
     """
-    from onemancompany.core.vessel import _current_vessel, _current_task_id
+    from onemancompany.core.agent_loop import _current_vessel, _current_task_id
 
     vessel = _current_vessel.get()
     task_id = _current_task_id.get()
     if not vessel or not task_id:
         return {"status": "error", "message": "No agent context."}
 
-    task = vessel.board.get_task(task_id)
+    task = vessel.get_task(task_id)
     if not task or not task.project_dir:
         return {"status": "error", "message": "No project directory in current task."}
 

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -3882,15 +3882,36 @@ async def dismiss_shortlist(body: dict) -> dict:
     from onemancompany.agents.recruitment import pending_candidates, _pending_project_ctx
 
     batch_id = body.get("batch_id", "")
-    if batch_id and batch_id in pending_candidates:
-        pending_candidates.pop(batch_id, None)
-        _pending_project_ctx.pop(batch_id, None)
+    if not batch_id:
+        return {"status": "error", "message": "batch_id required"}
+
+    # Clean up pending data
+    pending_candidates.pop(batch_id, None)
+    _pending_project_ctx.pop(batch_id, None)
+
+    from onemancompany.agents.recruitment import _persist_candidates
+    _persist_candidates()
+
+    # Resume HR's HOLDING task so it doesn't hang forever
+    from onemancompany.core.vessel import employee_manager as _em
+    from onemancompany.core.task_tree import get_tree as _get_tree
+    dismiss_reason = "CEO认为这次招聘是不需要的或者错误的，已取消本轮招聘"
+    for entry in _em._schedule.get(HR_ID, []):
+        tp = Path(entry.tree_path)
+        if not tp.exists():
+            continue
+        tree = _get_tree(tp)
+        node = tree.get_node(entry.node_id)
+        if node and node.status == "holding" and node.result and f"batch_id={batch_id}" in node.result:
+            await _em.resume_held_task(HR_ID, entry.node_id, dismiss_reason)
+            break
 
     await event_bus.publish(CompanyEvent(
         type="activity",
         payload={"text": "CEO dismissed the shortlist — this recruitment round is cancelled.", "cls": "ceo"},
         agent="CEO",
     ))
+    await event_bus.publish(CompanyEvent(type="state_snapshot", payload={}, agent="CEO"))
 
     return {"status": "ok", "message": "Shortlist dismissed"}
 

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -1735,15 +1735,20 @@ async def cancel_agent_task(employee_id: str, task_id: str) -> dict:
     from onemancompany.core.agent_loop import employee_manager
     from onemancompany.core.task_tree import get_tree, save_tree_async
 
-    # Find the entry in the schedule
+    # Find the entry in the schedule OR check if it's the currently running task
     entry_found = None
     for entry in employee_manager._schedule.get(employee_id, []):
         if entry.node_id == task_id:
             entry_found = entry
             break
 
+    # Also check the running task's entry (running tasks are popped from schedule)
+    running_entry = employee_manager._current_entries.get(employee_id)
+    if not entry_found and running_entry and running_entry.node_id == task_id:
+        entry_found = running_entry
+
     if not entry_found:
-        return {"status": "error", "message": "Task not found in schedule"}
+        return {"status": "error", "message": "Task not found in schedule or running tasks"}
 
     # Load tree and node
     tp = Path(entry_found.tree_path)
@@ -3869,6 +3874,25 @@ async def _do_hire_single(
                      "message": str(e)},
             agent="HR",
         ))
+
+
+@router.post("/api/candidates/dismiss")
+async def dismiss_shortlist(body: dict) -> dict:
+    """CEO dismissed the shortlist — cancel this recruitment round."""
+    from onemancompany.agents.recruitment import pending_candidates, _pending_project_ctx
+
+    batch_id = body.get("batch_id", "")
+    if batch_id and batch_id in pending_candidates:
+        pending_candidates.pop(batch_id, None)
+        _pending_project_ctx.pop(batch_id, None)
+
+    await event_bus.publish(CompanyEvent(
+        type="activity",
+        payload={"text": "CEO dismissed the shortlist — this recruitment round is cancelled.", "cls": "ceo"},
+        agent="CEO",
+    ))
+
+    return {"status": "ok", "message": "Shortlist dismissed"}
 
 
 @router.post("/api/candidates/batch-hire")

--- a/src/onemancompany/core/automation.py
+++ b/src/onemancompany/core/automation.py
@@ -66,10 +66,10 @@ async def _cron_loop(employee_id: str, cron_name: str, interval_seconds: int, ta
             await asyncio.sleep(interval_seconds)
             loop = get_agent_loop(employee_id)
             if loop:
-                agent_task = loop.push_task(f"[cron:{cron_name}] {task_description}")
+                task_id = loop.push_task(f"[cron:{cron_name}] {task_description}")
                 # Record dispatched task ID
-                _record_dispatched_task(employee_id, cron_name, agent_task.id)
-                logger.debug(f"[cron] Dispatched '{cron_name}' to {employee_id}, task_id={agent_task.id}")
+                _record_dispatched_task(employee_id, cron_name, task_id)
+                logger.debug(f"[cron] Dispatched '{cron_name}' to {employee_id}, task_id={task_id}")
             else:
                 logger.warning(f"[cron] Employee {employee_id} not found, skipping '{cron_name}'")
     except asyncio.CancelledError:

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1057,6 +1057,10 @@ class EmployeeManager:
             self._log_node(employee_id, entry.node_id, "cancelled", "Task cancelled")
             save_tree_async(entry.tree_path)
             self._publish_node_update(employee_id, node)
+            # Cascade-cancel downstream dependents
+            if project_dir:
+                tree = get_tree(entry.tree_path)
+                _trigger_dep_resolution(project_dir, tree, node)
             raise
         except TimeoutError as te:
             agent_error = True

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1055,6 +1055,9 @@ class EmployeeManager:
             if not node.completed_at:
                 node.completed_at = datetime.now().isoformat()
             self._log_node(employee_id, entry.node_id, "cancelled", "Task cancelled")
+            save_tree_async(entry.tree_path)
+            self._publish_node_update(employee_id, node)
+            raise
         except TimeoutError as te:
             agent_error = True
             node.set_status(TaskPhase.FAILED)

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -554,6 +554,7 @@ class EmployeeManager:
         self.task_histories: dict[str, list[dict]] = {}
         self._history_summaries: dict[str, str] = {}
         self._running_tasks: dict[str, asyncio.Task] = {}
+        self._current_entries: dict[str, ScheduleEntry] = {}  # currently executing entry per employee
         self._system_tasks: dict[str, asyncio.Task] = {}  # system operation tracking
         self._deferred_schedule: set[str] = set()
         self._hooks: dict[str, dict[str, Callable]] = {}
@@ -895,9 +896,11 @@ class EmployeeManager:
 
     async def _run_task(self, employee_id: str, entry: ScheduleEntry) -> None:
         """Execute a task, then schedule the next one."""
+        self._current_entries[employee_id] = entry
         try:
             await self._execute_task(employee_id, entry)
         finally:
+            self._current_entries.pop(employee_id, None)
             self._running_tasks.pop(employee_id, None)
             self._schedule_next(employee_id)
             if self._restart_pending and self.is_idle():

--- a/tests/unit/agents/test_common_tools.py
+++ b/tests/unit/agents/test_common_tools.py
@@ -1661,10 +1661,8 @@ class TestUpdateProjectTeam:
         task = MagicMock()
         task.project_dir = str(tmp_path)
         task.project_id = "test-proj"
-        board = MagicMock()
-        board.get_task.return_value = task
         vessel = MagicMock()
-        vessel.board = board
+        vessel.get_task.return_value = task
 
         tok_v = _current_vessel.set(vessel)
         tok_t = _current_task_id.set("task-1")
@@ -1703,10 +1701,8 @@ class TestUpdateProjectTeam:
         task = MagicMock()
         task.project_dir = str(tmp_path)
         task.project_id = "test-proj"
-        board = MagicMock()
-        board.get_task.return_value = task
         vessel = MagicMock()
-        vessel.board = board
+        vessel.get_task.return_value = task
 
         tok_v = _current_vessel.set(vessel)
         tok_t = _current_task_id.set("task-2")

--- a/tests/unit/api/test_routes.py
+++ b/tests/unit/api/test_routes.py
@@ -2662,7 +2662,7 @@ class TestCancelTask:
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.post("/api/employee/00010/task/t1/cancel")
 
-        assert resp.json()["message"] == "Task not found in schedule"
+        assert resp.json()["message"] == "Task not found in schedule or running tasks"
 
     async def test_cancel_task_already_completed(self, tmp_path):
         from onemancompany.core.task_tree import TaskTree


### PR DESCRIPTION
## Summary
- **update_project_team tool**: Fixed `vessel.board.get_task()` → `vessel.get_task()` (attribute removed in compat cleanup)
- **automation.py cron crash**: Fixed `agent_task.id` → `task_id` (`push_task()` returns `str`, not object)
- **Cancel/nuke buttons**: Added `_current_entries` tracking to `EmployeeManager` so cancel endpoint can find running tasks (previously only searched `_schedule`, but running tasks are popped from it)
- **Shortlist dismiss**: Closing candidate modal without hiring now calls `/api/candidates/dismiss` to clean up state and log CEO's decision

## Test plan
- [x] All 1838 existing tests pass
- [x] Updated `TestUpdateProjectTeam` to mock `vessel.get_task()` instead of `vessel.board`
- [x] Updated `TestCancelTask` assertion to match new error message
- [ ] Manual test: trigger cron, verify no crash
- [ ] Manual test: cancel a running task via UI
- [ ] Manual test: close shortlist modal, verify state cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)