### PR TITLE
fix: polish direction result not saved — route org edits through COO

### DIFF
--- a/company/shared_prompts/tool_usage.md
+++ b/company/shared_prompts/tool_usage.md
@@ -1,10 +1,13 @@
 ## Tool Usage
-- list_project_workspace: ALWAYS call this first to see existing project files.
-- read_file / list_directory: Read existing files to understand context before working.
-- save_to_project: Save ALL deliverables to the project workspace.
+- ls: ALWAYS call this first to see existing project files.
+- read / ls: Read existing files to understand context before working.
+- write: Save ALL deliverables to the project workspace.
+- edit: Modify existing files (partial edits).
+- bash: Run shell commands (build, test, deploy, etc.).
 - dispatch_child: Delegate sub-work to colleagues if needed.
 - pull_meeting: ONLY for multi-person communication/discussion (2+ colleagues). Never call a meeting with yourself alone — if you need to think, just think internally.
 - use_tool: Access company equipment/tools registered by COO.
+- request_tool_access: Apply for access to tools you don't have permission to use.
 
 ## Modifying Company-Level Knowledge
 When your task involves updating **company direction, culture, workflows, SOPs, or shared guidance**, you do NOT have direct write access to these resources. Instead:
@@ -20,7 +23,7 @@ When a task involves operations that can be completed using system tools, **you 
 |-----------|---------------|-----------------|
 | Send/draft email | Write email content as plain text in response | Call `gmail_create_draft` or `gmail_send` to create a real draft |
 | Create calendar event | Only describe event information | Call the calendar tool to create a real event |
-| Save file | Only display file content | Call `save_to_project` to write an actual file |
+| Save file | Only display file content | Call `write` to save an actual file |
 | Code execution | Only paste code snippets | Actually run in sandbox and provide execution results |
 
 ### Rules

--- a/company/shared_prompts/tool_usage.md
+++ b/company/shared_prompts/tool_usage.md
@@ -2,9 +2,15 @@
 - list_project_workspace: ALWAYS call this first to see existing project files.
 - read_file / list_directory: Read existing files to understand context before working.
 - save_to_project: Save ALL deliverables to the project workspace.
-- dispatch_task: Delegate sub-work to colleagues if needed.
+- dispatch_child: Delegate sub-work to colleagues if needed.
 - pull_meeting: ONLY for multi-person communication/discussion (2+ colleagues). Never call a meeting with yourself alone — if you need to think, just think internally.
 - use_tool: Access company equipment/tools registered by COO.
+
+## Modifying Company-Level Knowledge
+When your task involves updating **company direction, culture, workflows, SOPs, or shared guidance**, you do NOT have direct write access to these resources. Instead:
+1. Prepare the final content (e.g. polished company direction text).
+2. Use `dispatch_child` to send the content to **COO (00003)**, requesting COO to call `deposit_company_knowledge(category=..., name=..., content=...)` to persist it.
+3. COO will review and save. Do NOT attempt to write these files directly.
 
 ## Tool-First Mandate
 When a task involves operations that can be completed using system tools, **you must directly invoke the tool to produce tangible artifacts**. Simply describing/displaying content in text form and expecting manual follow-up is prohibited.

--- a/company/shared_prompts/work_approach.md
+++ b/company/shared_prompts/work_approach.md
@@ -1,5 +1,5 @@
 ## Work Approach
