### PR TITLE
fix: accept_child str/enum bug + debug logging design principle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.313",
+  "version": "0.2.314",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.313"
+version = "0.2.314"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -353,17 +353,20 @@ def accept_child(node_id: str, notes: str = "") -> dict:
         if not node:
             return {"status": "error", "message": f"Node {node_id} not found."}
 
+        # Normalize status to string for comparison (TaskNode.status is str)
+        current = node.status.value if hasattr(node.status, "value") else node.status
+
         # Idempotent: already accepted → return success without re-transitioning
-        if node.status == TaskPhase.ACCEPTED:
+        if current == TaskPhase.ACCEPTED.value:
             return {"status": "accepted", "node_id": node_id, "notes": notes, "already_accepted": True}
-        if node.status == TaskPhase.FINISHED:
+        if current == TaskPhase.FINISHED.value:
             return {"status": "accepted", "node_id": node_id, "notes": notes, "already_finished": True}
 
         # Only completed tasks can be accepted
-        if node.status != TaskPhase.COMPLETED:
+        if current != TaskPhase.COMPLETED.value:
             return {
                 "status": "error",
-                "message": f"Cannot accept node {node_id}: current status is '{node.status.value}', must be 'completed' first.",
+                "message": f"Cannot accept node {node_id}: current status is '{current}', must be 'completed' first.",
             }
 
         node.set_status(TaskPhase.ACCEPTED)

--- a/vibe-coding-guide.md
+++ b/vibe-coding-guide.md
@@ -120,7 +120,34 @@ company_state.employees[emp_id].status = "working"
 await store.save_employee_runtime(emp_id, status="working")
 ```
 
-### 6. Minimal Complexity
+### 6. Debug Logging at Key Nodes
+
+Every critical code path must have `logger.debug(...)` at key decision points: function entry with parameters, branching conditions, external call results, and error context. Users deploy with INFO level (default); `--debug` mode (`OMC_DEBUG=1`) enables DEBUG level to surface these logs for diagnosis.
+
+**What to log (DEBUG level):**
+- Function entry with key parameters (truncate long strings)
+- Branch decisions: which path was taken and why
+- External call inputs/outputs (MCP, LLM, API)
+- State transitions and their triggers
+- Loop iterations with item identifiers
+
+**What NOT to log at DEBUG:**
+- Every line of execution (that's tracing, not debugging)
+- Full request/response bodies (truncate to key fields)
+- Sensitive data (API keys, tokens — mask them)
+
+```python
+# Good: key decision points logged
+logger.debug("[recruitment] search called, market_connected={}", talent_market.connected)
+logger.debug("[recruitment] Talent Market candidate #{}: id={}, name={}", idx, tid, tname)
+
+# Bad: no debug logs, impossible to diagnose in production
+grouped = await talent_market.search(jd)  # what happened? who knows
+```
+
+**Rule:** If a bug required adding debug logs to diagnose, those logs stay in the codebase permanently. They cost nothing at INFO level and save hours on the next issue.
+
+### 7. Minimal Complexity
 
 Don't over-engineer. The right amount of complexity is the **minimum** needed for the current task. Three similar lines are better than a premature abstraction.
 


### PR DESCRIPTION
## Summary
- **accept_child bug**: `TaskNode.status` is `str` but was compared against `TaskPhase` enum (always `False`), then `.value` called on string → `AttributeError`. Fixed to normalize to string comparison, consistent with rest of codebase.
- **Debug logging principle**: Added as design principle #6 in `vibe-coding-guide.md` — all critical code paths must have `logger.debug()` at key decision points. Default deploy uses INFO level; `--debug` (`OMC_DEBUG=1`) enables DEBUG.

## Test plan
- [x] All 1848 existing tests pass
- [ ] Manual: trigger accept_child on a completed task node → should succeed without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)