### PR TITLE
fix: batch-hire reliability — prevent task GC, always resume HR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.296"
+version = "0.2.297"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.297"
+version = "0.2.298"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.295"
+version = "0.2.296"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.298"
+version = "0.2.299"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -169,9 +169,13 @@ def make_llm(employee_id: str = "") -> BaseChatModel:
         logger.debug("Provider '{}' has no key, falling back to openrouter default", api_provider)
         model = settings.default_llm_model
 
+    fallback_key = settings.openrouter_api_key
+    if not fallback_key:
+        logger.warning("make_llm: no API key for provider '{}' and no OpenRouter fallback key; LLM calls will fail", api_provider)
+
     return ChatOpenAI(
         model=model,
-        api_key=settings.openrouter_api_key,
+        api_key=fallback_key,
         base_url=settings.openrouter_base_url,
         temperature=temperature,
         max_retries=3,

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -104,14 +104,18 @@ def _resolve_provider_key(provider_name: str, employee_api_key: str) -> str:
     return ""
 
 
-def make_llm(employee_id: str = "") -> BaseChatModel:
+def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseChatModel:
     """Create an LLM instance, using per-agent model config from employees/{id}/profile.yaml.
 
     Supports all providers in PROVIDER_REGISTRY (openrouter, openai, anthropic,
     kimi, deepseek, qwen, zhipu, groq, together, etc.).
+
+    Args:
+        employee_id: Use this employee's LLM config. Empty = company default.
+        temperature: Override temperature. None = use employee/default value.
     """
     model = settings.default_llm_model
-    temperature = 0.7
+    effective_temp = 0.7
     api_provider = "openrouter"
     api_key = ""
 
@@ -119,9 +123,12 @@ def make_llm(employee_id: str = "") -> BaseChatModel:
         cfg = employee_configs[employee_id]
         if cfg.llm_model:
             model = cfg.llm_model
-        temperature = cfg.temperature
+        effective_temp = cfg.temperature
         api_provider = cfg.api_provider
         api_key = cfg.api_key
+
+    if temperature is not None:
+        effective_temp = temperature
 
     prov = get_provider(api_provider)
 
@@ -143,7 +150,7 @@ def make_llm(employee_id: str = "") -> BaseChatModel:
             return ChatAnthropic(
                 model=model,
                 api_key=effective_key,
-                temperature=temperature,
+                temperature=effective_temp,
                 max_retries=3,
                 default_headers=extra_headers or None,
             )
@@ -160,7 +167,7 @@ def make_llm(employee_id: str = "") -> BaseChatModel:
                 model=model,
                 api_key=effective_key,
                 base_url=base_url,
-                temperature=temperature,
+                temperature=effective_temp,
                 max_retries=3,
             )
 
@@ -177,7 +184,7 @@ def make_llm(employee_id: str = "") -> BaseChatModel:
         model=model,
         api_key=fallback_key,
         base_url=settings.openrouter_base_url,