-1. Review: FIRST use list_project_workspace to see what already exists in the project. Read key files to understand what's been done — never start from scratch blindly.
+1. Review: FIRST use `ls` to see what already exists in the project workspace. Read key files with `read` to understand what's been done — never start from scratch blindly.
 2. Analyze: Understand the task requirements in context of existing deliverables.
 3. Execute: Produce the deliverable — iterate on what exists, don't duplicate.
 4. Verify: Check your output once (run code, proofread doc). Fix if needed.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4987,7 +4987,7 @@ class AppController {
     btn.disabled = true;
     btn.textContent = '⏳ Sending...';
 
-    const task = `The CEO has drafted a company direction statement. Please polish and expand it into a complete corporate positioning description, preserving the core message while adding strategic vision, target market, core competencies, and other dimensions. Once polished, use the save_company_direction tool to save.\n\nDraft content:\n${draft}`;
+    const task = `The CEO has drafted a company direction statement. Please polish and expand it into a complete corporate positioning description, preserving the core message while adding strategic vision, target market, core competencies, and other dimensions. Once polished, dispatch to COO to save via deposit_company_knowledge(category="direction").\n\nDraft content:\n${draft}`;
 
     fetch('/api/ceo/task', {
       method: 'POST',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.379",
+  "version": "0.2.380",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.377",
+  "version": "0.2.378",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.380",
+  "version": "0.2.381",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.378",
+  "version": "0.2.379",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.381",
+  "version": "0.2.382",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.378"
+version = "0.2.379"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.377"
+version = "0.2.378"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.381"
+version = "0.2.382"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.380"
+version = "0.2.381"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.379"
+version = "0.2.380"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -101,13 +101,18 @@ async def _publish(event_type: str, payload: dict) -> None:
 
 
 async def _chat(room_id: str, speaker: str, role: str, message: str) -> None:
-    """Publish a meeting_chat event for real-time meeting chat display."""
-    await _publish("meeting_chat", {
+    """Publish a meeting_chat event and persist to disk."""
+    from datetime import datetime
+    entry = {
         "room_id": room_id,
         "speaker": speaker,
         "role": role,
         "message": message,
-    })
+        "time": datetime.now().strftime("%H:%M:%S"),
+    }
+    await _publish("meeting_chat", entry)
+    from onemancompany.core.store import append_room_chat
+    await append_room_chat(room_id, entry)
 
 
 # ---------------------------------------------------------------------------

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -330,7 +330,7 @@ async def project_progress_watchdog() -> list | None:
                 description=nudge_desc,
                 acceptance_criteria=[],
             )
-            nudge_node.node_type = "review"
+            nudge_node.node_type = "watchdog_nudge"
             nudge_node.project_id = project_id
             nudge_node.project_dir = ea_node.project_dir or str(tree_path.parent)
             save_tree_async(tree_path_str)

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1838,8 +1838,22 @@ class EmployeeManager:
                 "Review circuit breaker: {} rounds for parent {} — escalating to CEO",
                 review_count, parent_node.id,
             )
-            parent_node.set_status(TaskPhase.HOLDING)
-            logger.debug("[TASK LIFECYCLE] parent={} → HOLDING (review circuit breaker, {} rounds)", parent_node.id, review_count)
+            # Check if CEO escalation already exists to prevent infinite loop
+            existing_escalation = any(
+                c for c in children
+                if c.node_type == "ceo_request" and c.employee_id == CEO_ID
+                and c.status not in (TaskPhase.CANCELLED,)
+            )
+            if existing_escalation:
+                logger.debug(
+                    "[CIRCUIT BREAKER] CEO escalation already exists for parent {} — skipping duplicate",
+                    parent_node.id,
+                )
+                return
+
+            if parent_node.status != TaskPhase.HOLDING:
+                parent_node.set_status(TaskPhase.HOLDING)
+                logger.debug("[TASK LIFECYCLE] parent={} → HOLDING (review circuit breaker, {} rounds)", parent_node.id, review_count)
             save_tree_async(entry.tree_path)
 
             # Build escalation summary


### PR DESCRIPTION
## Summary
- Fix Company Direction "Polish" button: result was never saved because frontend told EA to use non-existent `save_company_direction` tool
- Add shared prompt guidance: all employees must `dispatch_child` to COO for org-level knowledge changes (direction, culture, workflows, SOPs, guidance)
- Fix stale tool name `dispatch_task` → `dispatch_child` in shared tool_usage.md

## Root Cause
Frontend task prompt referenced `save_company_direction` tool which doesn't exist. EA has no direct org-level write access — only COO has `deposit_company_knowledge`.

## Test plan
- [x] All 1926 unit tests pass
- [ ] Click "Polish / Enrich" on Company Direction → verify EA dispatches to COO → COO saves polished result

🤖 Generated with [Claude Code](https://claude.com/claude-code)