### PR TITLE
fix: Settings has no data_dir — use DATA_ROOT for nickname pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.308",
+  "version": "0.2.309",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.308"
+version = "0.2.309"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -67,7 +67,8 @@ def _load_nickname_pool() -> list[str]:
     so there is no measurable overhead.
     """
     # Runtime data dir takes priority (user may have customised it there)
-    runtime_file = settings.data_dir / "company" / "human_resource" / "nicknames.txt"
+    from onemancompany.core.config import DATA_ROOT
+    runtime_file = DATA_ROOT / "company" / "human_resource" / "nicknames.txt"
     src = runtime_file if runtime_file.exists() else _NICKNAMES_FILE
 
     if src.exists():

--- a/tests/unit/agents/test_onboarding.py
+++ b/tests/unit/agents/test_onboarding.py
@@ -135,16 +135,15 @@ class TestGenerateNickname:
     @pytest.mark.asyncio
     async def test_loads_from_file(self, monkeypatch, tmp_path):
         from onemancompany.agents import onboarding
+        from onemancompany.core import config as _config
 
         monkeypatch.setattr(onboarding, "_get_existing_nicknames", lambda: set())
 
         nick_file = tmp_path / "nicknames.txt"
         nick_file.write_text("剑心\n龙吟\n虎啸\n")
         monkeypatch.setattr(onboarding, "_NICKNAMES_FILE", nick_file)
-        # Also mock settings.data_dir to a non-existent path so it falls back to _NICKNAMES_FILE
-        mock_settings = MagicMock()
-        mock_settings.data_dir = tmp_path / "nonexistent"
-        monkeypatch.setattr(onboarding, "settings", mock_settings)
+        # Point DATA_ROOT to a non-existent path so it falls back to _NICKNAMES_FILE
+        monkeypatch.setattr(_config, "DATA_ROOT", tmp_path / "nonexistent")
 
         nickname = await onboarding.generate_nickname("Dev", "Engineer")
         assert nickname in {"剑心", "龙吟", "虎啸"}
@@ -580,12 +579,12 @@ class TestPickNickname:
 
     def test_loads_from_file(self, monkeypatch, tmp_path):
         from onemancompany.agents import onboarding
+        from onemancompany.core import config as _config
         nick_file = tmp_path / "nicknames.txt"
         nick_file.write_text("剑心\n龙吟\n")
         monkeypatch.setattr(onboarding, "_NICKNAMES_FILE", nick_file)
-        mock_settings = MagicMock()
-        mock_settings.data_dir = tmp_path / "nonexistent"
-        monkeypatch.setattr(onboarding, "settings", mock_settings)
+        # Point DATA_ROOT to a non-existent path so it falls back to _NICKNAMES_FILE
+        monkeypatch.setattr(_config, "DATA_ROOT", tmp_path / "nonexistent")
         result = onboarding._pick_nickname(2, set())
         assert result in {"剑心", "龙吟"}
 


### PR DESCRIPTION
## Summary
- `_load_nickname_pool()` used `settings.data_dir` which doesn't exist on the Settings pydantic model
- Replace with `DATA_ROOT` from `core.config` (the module-level constant used everywhere else)
- Update 2 tests that mocked `settings.data_dir` to mock `config.DATA_ROOT` instead

## Root cause
`settings.data_dir` was introduced during PR #17 nickname pool implementation but `Settings` class never had this attribute. All other code uses `DATA_ROOT = Path.cwd() / ".onemancompany"`.

## Test plan
- [x] 76 onboarding tests pass
- [x] 1848 total tests pass
- [ ] Manual test: recruitment flow assigns nicknames successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)