### PR TITLE
fix: dynamic provider hint + LLM-powered project naming

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.294"
+version = "0.2.295"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -557,9 +557,9 @@ async def ceo_submit_task(body: dict) -> dict:
     from pathlib import Path
     from onemancompany.core.agent_loop import get_agent_loop
     from onemancompany.core.project_archive import (
+        async_create_project_from_task,
         create_iteration,
         create_named_project,
-        create_project_from_task,
         get_project_workspace,
     )
 
@@ -583,8 +583,8 @@ async def ceo_submit_task(body: dict) -> dict:
         pid = create_named_project(project_name)
         iter_id = create_iteration(pid, task, "pending")
     else:
-        # Auto-create named project from task description
-        pid, iter_id = create_project_from_task(task, "pending")
+        # Auto-create named project from task description (LLM-powered naming)
+        pid, iter_id = await async_create_project_from_task(task, "pending")
 
     pdir = get_project_workspace(pid)
 

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -172,21 +172,61 @@ def _save_resolved(version: str, resolved_key: str, doc: dict) -> None:
 # ─────────────────────────────────────────────
 
 def _auto_project_name(task: str) -> str:
-    """Generate a short project name from a task description.
-
-    Takes the first line, truncates to ~50 chars on a word boundary.
-    """
+    """Fallback: derive a project name by truncating the task description."""
     first_line = task.strip().split("\n")[0].strip()
     if len(first_line) <= 50:
         return first_line or "Untitled Project"
-    # Truncate at word boundary
     truncated = first_line[:50].rsplit(" ", 1)[0]
     return truncated or first_line[:50]
 
 
+async def _llm_project_name(task: str) -> str:
+    """Use the default LLM to generate a concise project name (2-6 words)."""
+    try:
+        from langchain_core.messages import HumanMessage, SystemMessage
+
+        from onemancompany.agents.base import build_llm, tracked_ainvoke
+
+        llm = build_llm(temperature=0)
+        result = await tracked_ainvoke(
+            llm,
+            [
+                SystemMessage(content=(
+                    "You are a project naming assistant. "
+                    "Given a CEO's task description, generate a concise project name in 2-6 words. "
+                    "Use the same language as the task description. "
+                    "Return ONLY the project name, nothing else. No quotes, no punctuation, no explanation."
+                )),
+                HumanMessage(content=task[:500]),
+            ],
+            category="overhead",
+        )
+        name = result.content.strip().strip('"\'')
+        if 1 < len(name) <= 60:
+            return name
+    except Exception as exc:
+        logger.debug("LLM project naming failed, using fallback: {}", exc)
+    return _auto_project_name(task)
+
+
+async def async_create_project_from_task(
+    task: str,
+    routed_to: str = "pending",
+    participants: list[str] | None = None,
+) -> tuple[str, str]:
+    """Create a named project + first iteration, using LLM for the name.
+
+    Returns (project_id, iteration_id).
+    """
+    name = await _llm_project_name(task)
+    project_id = create_named_project(name)
+    iter_id = create_iteration(project_id, task, routed_to)
+    return project_id, iter_id
+
+
 def create_project_from_task(task: str, routed_to: str = "pending",
                              participants: list[str] | None = None) -> tuple[str, str]:
