### PR TITLE
fix: async project naming + talent market debug logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.310",
+  "version": "0.2.311",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.309",
+  "version": "0.2.310",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.310"
+version = "0.2.311"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.309"
+version = "0.2.310"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/recruitment.py
+++ b/src/onemancompany/agents/recruitment.py
@@ -347,15 +347,20 @@ class TalentMarketClient:
         if not self._session:
             raise RuntimeError("Not connected to Talent Market")
         kwargs["api_key"] = self._api_key
+        logger.debug("[TalentMarket] calling tool={} args={}", tool_name,
+                     {k: v[:30] + "..." if isinstance(v, str) and len(v) > 30 else v for k, v in kwargs.items() if k != "api_key"})
         result = await self._session.call_tool(tool_name, arguments=kwargs)
+        logger.debug("[TalentMarket] result content blocks: {}", len(result.content))
         for item in result.content:
             try:
                 parsed = json.loads(item.text)
             except (json.JSONDecodeError, AttributeError):
-                logger.debug("Skipping unparseable MCP content block")
+                logger.debug("Skipping unparseable MCP content block: {}", getattr(item, 'text', '')[:200])
                 continue
             if isinstance(parsed, dict):
                 return parsed
+        logger.warning("[TalentMarket] No dict found in response, raw content: {}",
+                      [getattr(item, 'text', '')[:200] for item in result.content])
         return {}
 
     async def search(self, job_description: str) -> dict:
@@ -398,11 +403,13 @@ async def start_talent_market() -> None:
     from onemancompany.core.config import load_app_config
 
     tm_config = load_app_config().get("talent_market", {})
+    logger.debug("[recruitment] talent_market config: {}", {k: v[:8] + "..." if k == "api_key" and v else v for k, v in tm_config.items()})
     url = tm_config.get("url", "https://api.one-man-company.com/mcp/sse")
     api_key = tm_config.get("api_key", "")
     if not api_key:
         logger.warning("Talent Market API key not configured — skipping connection")
         return
+    logger.info("[recruitment] Connecting to Talent Market at {} ...", url)
     await talent_market.connect(url, api_key)
 
 
@@ -441,16 +448,19 @@ async def search_candidates(job_description: str) -> dict:
     """
     global _last_session_id
 
+    logger.debug("[recruitment] search_candidates called, talent_market.connected={}", talent_market.connected)
     if talent_market.connected:
         try:
+            logger.debug("[recruitment] Calling Talent Market API for JD: {}", job_description[:80])
             grouped = await talent_market.search(job_description)
             total = sum(len(r.get("candidates", [])) for r in grouped.get("roles", []))
             logger.info("Talent Market returned {} candidates in {} roles for JD: {}",
                         total, len(grouped.get("roles", [])), job_description[:80])
         except Exception as e:
-            logger.error("Talent Market search failed: {}", e)
+            logger.opt(exception=e).error("Talent Market search failed, falling back to local: {!r}", e)
             grouped = _local_fallback_search(job_description)
     else:
+        logger.info("[recruitment] Talent Market not connected, using local talent pool")
         grouped = _local_fallback_search(job_description)
 
     _last_session_id = grouped.get("session_id", "")

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -231,7 +231,12 @@ async def async_create_project_from_task(
     from onemancompany.core.async_utils import spawn_background
 
     async def _rename_when_ready() -> None:
-        llm_name = await _llm_project_name(task)
+        import asyncio as _aio
+        try:
+            llm_name = await _aio.wait_for(_llm_project_name(task), timeout=30.0)
+        except _aio.TimeoutError:
+            logger.warning("LLM project naming timed out for {}, keeping fallback", project_id)
+            return
         if llm_name and llm_name != fallback_name:
             _update_project_name(project_id, llm_name)
             logger.info("Project {} renamed: '{}' → '{}'", project_id, fallback_name, llm_name)
@@ -246,10 +251,10 @@ async def async_create_project_from_task(
 def _update_project_name(project_id: str, new_name: str) -> None:
     """Update the display name of an existing named project."""
     path = PROJECTS_DIR / project_id / "project.yaml"
-    if not path.exists():
-        return
     lock = _get_project_lock(project_id)
     with lock:
+        if not path.exists():
+            return
         with open(path) as f:
             doc = yaml.safe_load(f) or {}
         doc["name"] = new_name

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -214,14 +214,47 @@ async def async_create_project_from_task(
     routed_to: str = "pending",
     participants: list[str] | None = None,
 ) -> tuple[str, str]:
-    """Create a named project + first iteration, using LLM for the name.
+    """Create a named project + first iteration, non-blocking.
+
+    Creates the project immediately with a truncation-based fallback name,
+    then spawns a background task to generate a better LLM name and update
+    the project asynchronously.
 
     Returns (project_id, iteration_id).
     """
-    name = await _llm_project_name(task)
-    project_id = create_named_project(name)
+    # Immediate: create project with fallback name so it appears instantly
+    fallback_name = _auto_project_name(task)
+    project_id = create_named_project(fallback_name)
     iter_id = create_iteration(project_id, task, routed_to)
+
+    # Background: generate LLM name and update when ready
+    from onemancompany.core.async_utils import spawn_background
+
+    async def _rename_when_ready() -> None:
+        llm_name = await _llm_project_name(task)
+        if llm_name and llm_name != fallback_name:
+            _update_project_name(project_id, llm_name)
+            logger.info("Project {} renamed: '{}' → '{}'", project_id, fallback_name, llm_name)
+            # Notify frontend via store dirty so next sync tick picks it up
+            from onemancompany.core.store import mark_dirty
+            mark_dirty("task_queue")
+
+    spawn_background(_rename_when_ready())
     return project_id, iter_id
+
+
+def _update_project_name(project_id: str, new_name: str) -> None:
+    """Update the display name of an existing named project."""
+    path = PROJECTS_DIR / project_id / "project.yaml"
+    if not path.exists():
+        return
+    lock = _get_project_lock(project_id)
+    with lock:
+        with open(path) as f:
+            doc = yaml.safe_load(f) or {}
+        doc["name"] = new_name
+        with open(path, "w") as f:
+            yaml.dump(doc, f, allow_unicode=True, default_flow_style=False)
 
 
 def create_project_from_task(task: str, routed_to: str = "pending",


### PR DESCRIPTION
## Summary
- **Async project naming**: Project now appears instantly with a truncation-based fallback name. LLM naming runs in background via `spawn_background()` and updates the name when ready (triggers `mark_dirty("task_queue")` so frontend picks it up on next sync tick).
- **Talent market debug logging**: Added detailed debug logs throughout `TalentMarketClient._call()`, `search_candidates()`, and `start_talent_market()` to diagnose why connected talent market falls back to local search (observed empty exception on `search()`).

## Test plan
- [x] All 1848 existing tests pass
- [ ] Manual: submit a new task → project appears immediately with fallback name, then name updates within a few seconds
- [ ] Manual: run with `--debug` flag and check talent market connection/search logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)