-        temperature=temperature,
+        temperature=effective_temp,
         max_retries=3,
     )
 

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -992,8 +992,8 @@ async def execute_hire(
                 _register_employee_hooks(emp_num, emp_dir)
 
     # Trigger onboarding routine as background task
-    import asyncio
     from onemancompany.core.routine import run_onboarding_routine
-    asyncio.create_task(run_onboarding_routine(emp_num))
+    from onemancompany.core.async_utils import spawn_background
+    spawn_background(run_onboarding_routine(emp_num))
 
     return emp

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -12,6 +12,7 @@ from fastapi.responses import FileResponse
 from loguru import logger
 
 from onemancompany.agents.base import tracked_ainvoke
+from onemancompany.core.async_utils import spawn_background
 from onemancompany.api.websocket import ws_manager
 from onemancompany.core.config import (
     CEO_ID,
@@ -3652,20 +3653,6 @@ _pending_oauth_hire: dict[str, dict] = {}
 # frontend can restore the progress modal after a page refresh.
 # Structure: { batch_id: { "items": { candidate_id: {name, role, step, message} }, "total": N } }
 _active_onboarding: dict[str, dict] = {}
-# prevent background tasks from being GC'd (Python 3.12+ asyncio weak-refs)
-_background_tasks: set[asyncio.Task] = set()
-
-
-def _spawn_background(coro) -> asyncio.Task:
-    """Launch a fire-and-forget background task with GC protection.
-
-    Python 3.12+ only keeps weak references to asyncio tasks.
-    This stores a strong reference until the task completes.
-    """
-    task = asyncio.create_task(coro)
-    _background_tasks.add(task)
-    task.add_done_callback(_background_tasks.discard)
-    return task
 
 
 def _track_onboarding_progress(batch_id: str, candidate_id: str, name: str, role: str, step: str, message: str, total: int) -> None:
@@ -3792,7 +3779,7 @@ async def hire_candidate(body: HireRequest) -> dict:
         logger.info("[hiring] Applying COO context: role='{}' over talent role='{}'", coo_ctx.get("role"), candidate.get("role"))
 
     # Launch onboarding as background task
-    _spawn_background(
+    spawn_background(
         _do_hire_single(body.batch_id, body.candidate_id, body.nickname, candidate, coo_ctx)
     )
 
@@ -4036,7 +4023,7 @@ async def batch_hire_candidates(body: dict) -> dict:
             coo_ctxs.append({})
 
     # Launch background task for the actual hiring
-    _spawn_background(
+    spawn_background(
         _do_batch_hire(batch_id, selections, list(all_candidates), coo_ctxs)
     )
 
@@ -4244,14 +4231,14 @@ async def _do_batch_hire(
                     logger.info("[hiring] Resumed HR holding task {}", entry.node_id)
                     break
             else:
-                logger.warning("[hiring] No matching HR holding task found for batch_id={}", batch_id)
+                logger.debug("[hiring] No matching HR holding task found for batch_id={}", batch_id)
         except Exception as resume_exc:
             logger.error("[hiring] Failed to resume HR holding task: {}", resume_exc)
 
         try:
             await event_bus.publish(CompanyEvent(type="state_snapshot", payload={}, agent="CEO"))
-        except Exception:
-            logger.debug("[hiring] Could not publish state_snapshot in finally")
+        except Exception as pub_exc:
+            logger.debug("[hiring] Could not publish state_snapshot in finally: {}", pub_exc)
 
 
 @router.post("/api/candidates/interview")
@@ -5471,7 +5458,7 @@ async def open_ceo_conversation(node_id: str):
     register_session(session)
 
     # Start conversation loop as background task
-    _spawn_background(_run_conversation_loop(session, node, tree, project_dir))
+    spawn_background(_run_conversation_loop(session, node, tree, project_dir))
 
     messages = load_messages(Path(project_dir) / "conversations", node_id)
     node.load_content(project_dir)

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import traceback
 import uuid as _uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -3657,6 +3656,18 @@ _active_onboarding: dict[str, dict] = {}
 _background_tasks: set[asyncio.Task] = set()
 
 
+def _spawn_background(coro) -> asyncio.Task:
+    """Launch a fire-and-forget background task with GC protection.
+
+    Python 3.12+ only keeps weak references to asyncio tasks.
+    This stores a strong reference until the task completes.
+    """
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task
+
+
 def _track_onboarding_progress(batch_id: str, candidate_id: str, name: str, role: str, step: str, message: str, total: int) -> None:
     """Update in-memory onboarding tracker for state recovery on refresh."""
     if batch_id not in _active_onboarding:
@@ -3781,7 +3792,7 @@ async def hire_candidate(body: HireRequest) -> dict:
         logger.info("[hiring] Applying COO context: role='{}' over talent role='{}'", coo_ctx.get("role"), candidate.get("role"))
 
     # Launch onboarding as background task
-    asyncio.create_task(
+    _spawn_background(
         _do_hire_single(body.batch_id, body.candidate_id, body.nickname, candidate, coo_ctx)
     )
 
@@ -3911,8 +3922,7 @@ async def _do_hire_single(
     except asyncio.CancelledError:
         raise
     except Exception as e:
-        logger.error("[hiring] Background hire failed for {}: {}", candidate.get("name"), e)
-        traceback.print_exc()
+        logger.exception("[hiring] Background hire failed for {}", candidate.get("name"))
         _track_onboarding_progress(batch_id, candidate_id, candidate.get("name", ""), "", "failed", str(e), 1)
         await event_bus.publish(CompanyEvent(
             type="onboarding_progress",
@@ -4025,12 +4035,10 @@ async def batch_hire_candidates(body: dict) -> dict:
         else:
             coo_ctxs.append({})
 
-    # Launch background task for the actual hiring (store ref to prevent GC)
-    task = asyncio.create_task(
+    # Launch background task for the actual hiring
+    _spawn_background(
         _do_batch_hire(batch_id, selections, list(all_candidates), coo_ctxs)
     )
-    _background_tasks.add(task)
-    task.add_done_callback(_background_tasks.discard)
 
     names = []
     for sel in selections:
@@ -4053,6 +4061,7 @@ async def _do_batch_hire(
 
     total = len(selections)
     results = []
+    hired_names: list[str] = []
     logger.info("[batch-hire] Starting batch hire: batch_id={}, {} candidates", batch_id, total)
 
     try:
@@ -4170,7 +4179,7 @@ async def _do_batch_hire(
                         _notify_coo_hire_ready(emp.id, coo_ctx)
 
             except Exception as e:
-                traceback.print_exc()
+                logger.exception("[hiring] execute_hire failed for {}", cand_name)
                 _track_onboarding_progress(batch_id, candidate_id, cand_name, sel_role, "failed", str(e), total)
                 await event_bus.publish(CompanyEvent(
                     type="onboarding_progress",
@@ -4217,14 +4226,10 @@ async def _do_batch_hire(
     except asyncio.CancelledError:
         raise
     except Exception as e:
-        logger.error("[hiring] Background batch hire failed: {}", e)
-        traceback.print_exc()
+        logger.exception("[hiring] Background batch hire failed")
     finally:
         # ALWAYS resume HR HOLDING task — even on partial/total failure
-        try:
-            resume_msg = f"Batch hired: {', '.join(hired_names)}" if hired_names else "Batch hire completed (no candidates hired)"
-        except NameError:
-            resume_msg = "Batch hire failed"
+        resume_msg = f"Batch hired: {', '.join(hired_names)}" if hired_names else "Batch hire completed (no candidates hired)"
         try:
             from onemancompany.core.vessel import employee_manager as _em_batch
             from onemancompany.core.task_tree import get_tree as _get_tree_batch
@@ -4243,7 +4248,10 @@ async def _do_batch_hire(
         except Exception as resume_exc:
             logger.error("[hiring] Failed to resume HR holding task: {}", resume_exc)
 
-        await event_bus.publish(CompanyEvent(type="state_snapshot", payload={}, agent="CEO"))
+        try:
+            await event_bus.publish(CompanyEvent(type="state_snapshot", payload={}, agent="CEO"))
+        except Exception:
+            logger.debug("[hiring] Could not publish state_snapshot in finally")
 
 
 @router.post("/api/candidates/interview")
@@ -5463,7 +5471,7 @@ async def open_ceo_conversation(node_id: str):
     register_session(session)
 
     # Start conversation loop as background task
-    asyncio.create_task(_run_conversation_loop(session, node, tree, project_dir))
+    _spawn_background(_run_conversation_loop(session, node, tree, project_dir))
 
     messages = load_messages(Path(project_dir) / "conversations", node_id)
     node.load_content(project_dir)

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -3653,6 +3653,8 @@ _pending_oauth_hire: dict[str, dict] = {}
 # frontend can restore the progress modal after a page refresh.
 # Structure: { batch_id: { "items": { candidate_id: {name, role, step, message} }, "total": N } }
 _active_onboarding: dict[str, dict] = {}
+# prevent background tasks from being GC'd (Python 3.12+ asyncio weak-refs)
+_background_tasks: set[asyncio.Task] = set()
 
 
 def _track_onboarding_progress(batch_id: str, candidate_id: str, name: str, role: str, step: str, message: str, total: int) -> None:
@@ -4023,10 +4025,12 @@ async def batch_hire_candidates(body: dict) -> dict:
         else:
             coo_ctxs.append({})
 
-    # Launch background task for the actual hiring
-    asyncio.create_task(
+    # Launch background task for the actual hiring (store ref to prevent GC)
+    task = asyncio.create_task(
         _do_batch_hire(batch_id, selections, list(all_candidates), coo_ctxs)
     )
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
 
     names = []
     for sel in selections:
@@ -4190,21 +4194,6 @@ async def _do_batch_hire(
         pending_candidates.pop(batch_id, None)
         _persist_candidates()
 
-        # Resume HR HOLDING task
-        from onemancompany.core.vessel import employee_manager as _em_batch
-        from onemancompany.core.task_tree import get_tree as _get_tree_batch
-        for entry in _em_batch._schedule.get(HR_ID, []):
-            tp = Path(entry.tree_path)
-            if not tp.exists():
-                continue
-            tree = _get_tree_batch(tp)
-            node = tree.get_node(entry.node_id)
-            if node and node.status == "holding" and node.result and f"batch_id={batch_id}" in node.result:
-                await _em_batch.resume_held_task(HR_ID, entry.node_id, f"Batch hired: {', '.join(hired_names)}")
-                break
-
-        await event_bus.publish(CompanyEvent(type="state_snapshot", payload={}, agent="CEO"))
-
         # Dispatch COO task for department assignment (only if no project context)
         last_coo_ctx = coo_ctxs[-1] if coo_ctxs else {}
         if not last_coo_ctx.get("project_id"):
@@ -4222,13 +4211,39 @@ async def _do_batch_hire(
                     f"{emp_lines}",
                 )
 
-        logger.info("[hiring] Background batch hire completed: {} hired", len(hired_names))
+        logger.info("[hiring] Background batch hire completed: {} hired, {} failed",
+                     len(hired_names), len(results) - len(hired_names))
 
     except asyncio.CancelledError:
         raise
     except Exception as e:
         logger.error("[hiring] Background batch hire failed: {}", e)
         traceback.print_exc()
+    finally:
+        # ALWAYS resume HR HOLDING task — even on partial/total failure
+        try:
+            resume_msg = f"Batch hired: {', '.join(hired_names)}" if hired_names else "Batch hire completed (no candidates hired)"
+        except NameError:
+            resume_msg = "Batch hire failed"
+        try:
+            from onemancompany.core.vessel import employee_manager as _em_batch
+            from onemancompany.core.task_tree import get_tree as _get_tree_batch
+            for entry in _em_batch._schedule.get(HR_ID, []):
+                tp = Path(entry.tree_path)
+                if not tp.exists():
+                    continue
+                tree = _get_tree_batch(tp)
+                node = tree.get_node(entry.node_id)
+                if node and node.status == "holding" and node.result and f"batch_id={batch_id}" in node.result:
+                    await _em_batch.resume_held_task(HR_ID, entry.node_id, resume_msg)
+                    logger.info("[hiring] Resumed HR holding task {}", entry.node_id)
+                    break
+            else:
+                logger.warning("[hiring] No matching HR holding task found for batch_id={}", batch_id)
+        except Exception as resume_exc:
+            logger.error("[hiring] Failed to resume HR holding task: {}", resume_exc)
+
+        await event_bus.publish(CompanyEvent(type="state_snapshot", payload={}, agent="CEO"))
 
 
 @router.post("/api/candidates/interview")

--- a/src/onemancompany/core/async_utils.py
+++ b/src/onemancompany/core/async_utils.py
@@ -1,0 +1,31 @@
+"""Async utilities — shared helpers for asyncio task management."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+
+from loguru import logger
+
+# Strong references to prevent Python 3.12+ GC of fire-and-forget tasks.
+_background_tasks: set[asyncio.Task] = set()
+
+
+def spawn_background(coro: Coroutine[Any, Any, Any]) -> asyncio.Task:
+    """Launch a fire-and-forget background task with GC protection.
+
+    Python 3.12+ only keeps weak references to asyncio tasks.
+    Without a strong reference, fire-and-forget tasks may be silently
+    garbage-collected before completion.
+    """
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+
+    def _on_done(t: asyncio.Task) -> None:
+        _background_tasks.discard(t)
+        if not t.cancelled() and t.exception():
+            logger.error("Background task failed: {}", t.exception())
+
+    task.add_done_callback(_on_done)
+    return task

--- a/src/onemancompany/core/heartbeat.py
+++ b/src/onemancompany/core/heartbeat.py
@@ -10,6 +10,8 @@ Health checks via probe_chat (minimal-token probe):
 from __future__ import annotations
 
 import asyncio
+
+from onemancompany.core.async_utils import spawn_background
 import os
 
 from loguru import logger
@@ -146,7 +148,7 @@ def _update_online(emp_id: str, online: bool, changed: list[str]) -> None:
     current = emp_data.get("runtime", {}).get("api_online", False)
     if current != online:
         try:
-            asyncio.create_task(_store.save_employee_runtime(emp_id, api_online=online))
+            spawn_background(_store.save_employee_runtime(emp_id, api_online=online))
         except RuntimeError:
             logger.debug("No event loop for runtime persist of {}", emp_id)
         if emp_id not in changed:

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -188,6 +188,9 @@ async def _llm_project_name(task: str) -> str:
         from onemancompany.agents.base import make_llm, tracked_ainvoke
 
         llm = make_llm()
+        # Use temperature=0 for deterministic naming
+        if hasattr(llm, 'temperature'):
+            llm.temperature = 0
         result = await tracked_ainvoke(
             llm,
             [

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -187,10 +187,7 @@ async def _llm_project_name(task: str) -> str:
 
         from onemancompany.agents.base import make_llm, tracked_ainvoke
 
-        llm = make_llm()
-        # Use temperature=0 for deterministic naming
-        if hasattr(llm, 'temperature'):
-            llm.temperature = 0
+        llm = make_llm(temperature=0)
         result = await tracked_ainvoke(
             llm,
             [

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -185,9 +185,9 @@ async def _llm_project_name(task: str) -> str:
     try:
         from langchain_core.messages import HumanMessage, SystemMessage
 
-        from onemancompany.agents.base import build_llm, tracked_ainvoke
+        from onemancompany.agents.base import make_llm, tracked_ainvoke
 
-        llm = build_llm(temperature=0)
+        llm = make_llm()
         result = await tracked_ainvoke(
             llm,
             [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -19,6 +19,8 @@ Design:
 from __future__ import annotations
 
 import asyncio
+
+from onemancompany.core.async_utils import spawn_background
 import json
 import traceback
 import uuid
@@ -2148,7 +2150,7 @@ class EmployeeManager:
 
     def _set_employee_status(self, employee_id: str, status: str) -> None:
         try:
-            asyncio.create_task(_store.save_employee_runtime(employee_id, status=status))
+            spawn_background(_store.save_employee_runtime(employee_id, status=status))
         except RuntimeError:
             logger.debug("No event loop for runtime persist of {}", employee_id)
 


### PR DESCRIPTION
## Summary
- **Background task GC prevention**: Python 3.12+ `asyncio.create_task` only keeps weak references — fire-and-forget tasks can be silently garbage collected. Store task references in `_background_tasks` set to keep them alive.
- **Always resume HR holding**: Move HR holding resume logic to `finally` block so it fires even when all hire attempts fail. Previously, if every `execute_hire` raised, HR would be stuck in holding forever.
- **API key warning**: `make_llm` now logs a warning when no API key is available, instead of silently creating an LLM client that will 401.
- **Fix `build_llm` typo**: PR #15 introduced a call to `build_llm()` which doesn't exist — fixed to `make_llm()`.

## Root cause
Observed in test environment: CEO submitted "我们招几个人吧" → HR submitted shortlist → batch-hire fired → `_do_batch_hire` background task produced zero log output → HR stuck in holding state permanently. The `pending.yaml` still had the batch on disk while in-memory state was cleared, confirming the task was interrupted mid-execution.

## Test plan
- [x] All 1847 unit tests pass
- [ ] Submit a hiring task, approve batch-hire, verify HR resumes even if candidates fail to hire
- [ ] Verify `[hiring]` log entries appear during batch-hire

🤖 Generated with [Claude Code](https://claude.com/claude-code)