-    """Create a v2 named project + first iteration from a task description.
+    """Sync fallback: create project with truncation-based name.
 
     Returns (project_id, iteration_id).
     """

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -2469,7 +2469,7 @@ async def _create_project_from_action_points(
     action_points: list[str], meeting_type: str, transcript_excerpt: str,
 ) -> str:
     """Create a new project from meeting action points, dispatched to EA."""
-    from onemancompany.core.project_archive import create_project_from_task, get_project_workspace
+    from onemancompany.core.project_archive import async_create_project_from_task, get_project_workspace
     from onemancompany.core.task_tree import TaskTree
     from onemancompany.core.vessel import _save_project_tree
     from onemancompany.core.agent_loop import employee_manager
@@ -2483,7 +2483,7 @@ async def _create_project_from_action_points(
         + f"\n\nMeeting context:\n{transcript_excerpt}"
     )
 
-    pid, _iter_id = create_project_from_task(task_desc, "pending")
+    pid, _iter_id = await async_create_project_from_task(task_desc, "pending")
     pdir = get_project_workspace(pid)
 
     tree = TaskTree(project_id=pid)

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -236,13 +236,23 @@ def _step_llm(console: Console) -> tuple[str, str, str]:
 
     console.print("  Select your LLM provider:\n")
     console.print(table)
+
+    # Find OpenRouter's actual position in the filtered list
+    or_num = next(
+        (i for i, g in enumerate(available_groups, 1) if g.group_id == "openrouter"),
+        None,
+    )
+    hint = (
+        f"  Not sure? [bold]{or_num}[/bold] (OpenRouter) works with most models."
+        if or_num else "  Not sure? OpenRouter works with most models."
+    )
     console.print(
-        "\n  [dim]Type the number of your provider and press [bold]Enter[/bold].\n"
-        "  Not sure? [bold]1[/bold] (OpenRouter) works with most models.[/dim]\n"
+        f"\n  [dim]Type the number of your provider and press [bold]Enter[/bold].\n"
+        f"  {hint}[/dim]\n"
     )
 
     while True:
-        choice = Prompt.ask("  Provider #", default="1", console=console).strip()
+        choice = Prompt.ask("  Provider #", default=str(or_num or 1), console=console).strip()
         if choice.isdigit() and 1 <= int(choice) <= len(available_groups):
             selected_group = available_groups[int(choice) - 1]
             break

--- a/tests/unit/api/test_routes.py
+++ b/tests/unit/api/test_routes.py
@@ -310,7 +310,7 @@ class TestCeoSubmitTask:
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
              patch("onemancompany.core.agent_loop.get_agent_loop", return_value=mock_loop), \
-             patch("onemancompany.core.project_archive.create_project_from_task", return_value=("proj_123", "iter_001")), \
+             patch("onemancompany.core.project_archive.async_create_project_from_task", new_callable=AsyncMock, return_value=("proj_123", "iter_001")), \
              patch("onemancompany.core.project_archive.get_project_workspace", return_value="/tmp/proj"):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -336,7 +336,7 @@ class TestCeoSubmitTask:
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
              patch("onemancompany.core.agent_loop.get_agent_loop", return_value=mock_loop), \
-             patch("onemancompany.core.project_archive.create_project_from_task", return_value=("proj_123", "iter_001")), \
+             patch("onemancompany.core.project_archive.async_create_project_from_task", new_callable=AsyncMock, return_value=("proj_123", "iter_001")), \
              patch("onemancompany.core.project_archive.get_project_workspace", return_value="/tmp/proj"), \
              patch("onemancompany.core.vessel._save_project_tree", mock_save_tree):
             app = _make_test_app()
@@ -4002,7 +4002,7 @@ class TestCeoTaskEAFallback:
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
              patch("onemancompany.core.agent_loop.get_agent_loop", return_value=None), \
-             patch("onemancompany.core.project_archive.create_project_from_task", return_value=("p1", "iter_001")), \
+             patch("onemancompany.core.project_archive.async_create_project_from_task", new_callable=AsyncMock, return_value=("p1", "iter_001")), \
              patch("onemancompany.core.project_archive.get_project_workspace", return_value="/tmp/p1"):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:


### PR DESCRIPTION
## Summary
- **Onboard wizard**: OpenRouter provider hint now shows actual position (9) instead of hardcoded "1"; default prompt value updated accordingly
- **Project naming**: New `async_create_project_from_task()` uses LLM to generate concise 2-6 word project names in the same language as the task, instead of truncating the CEO's prompt to 50 chars; falls back to truncation if LLM call fails

## Test plan
- [x] All 1847 unit tests pass
- [ ] Run `onemancompany-init` and verify OpenRouter shows as #9 in hint text
- [ ] Submit a CEO task and verify project gets a meaningful name (not truncated prompt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)