### PR TITLE
fix: project docs, workspace path, and wall modal

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3672,7 +3672,7 @@ class AppController {
     listEl.classList.remove('hidden');
     document.getElementById('project-detail').classList.add('hidden');
 
-    fetch('/api/projects')
+    fetch('/api/projects/named')
       .then(r => r.json())
       .then(data => {
         const projects = data.projects || [];
@@ -3684,25 +3684,52 @@ class AppController {
         for (const p of projects) {
           const card = document.createElement('div');
           card.className = 'project-card';
-          const statusIcon = p.status === 'completed' ? '\u2705' : '\uD83D\uDD04';
+          const statusIcon = p.status === 'completed' ? '\u2705' : (p.status === 'archived' ? '\uD83D\uDCE6' : '\uD83D\uDD04');
           const date = p.created_at ? p.created_at.substring(0, 10) : '';
           const costStr = p.cost_usd ? ` · $${p.cost_usd.toFixed(3)}` : '';
+          const name = p.name || p.task || p.project_id;
           card.innerHTML = `
             <div class="project-card-header">
-              <span>${statusIcon} ${p.task.substring(0, 40)}${p.task.length > 40 ? '...' : ''}</span>
+              <span>${statusIcon} ${name.substring(0, 50)}${name.length > 50 ? '...' : ''}</span>
               <span class="project-card-date">${date}</span>
             </div>
             <div class="project-card-meta">
-              ${p.routed_to}${p.current_owner && p.status !== 'completed' ? ' · Current: ' + p.current_owner : ''} | ${p.participant_count} participants | ${p.action_count} entries${costStr}
+              ${p.iteration_count || 0} iteration(s) | ${p.file_count || 0} files${costStr}${p.current_owner ? ' · ' + p.current_owner : ''}
             </div>
           `;
           card.style.cursor = 'pointer';
-          card.addEventListener('click', () => this.loadProjectDetail(p.project_id));
+          card.addEventListener('click', () => {
+            // Show iteration split view (same as sidebar)
+            this._showProjectInModal(p.project_id);
+          });
           listEl.appendChild(card);
         }
       })
       .catch(err => {
         listEl.innerHTML = `<div style="color:var(--pixel-red);font-size:7px;">Load failed: ${err.message}</div>`;
+      });
+  }
+
+  _showProjectInModal(projectId) {
+    // Reuse _openProjectDetail logic but stay inside the already-open modal
+    const listEl = document.getElementById('project-list');
+    const detailEl = document.getElementById('project-detail');
+    const contentEl = document.getElementById('project-detail-content');
+    listEl.classList.add('hidden');
+    detailEl.classList.remove('hidden');
+    contentEl.innerHTML = '<div style="color:var(--text-dim);font-size:7px;">Loading...</div>';
+
+    fetch(`/api/projects/named/${encodeURIComponent(projectId)}`)
+      .then(r => r.json())
+      .then(proj => {
+        if (proj.error) {
+          contentEl.innerHTML = `<div style="color:var(--pixel-red);">${proj.error}</div>`;
+          return;
+        }
+        this._renderProjectDetail(projectId, proj, contentEl);
+      })
+      .catch(err => {
+        contentEl.innerHTML = `<div style="color:var(--pixel-red);font-size:7px;">Load failed: ${err.message}</div>`;
       });
   }
 
@@ -5815,91 +5842,95 @@ class AppController {
         modal.classList.remove('hidden');
         listEl.classList.add('hidden');
         detailEl.classList.remove('hidden');
-
-        const totalCost = proj.total_cost_usd || 0;
-        let headerHtml = `<div style="margin-bottom:8px;display:flex;align-items:center;gap:8px;">
-          <span class="project-name-editable" data-project-id="${this._escHtml(projectId)}" title="Click to rename" style="color:var(--pixel-cyan);font-size:8px;cursor:pointer;border-bottom:1px dashed var(--text-dim);">${this._escHtml(proj.name || projectId)}</span>
-          <span style="color:var(--text-dim);font-size:6px;">${proj.status}</span>
-          ${totalCost > 0 ? `<span style="color:var(--pixel-yellow);font-size:6px;">$${totalCost.toFixed(4)}</span>` : ''}
-        </div>`;
-
-        // Build split layout: iteration list (left) + detail (right)
-        let iterListHtml = '';
-        const iters = proj.iteration_details || [];
-        if (iters.length === 0) {
-          iterListHtml = '<div style="color:var(--text-dim);font-size:6px;">No iterations yet</div>';
-        }
-        for (const it of iters) {
-          const statusColor = it.status === 'completed' ? 'var(--pixel-green)' : 'var(--pixel-yellow)';
-          const iterCost = it.cost_usd ? ` · $${it.cost_usd.toFixed(4)}` : '';
-          iterListHtml += `<div class="project-iter-card" data-iter-id="${it.iteration_id}" data-project-id="${projectId}">
-            <div style="color:${statusColor};">${it.status === 'completed' ? '\u2705' : '\uD83D\uDD04'} ${it.iteration_id}${iterCost}</div>
-            <div style="color:var(--pixel-white);margin-top:2px;">${this._escHtml((it.task || '').substring(0, 60))}</div>
-            <div style="color:var(--text-dim);margin-top:1px;">${it.created_at ? it.created_at.substring(0, 16) : ''}</div>
-          </div>`;
-        }
-        if (proj.status === 'active') {
-          iterListHtml += `<div style="margin-top:8px;"><button class="pixel-btn secondary" style="font-size:6px;padding:4px 8px;" onclick="window.app._archiveProject('${projectId}')">Archive</button></div>`;
-        }
-
-        contentEl.innerHTML = `${headerHtml}
-          <div class="project-detail-split">
-            <div class="project-iter-list">${iterListHtml}</div>
-            <div class="project-iter-detail" id="project-iter-detail">
-              <div style="color:var(--text-dim);font-size:6px;padding:12px;">Select an iteration to view details</div>
-            </div>
-          </div>`;
-
-        // Bind click on iteration cards
-        contentEl.querySelectorAll('.project-iter-card').forEach(card => {
-          card.addEventListener('click', () => {
-            contentEl.querySelectorAll('.project-iter-card').forEach(c => c.classList.remove('active'));
-            card.classList.add('active');
-            this._loadIterationDetail(card.dataset.projectId, card.dataset.iterId);
-          });
-        });
-
-        // Bind click-to-edit on project name
-        const nameEl = contentEl.querySelector('.project-name-editable');
-        if (nameEl) {
-          nameEl.addEventListener('click', () => {
-            const pid = nameEl.dataset.projectId;
-            const current = nameEl.textContent;
-            const input = document.createElement('input');
-            input.type = 'text';
-            input.value = current;
-            input.style.cssText = 'font-size:8px;color:var(--pixel-cyan);background:var(--bg-dark);border:1px solid var(--pixel-cyan);padding:1px 4px;width:160px;';
-            const save = () => {
-              const newName = input.value.trim();
-              if (newName && newName !== current) {
-                fetch(`/api/projects/${encodeURIComponent(pid)}/name`, {
-                  method: 'PATCH',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ name: newName }),
-                }).then(r => r.json()).then(d => {
-                  if (d.status === 'ok') {
-                    nameEl.textContent = newName;
-                    this.loadActiveProjects();
-                  }
-                }).catch(() => {});
-              }
-              input.replaceWith(nameEl);
-            };
-            input.addEventListener('blur', save);
-            input.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); save(); } if (e.key === 'Escape') input.replaceWith(nameEl); });
-            nameEl.replaceWith(input);
-            input.focus();
-            input.select();
-          });
-        }
-
-        // Auto-select first iteration
-        if (iters.length > 0) {
-          const firstCard = contentEl.querySelector('.project-iter-card');
-          if (firstCard) firstCard.click();
-        }
+        this._renderProjectDetail(projectId, proj, contentEl);
       })
       .catch(() => {});
+  }
+
+  _renderProjectDetail(projectId, proj, contentEl) {
+    const totalCost = proj.total_cost_usd || 0;
+    let headerHtml = `<div style="margin-bottom:8px;display:flex;align-items:center;gap:8px;">
+      <button class="pixel-btn secondary" style="font-size:5px;padding:2px 6px;" onclick="window.app.loadProjectList()">\u25C0 Back</button>
+      <span class="project-name-editable" data-project-id="${this._escHtml(projectId)}" title="Click to rename" style="color:var(--pixel-cyan);font-size:8px;cursor:pointer;border-bottom:1px dashed var(--text-dim);">${this._escHtml(proj.name || projectId)}</span>
+      <span style="color:var(--text-dim);font-size:6px;">${proj.status}</span>
+      ${totalCost > 0 ? `<span style="color:var(--pixel-yellow);font-size:6px;">$${totalCost.toFixed(4)}</span>` : ''}
+    </div>`;
+
+    // Build split layout: iteration list (left) + detail (right)
+    let iterListHtml = '';
+    const iters = proj.iteration_details || [];
+    if (iters.length === 0) {
+      iterListHtml = '<div style="color:var(--text-dim);font-size:6px;">No iterations yet</div>';
+    }
+    for (const it of iters) {
+      const statusColor = it.status === 'completed' ? 'var(--pixel-green)' : 'var(--pixel-yellow)';
+      const iterCost = it.cost_usd ? ` · $${it.cost_usd.toFixed(4)}` : '';
+      iterListHtml += `<div class="project-iter-card" data-iter-id="${it.iteration_id}" data-project-id="${projectId}">
+        <div style="color:${statusColor};">${it.status === 'completed' ? '\u2705' : '\uD83D\uDD04'} ${it.iteration_id}${iterCost}</div>
+        <div style="color:var(--pixel-white);margin-top:2px;">${this._escHtml((it.task || '').substring(0, 60))}</div>
+        <div style="color:var(--text-dim);margin-top:1px;">${it.created_at ? it.created_at.substring(0, 16) : ''}</div>
+      </div>`;
+    }
+    if (proj.status === 'active') {
+      iterListHtml += `<div style="margin-top:8px;"><button class="pixel-btn secondary" style="font-size:6px;padding:4px 8px;" onclick="window.app._archiveProject('${projectId}')">Archive</button></div>`;
+    }
+
+    contentEl.innerHTML = `${headerHtml}
+      <div class="project-detail-split">
+        <div class="project-iter-list">${iterListHtml}</div>
+        <div class="project-iter-detail" id="project-iter-detail">
+          <div style="color:var(--text-dim);font-size:6px;padding:12px;">Select an iteration to view details</div>
+        </div>
+      </div>`;
+
+    // Bind click on iteration cards
+    contentEl.querySelectorAll('.project-iter-card').forEach(card => {
+      card.addEventListener('click', () => {
+        contentEl.querySelectorAll('.project-iter-card').forEach(c => c.classList.remove('active'));
+        card.classList.add('active');
+        this._loadIterationDetail(card.dataset.projectId, card.dataset.iterId);
+      });
+    });
+
+    // Bind click-to-edit on project name
+    const nameEl = contentEl.querySelector('.project-name-editable');
+    if (nameEl) {
+      nameEl.addEventListener('click', () => {
+        const pid = nameEl.dataset.projectId;
+        const current = nameEl.textContent;
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.value = current;
+        input.style.cssText = 'font-size:8px;color:var(--pixel-cyan);background:var(--bg-dark);border:1px solid var(--pixel-cyan);padding:1px 4px;width:160px;';
+        const save = () => {
+          const newName = input.value.trim();
+          if (newName && newName !== current) {
+            fetch(`/api/projects/${encodeURIComponent(pid)}/name`, {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ name: newName }),
+            }).then(r => r.json()).then(d => {
+              if (d.status === 'ok') {
+                nameEl.textContent = newName;
+                this.loadActiveProjects();
+              }
+            }).catch(() => {});
+          }
+          input.replaceWith(nameEl);
+        };
+        input.addEventListener('blur', save);
+        input.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); save(); } if (e.key === 'Escape') input.replaceWith(nameEl); });
+        nameEl.replaceWith(input);
+        input.focus();
+        input.select();
+      });
+    }
+
+    // Auto-select first iteration
+    if (iters.length > 0) {
+      const firstCard = contentEl.querySelector('.project-iter-card');
+      if (firstCard) firstCard.click();
+    }
   }
 
   _loadIterationDetail(projectId, iterationId) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -27,6 +27,8 @@ class AppController {
     this._historyDraft = '';
     // Task attachment files
     this._taskPendingFiles = [];
+    // Cooldown: prevent accidental double-submit (key → timestamp)
+    this._actionCooldowns = {};
     // Board view: track which project's plugin tab is being viewed
     this._viewingBoardProjectId = null;
     // Initialize plugin system before connecting
@@ -4980,6 +4982,7 @@ class AppController {
       this.logEntry('SYSTEM', 'Please write a draft direction first.', 'system');
       return;
     }
+    if (!this._checkCooldown('enrichDirection')) return;
     btn.disabled = true;
     btn.textContent = '⏳ Sending...';
 
@@ -5698,10 +5701,20 @@ class AppController {
     return html;
   }
 
+  /** Returns true if the action is allowed (not in cooldown). Sets a 5s cooldown on first call. */
+  _checkCooldown(actionKey, cooldownMs = 5000) {
+    const now = Date.now();
+    const last = this._actionCooldowns[actionKey] || 0;
+    if (now - last < cooldownMs) return false;
+    this._actionCooldowns[actionKey] = now;
+    return true;
+  }
+
   async submitTask() {
     const input = document.getElementById('task-input');
     const task = input.value.trim();
     if (!task) return;
+    if (!this._checkCooldown('submitTask')) return;
 
     // Read project selector
     const projectSelect = document.getElementById('project-select');
@@ -6218,6 +6231,7 @@ class AppController {
   }
 
   _continueIteration(projectId, iterationId) {
+    if (!this._checkCooldown('continueIteration')) return;
     const btn = document.getElementById('continue-iter-btn');
     if (btn) { btn.disabled = true; btn.textContent = '⏳ Submitting...'; }
 
@@ -6244,6 +6258,7 @@ class AppController {
   }
 
   _submitFollowup(projectId, instructions) {
+    if (!this._checkCooldown('submitFollowup')) return;
     const submitBtn = document.getElementById('followup-submit');
     if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = '⏳ Submitting...'; }
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3692,11 +3692,11 @@ class AppController {
           const name = p.name || p.task || p.project_id;
           card.innerHTML = `
             <div class="project-card-header">
-              <span>${statusIcon} ${name.substring(0, 50)}${name.length > 50 ? '...' : ''}</span>
+              <span>${statusIcon} ${this._escHtml(name.substring(0, 50))}${name.length > 50 ? '...' : ''}</span>
               <span class="project-card-date">${date}</span>
             </div>
             <div class="project-card-meta">
-              ${p.iteration_count || 0} iteration(s) | ${p.file_count || 0} files${costStr}${p.current_owner ? ' · ' + p.current_owner : ''}
+              ${p.iteration_count || 0} iteration(s) | ${p.file_count || 0} files${costStr}${p.current_owner ? ' · ' + this._escHtml(p.current_owner) : ''}
             </div>
           `;
           card.style.cursor = 'pointer';
@@ -3725,13 +3725,13 @@ class AppController {
       .then(r => r.json())
       .then(proj => {
         if (proj.error) {
-          contentEl.innerHTML = `<div style="color:var(--pixel-red);">${proj.error}</div>`;
+          contentEl.innerHTML = `<div style="color:var(--pixel-red);">${this._escHtml(proj.error)}</div>`;
           return;
         }
         this._renderProjectDetail(projectId, proj, contentEl);
       })
       .catch(err => {
-        contentEl.innerHTML = `<div style="color:var(--pixel-red);font-size:7px;">Load failed: ${err.message}</div>`;
+        contentEl.innerHTML = `<div style="color:var(--pixel-red);font-size:7px;">Load failed: ${this._escHtml(err.message)}</div>`;
       });
   }
 
@@ -3814,7 +3814,7 @@ class AppController {
           for (const f of files) {
             const url = `/api/projects/${encodeURIComponent(projectId)}/files/${encodeURIComponent(f)}`;
             html += `<div style="font-size:6px;margin:2px 0;">`;
-            html += `<a href="${url}" target="_blank" style="color:var(--pixel-green);text-decoration:underline;cursor:pointer;">${f}</a>`;
+            html += `<a href="${url}" target="_blank" style="color:var(--pixel-green);text-decoration:underline;cursor:pointer;">${this._escHtml(f)}</a>`;
             html += `</div>`;
           }
         }
@@ -5932,7 +5932,7 @@ class AppController {
                 nameEl.textContent = newName;
                 this.loadActiveProjects();
               }
-            }).catch(() => {});
+            }).catch(err => console.error('[rename project] failed:', err));
           }
           input.replaceWith(nameEl);
         };

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5705,7 +5705,10 @@ class AppController {
   _checkCooldown(actionKey, cooldownMs = 5000) {
     const now = Date.now();
     const last = this._actionCooldowns[actionKey] || 0;
-    if (now - last < cooldownMs) return false;
+    if (now - last < cooldownMs) {
+      console.debug(`[cooldown] ${actionKey} blocked, ${cooldownMs - (now - last)}ms remaining`);
+      return false;
+    }
     this._actionCooldowns[actionKey] = now;
     return true;
   }
@@ -5857,7 +5860,9 @@ class AppController {
         detailEl.classList.remove('hidden');
         this._renderProjectDetail(projectId, proj, contentEl);
       })
-      .catch(() => {});
+      .catch(err => {
+        console.error('[_openProjectDetail] failed:', err);
+      });
   }
 
   _renderProjectDetail(projectId, proj, contentEl) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -562,7 +562,7 @@ class AppController {
     fetch('/api/task-queue')
       .then(r => r.json())
       .then(t => this._renderTaskPanel(t))
-      .catch(() => {});
+      .catch(err => console.error('[loadTaskQueue] failed:', err));
   }
 
   _renderTaskPanel(tasks) {
@@ -901,7 +901,7 @@ class AppController {
             // Will auto-restart when tasks complete; reconnect logic handles the rest
           }
         })
-        .catch(() => {});
+        .catch(err => console.error('[apply-code-update] failed:', err));
     });
     document.getElementById('code-update-dismiss-btn').addEventListener('click', () => {
       document.getElementById('code-update-banner').classList.add('hidden');
@@ -2031,7 +2031,8 @@ class AppController {
           });
         });
       })
-      .catch(() => {
+      .catch(err => {
+        console.error('[loadProjectList] failed:', err);
         container.innerHTML = '<span class="empty-hint">Failed to load</span>';
       });
   }
@@ -2112,7 +2113,7 @@ class AppController {
 
   _escHtml(str) {
     const div = document.createElement('div');
-    div.textContent = str;
+    div.textContent = String(str ?? '');
     return div.innerHTML;
   }
 
@@ -3983,7 +3984,7 @@ class AppController {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(values),
-        }).catch(() => {});
+        }).catch(err => console.error('[credentials submit] failed:', err));
         this.closePopup();
       };
       const cancelBtn = document.createElement('button');
@@ -4007,7 +4008,7 @@ class AppController {
           el.onclick = () => this.closePopup();
         } else if (btn.callback_url) {
           el.onclick = () => {
-            fetch(btn.callback_url, { method: 'POST' }).catch(() => {});
+            fetch(btn.callback_url, { method: 'POST' }).catch(err => console.error('[button callback] failed:', err));
             this.closePopup();
           };
         }
@@ -4174,7 +4175,8 @@ class AppController {
           }
         }
       })
-      .catch(() => {
+      .catch(err => {
+        console.error('[loadChat] failed:', err);
         chatEl.innerHTML = '<div class="chat-empty">Failed to load chat</div>';
       });
   }
@@ -4844,7 +4846,7 @@ class AppController {
       }
 
       content.insertAdjacentHTML('beforeend', costHtml);
-    }).catch(() => {});
+    }).catch(err => console.error('[loadCostPanel] failed:', err));
   }
 
   // ===== Company Culture =====
@@ -4885,7 +4887,8 @@ class AppController {
           btn.addEventListener('click', () => this.removeCultureItem(parseInt(btn.dataset.index)));
         });
       })
-      .catch(() => {
+      .catch(err => {
+        console.error('[loadCulture] failed:', err);
         list.innerHTML = '<div style="color:var(--text-dim);font-size:7px;padding:12px;">Failed to load culture.</div>';
       });
   }
@@ -4943,7 +4946,7 @@ class AppController {
         input.value = data.direction || '';
         this._renderCurrentDirection(data.direction || '');
       })
-      .catch(() => { input.value = ''; });
+      .catch(err => { console.error('[addCultureItem] failed:', err); input.value = ''; });
   }
 
   closeCompanyDirection() {
@@ -5827,7 +5830,7 @@ class AppController {
           panel.appendChild(card);
         }
       })
-      .catch(() => {});
+      .catch(err => console.error('[updateProjectsPanel] failed:', err));
   }
 
   _openTaskInBoard(projectId, nodeId) {
@@ -5890,7 +5893,7 @@ class AppController {
       </div>`;
     }
     if (proj.status === 'active') {
-      iterListHtml += `<div style="margin-top:8px;"><button class="pixel-btn secondary" style="font-size:6px;padding:4px 8px;" onclick="window.app._archiveProject('${projectId}')">Archive</button></div>`;
+      iterListHtml += `<div style="margin-top:8px;"><button class="pixel-btn secondary archive-project-btn" style="font-size:6px;padding:4px 8px;">Archive</button></div>`;
     }
 
     contentEl.innerHTML = `${headerHtml}
@@ -5900,6 +5903,12 @@ class AppController {
           <div style="color:var(--text-dim);font-size:6px;padding:12px;">Select an iteration to view details</div>
         </div>
       </div>`;
+
+    // Bind archive button
+    const archiveBtn = contentEl.querySelector('.archive-project-btn');
+    if (archiveBtn) {
+      archiveBtn.addEventListener('click', () => this._archiveProject(projectId));
+    }
 
     // Bind click on iteration cards
     contentEl.querySelectorAll('.project-iter-card').forEach(card => {
@@ -6205,7 +6214,7 @@ class AppController {
                 stopBtn.textContent = `■ Stopped (${data.cancelled || 0})`;
                 this._loadIterationDetail(projectId, iterationId);
               })
-              .catch(() => { stopBtn.disabled = false; stopBtn.textContent = '■ Stop All Tasks'; });
+              .catch(err => { console.error('[stopTasks] failed:', err); stopBtn.disabled = false; stopBtn.textContent = '■ Stop All Tasks'; });
           });
         }
 
@@ -6306,7 +6315,7 @@ class AppController {
         .then(text => {
           this._showFileViewer(filename, `<pre style="font-size:6px;color:var(--pixel-white);white-space:pre-wrap;word-break:break-all;max-height:65vh;overflow-y:auto;margin:0;padding:6px;background:var(--bg-dark);border:1px solid var(--border);">${this._escHtml(text)}</pre>`);
         })
-        .catch(() => { window.open(url, '_blank'); });
+        .catch(err => { console.error('[viewFile] failed, opening in new tab:', err); window.open(url, '_blank'); });
     } else if (ext === 'pdf') {
       window.open(url, '_blank');
     } else {
@@ -6355,7 +6364,7 @@ class AppController {
           document.getElementById('project-modal').classList.add('hidden');
         }
       })
-      .catch(() => {});
+      .catch(err => console.error('[archiveProject] failed:', err));
   }
 
   loadActiveProjects() {
@@ -6379,7 +6388,7 @@ class AppController {
           select.value = currentVal;
         }
       })
-      .catch(() => {});
+      .catch(err => console.error('[loadActiveProjects] failed:', err));
   }
 
   // ===== Admin Reload =====

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3709,7 +3709,7 @@ class AppController {
         }
       })
       .catch(err => {
-        listEl.innerHTML = `<div style="color:var(--pixel-red);font-size:7px;">Load failed: ${err.message}</div>`;
+        listEl.innerHTML = `<div style="color:var(--pixel-red);font-size:7px;">Load failed: ${this._escHtml(err.message)}</div>`;
       });
   }
 
@@ -3823,7 +3823,7 @@ class AppController {
         contentEl.innerHTML = html;
       })
       .catch(err => {
-        contentEl.innerHTML = `<div style="color:var(--pixel-red);">Load failed: ${err.message}</div>`;
+        contentEl.innerHTML = `<div style="color:var(--pixel-red);">Load failed: ${this._escHtml(err.message)}</div>`;
       });
   }
 
@@ -4362,7 +4362,7 @@ class AppController {
         this._renderExEmployees(list);
       })
       .catch(err => {
-        listEl.innerHTML = `<div style="color:var(--pixel-red);font-size:7px;">Load failed: ${err.message}</div>`;
+        listEl.innerHTML = `<div style="color:var(--pixel-red);font-size:7px;">Load failed: ${this._escHtml(err.message)}</div>`;
       });
   }
 
@@ -6240,7 +6240,7 @@ class AppController {
         }
       })
       .catch(err => {
-        panel.innerHTML = `<div style="color:var(--pixel-red);font-size:6px;">Load failed: ${err.message}</div>`;
+        panel.innerHTML = `<div style="color:var(--pixel-red);font-size:6px;">Load failed: ${this._escHtml(err.message)}</div>`;
       });
   }
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3778,6 +3778,18 @@ class AppController {
           html += `<div style="font-size:6px;color:var(--pixel-white);background:var(--bg-dark);padding:6px;border:1px solid var(--border);">${doc.output}</div>`;
         }
 
+        // Documents
+        const files = doc.files || [];
+        if (files.length > 0) {
+          html += `<div style="font-size:7px;color:var(--pixel-cyan);margin:8px 0 4px;">Documents (${files.length}):</div>`;
+          for (const f of files) {
+            const url = `/api/projects/${encodeURIComponent(projectId)}/files/${encodeURIComponent(f)}`;
+            html += `<div style="font-size:6px;margin:2px 0;">`;
+            html += `<a href="${url}" target="_blank" style="color:var(--pixel-green);text-decoration:underline;cursor:pointer;">${f}</a>`;
+            html += `</div>`;
+          }
+        }
+
         contentEl.innerHTML = html;
       })
       .catch(err => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.387",
+  "version": "0.2.388",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.386",
+  "version": "0.2.387",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.389",
+  "version": "0.2.390",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.388",
+  "version": "0.2.389",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.384",
+  "version": "0.2.385",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.385",
+  "version": "0.2.386",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.383",
+  "version": "0.2.384",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.391",
+  "version": "0.2.392",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.390",
+  "version": "0.2.391",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.392",
+  "version": "0.2.393",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.391"
+version = "0.2.392"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.386"
+version = "0.2.387"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.383"
+version = "0.2.384"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.384"
+version = "0.2.385"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.390"
+version = "0.2.391"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.385"
+version = "0.2.386"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.387"
+version = "0.2.388"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.389"
+version = "0.2.390"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.392"
+version = "0.2.393"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.388"
+version = "0.2.389"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -2797,18 +2797,19 @@ async def rename_project(project_id: str, body: dict) -> dict:
         proj_yaml = (proj_dir or Path(get_project_dir(project_id))) / "project.yaml" if proj_dir else None
         # Update the name in the named project doc
         import yaml as _yaml
-        for candidate in [Path(get_project_dir(project_id)) / "project.yaml"]:
-            if candidate.exists():
-                data = _yaml.safe_load(candidate.read_text(encoding="utf-8")) or {}
-                data["name"] = name
-                candidate.write_text(
-                    _yaml.dump(data, allow_unicode=True, sort_keys=False), encoding="utf-8"
-                )
-                return {"status": "ok", "name": name}
+        from onemancompany.core.config import PROJECTS_DIR as _PROJ_DIR
+        candidate = _PROJ_DIR / project_id / "project.yaml"
+        if candidate.exists():
+            data = _yaml.safe_load(candidate.read_text(encoding="utf-8")) or {}
+            data["name"] = name
+            candidate.write_text(
+                _yaml.dump(data, allow_unicode=True, sort_keys=False), encoding="utf-8"
+            )
+            return {"status": "ok", "name": name}
 
-    # Try v1 project
-    pdir = get_project_dir(project_id)
-    project_yaml = Path(pdir) / "project.yaml"
+    # Try v1 project — project.yaml at project root
+    from onemancompany.core.config import PROJECTS_DIR as _PROJ_DIR2
+    project_yaml = _PROJ_DIR2 / project_id / "project.yaml"
     if project_yaml.exists():
         import yaml as _yaml
         data = _yaml.safe_load(project_yaml.read_text(encoding="utf-8")) or {}
@@ -3531,9 +3532,9 @@ async def download_project_workspace(project_id: str):
 
     from pathlib import Path
 
-    from onemancompany.core.project_archive import get_project_dir
+    from onemancompany.core.project_archive import get_project_workspace
 
-    pdir = Path(get_project_dir(project_id))
+    pdir = Path(get_project_workspace(project_id))
     if not pdir.is_dir():
         from fastapi.responses import Response
         return Response(content="Project workspace not found", status_code=404)

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -2788,16 +2788,13 @@ async def rename_project(project_id: str, body: dict) -> dict:
     name = body.get("name", "").strip()
     if not name:
         raise HTTPException(400, "Name required")
-    from onemancompany.core.project_archive import get_project_dir, load_named_project
+    import yaml as _yaml
+    from onemancompany.core.config import PROJECTS_DIR as _PROJ_DIR
+    from onemancompany.core.project_archive import load_named_project
 
     # Try named project first
     proj = load_named_project(project_id)
     if proj:
-        proj_dir = Path(proj["project_dir"]) if "project_dir" in proj else None
-        proj_yaml = (proj_dir or Path(get_project_dir(project_id))) / "project.yaml" if proj_dir else None
-        # Update the name in the named project doc
-        import yaml as _yaml
-        from onemancompany.core.config import PROJECTS_DIR as _PROJ_DIR
         candidate = _PROJ_DIR / project_id / "project.yaml"
         if candidate.exists():
             data = _yaml.safe_load(candidate.read_text(encoding="utf-8")) or {}
@@ -2808,8 +2805,7 @@ async def rename_project(project_id: str, body: dict) -> dict:
             return {"status": "ok", "name": name}
 
     # Try v1 project — project.yaml at project root
-    from onemancompany.core.config import PROJECTS_DIR as _PROJ_DIR2
-    project_yaml = _PROJ_DIR2 / project_id / "project.yaml"
+    project_yaml = _PROJ_DIR / project_id / "project.yaml"
     if project_yaml.exists():
         import yaml as _yaml
         data = _yaml.safe_load(project_yaml.read_text(encoding="utf-8")) or {}

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -2789,12 +2789,12 @@ async def rename_project(project_id: str, body: dict) -> dict:
     if not name:
         raise HTTPException(400, "Name required")
     from onemancompany.core.config import PROJECTS_DIR as _PROJ_DIR
-    from onemancompany.core.project_archive import _update_project_name
+    from onemancompany.core.project_archive import update_project_name
 
     candidate = _PROJ_DIR / project_id / "project.yaml"
     if not candidate.exists():
         raise HTTPException(404, "Project not found")
-    _update_project_name(project_id, name)
+    update_project_name(project_id, name)
     return {"status": "ok", "name": name}
 
 

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -3390,9 +3390,9 @@ async def get_project_file(project_id: str, file_path: str):
 
     from fastapi.responses import Response
 
-    from onemancompany.core.project_archive import get_project_dir
+    from onemancompany.core.project_archive import get_project_workspace
 
-    workspace = Path(get_project_dir(project_id))
+    workspace = Path(get_project_workspace(project_id))
     target = (workspace / file_path).resolve()
     # Security: ensure path stays within workspace
     if not str(target).startswith(str(workspace.resolve())):

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -2788,34 +2788,14 @@ async def rename_project(project_id: str, body: dict) -> dict:
     name = body.get("name", "").strip()
     if not name:
         raise HTTPException(400, "Name required")
-    import yaml as _yaml
     from onemancompany.core.config import PROJECTS_DIR as _PROJ_DIR
-    from onemancompany.core.project_archive import load_named_project
+    from onemancompany.core.project_archive import _update_project_name
 
-    # Try named project first
-    proj = load_named_project(project_id)
-    if proj:
-        candidate = _PROJ_DIR / project_id / "project.yaml"
-        if candidate.exists():
-            data = _yaml.safe_load(candidate.read_text(encoding="utf-8")) or {}
-            data["name"] = name
-            candidate.write_text(
-                _yaml.dump(data, allow_unicode=True, sort_keys=False), encoding="utf-8"
-            )
-            return {"status": "ok", "name": name}
-
-    # Try v1 project — project.yaml at project root
-    project_yaml = _PROJ_DIR / project_id / "project.yaml"
-    if project_yaml.exists():
-        import yaml as _yaml
-        data = _yaml.safe_load(project_yaml.read_text(encoding="utf-8")) or {}
-        data["name"] = name
-        project_yaml.write_text(
-            _yaml.dump(data, allow_unicode=True, sort_keys=False), encoding="utf-8"
-        )
-        return {"status": "ok", "name": name}
-
-    raise HTTPException(404, "Project not found")
+    candidate = _PROJ_DIR / project_id / "project.yaml"
+    if not candidate.exists():
+        raise HTTPException(404, "Project not found")
+    _update_project_name(project_id, name)
+    return {"status": "ok", "name": name}
 
 
 @router.post("/api/projects/continue")

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -330,6 +330,9 @@ def create_iteration(project_id: str, task: str, routed_to: str) -> str:
             candidate = prev_iter_dir / "workspace"
             if candidate.is_dir():
                 prev_workspace = candidate
+            elif prev_iter_dir.is_dir() and any(prev_iter_dir.iterdir()):
+                # Backward compat: old layout stored files directly in iter_dir
+                prev_workspace = prev_iter_dir
 
     # Create the new iteration directory and its workspace subdirectory
     iter_dir = iterations_dir / iter_id

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -1,9 +1,10 @@
 """Project Archive — project record and workspace system.
 
 Named projects with multiple iterations:
-  projects/{slug}/project.yaml    — project metadata
-  projects/{slug}/workspace/      — shared workspace for all iterations
-  projects/{slug}/iterations/     — per-iteration YAML files
+  projects/{slug}/project.yaml              — project metadata
+  projects/{slug}/iterations/iter_NNN.yaml  — per-iteration metadata
+  projects/{slug}/iterations/iter_NNN/      — per-iteration directory
+  projects/{slug}/iterations/iter_NNN/workspace/  — per-iteration workspace
 
 Employees can save artifacts to their project workspace via save_project_file().
 """
@@ -288,7 +289,6 @@ def create_named_project(name: str) -> str:
 
     proj_dir = PROJECTS_DIR / slug
     proj_dir.mkdir(parents=True, exist_ok=True)
-    (proj_dir / "workspace").mkdir(exist_ok=True)
     (proj_dir / "iterations").mkdir(exist_ok=True)
 
     doc = {
@@ -326,17 +326,15 @@ def create_iteration(project_id: str, task: str, routed_to: str) -> str:
         prev_iter_id = existing[-1]
         prev_doc = load_iteration(project_id, prev_iter_id)
         if prev_doc and prev_doc.get("project_dir"):
-            candidate = _rebase_project_dir(prev_doc["project_dir"])
+            prev_iter_dir = _rebase_project_dir(prev_doc["project_dir"])
+            candidate = prev_iter_dir / "workspace"
             if candidate.is_dir():
                 prev_workspace = candidate
-    if prev_workspace is None:
-        # Fallback to shared workspace/
-        fallback = PROJECTS_DIR / project_id / "workspace"
-        if fallback.is_dir():
-            prev_workspace = fallback
 
-    # Create the new iteration workspace directory
-    new_workspace = iterations_dir / iter_id
+    # Create the new iteration directory and its workspace subdirectory
+    iter_dir = iterations_dir / iter_id
+    iter_dir.mkdir(parents=True, exist_ok=True)
+    new_workspace = iter_dir / "workspace"
     new_workspace.mkdir(parents=True, exist_ok=True)
 
     # Copy files from previous workspace
@@ -370,7 +368,7 @@ def create_iteration(project_id: str, task: str, routed_to: str) -> str:
             "token_usage": {"input": 0, "output": 0, "total": 0},
             "breakdown": [],
         },
-        "project_dir": str(new_workspace),
+        "project_dir": str(iter_dir),
     }
     _save_iteration(project_id, iter_id, doc)
 
@@ -472,8 +470,7 @@ def archive_project(project_id: str) -> None:
 def get_project_workspace(project_id: str) -> str:
     """Return the workspace directory path for a v2 named project.
 
-    Prefers the latest iteration's per-iteration workspace if available,
-    otherwise falls back to the shared workspace/ directory.
+    Returns the latest iteration's workspace/ subdirectory.
     """
     proj = load_named_project(project_id)
     if proj:
@@ -481,10 +478,11 @@ def get_project_workspace(project_id: str) -> str:
         if iters:
             latest_doc = load_iteration(project_id, iters[-1])
             if latest_doc and latest_doc.get("project_dir"):
-                ws = _rebase_project_dir(latest_doc["project_dir"])
+                iter_dir = _rebase_project_dir(latest_doc["project_dir"])
+                ws = iter_dir / "workspace"
                 ws.mkdir(parents=True, exist_ok=True)
                 return str(ws)
-    # Fallback to shared workspace/
+    # Fallback: create workspace under project dir directly
     ws = PROJECTS_DIR / project_id / "workspace"
     ws.mkdir(parents=True, exist_ok=True)
     return str(ws)
@@ -546,9 +544,7 @@ def load_project(project_id: str) -> dict | None:
 def _resolve_workspace(project_id: str) -> Path:
     """Resolve the workspace directory for any project identifier.
 
-    - v2 project slug: latest iteration's per-iteration workspace (via get_project_workspace)
-    - v2 iteration ID: that iteration's project_dir from its YAML
-
+    Returns the workspace/ subdirectory under the iteration directory.
     Supports qualified iteration IDs like "first-game/iter_002".
     """
     if _is_iteration(project_id):
@@ -557,25 +553,51 @@ def _resolve_workspace(project_id: str) -> Path:
         if slug:
             iter_doc = load_iteration(slug, bare_id)
             if iter_doc and iter_doc.get("project_dir"):
-                ws = _rebase_project_dir(iter_doc["project_dir"])
+                iter_dir = _rebase_project_dir(iter_doc["project_dir"])
+                ws = iter_dir / "workspace"
                 ws.mkdir(parents=True, exist_ok=True)
                 return ws
             # Fallback for old iterations without per-iter workspace
-            ws = PROJECTS_DIR / slug / "workspace"
+            ws = PROJECTS_DIR / slug / "iterations" / bare_id / "workspace"
             ws.mkdir(parents=True, exist_ok=True)
             return ws
     return Path(get_project_workspace(project_id))
 
 
 def get_project_dir(project_id: str) -> str:
-    """Return the absolute path of a project's workspace directory.
+    """Return the absolute path of a project's iteration directory.
 
-    iteration: returns that iteration's workspace
-    slug: returns latest iteration's workspace (or shared workspace/)
+    This is the iteration root (where task_tree.yaml lives),
+    NOT the workspace/ subdirectory for user files.
     """
-    ws = _resolve_workspace(project_id)
-    ws.mkdir(parents=True, exist_ok=True)
-    return str(ws)
+    if _is_iteration(project_id):
+        slug = _find_project_for_iteration(project_id)
+        _, bare_id = _split_qualified_iter(project_id)
+        if slug:
+            iter_doc = load_iteration(slug, bare_id)
+            if iter_doc and iter_doc.get("project_dir"):
+                d = _rebase_project_dir(iter_doc["project_dir"])
+                d.mkdir(parents=True, exist_ok=True)
+                return str(d)
+            # Fallback
+            d = PROJECTS_DIR / slug / "iterations" / bare_id
+            d.mkdir(parents=True, exist_ok=True)
+            return str(d)
+
+    # Project slug — resolve to latest iteration dir
+    proj = load_named_project(project_id)
+    if proj:
+        iters = proj.get("iterations", [])
+        if iters:
+            latest_doc = load_iteration(project_id, iters[-1])
+            if latest_doc and latest_doc.get("project_dir"):
+                d = _rebase_project_dir(latest_doc["project_dir"])
+                d.mkdir(parents=True, exist_ok=True)
+                return str(d)
+    # Fallback
+    d = PROJECTS_DIR / project_id
+    d.mkdir(parents=True, exist_ok=True)
+    return str(d)
 
 
 def save_project_file(project_id: str, filename: str, content: str | bytes) -> dict:

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -480,9 +480,16 @@ def get_project_workspace(project_id: str) -> str:
             if latest_doc and latest_doc.get("project_dir"):
                 iter_dir = _rebase_project_dir(latest_doc["project_dir"])
                 ws = iter_dir / "workspace"
+                if ws.exists():
+                    return str(ws)
+                # Backward compat: old iterations stored files directly in iter_dir
+                if iter_dir.exists() and any(iter_dir.iterdir()):
+                    logger.debug("get_project_workspace: legacy layout, using iter_dir as workspace for {}", project_id)
+                    return str(iter_dir)
                 ws.mkdir(parents=True, exist_ok=True)
                 return str(ws)
-    # Fallback: create workspace under project dir directly
+    # Fallback: project has no iterations — log warning
+    logger.warning("get_project_workspace fallback: project {} has no iterations", project_id)
     ws = PROJECTS_DIR / project_id / "workspace"
     ws.mkdir(parents=True, exist_ok=True)
     return str(ws)
@@ -555,6 +562,11 @@ def _resolve_workspace(project_id: str) -> Path:
             if iter_doc and iter_doc.get("project_dir"):
                 iter_dir = _rebase_project_dir(iter_doc["project_dir"])
                 ws = iter_dir / "workspace"
+                if ws.exists():
+                    return ws
+                # Backward compat: old iterations stored files directly in iter_dir
+                if iter_dir.exists() and any(iter_dir.iterdir()):
+                    return iter_dir
                 ws.mkdir(parents=True, exist_ok=True)
                 return ws
             # Fallback for old iterations without per-iter workspace

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -239,7 +239,7 @@ async def async_create_project_from_task(
             logger.warning("LLM project naming timed out for {}, keeping fallback", project_id)
             return
         if llm_name and llm_name != fallback_name:
-            _update_project_name(project_id, llm_name)
+            update_project_name(project_id, llm_name)
             logger.info("Project {} renamed: '{}' → '{}'", project_id, fallback_name, llm_name)
             # Notify frontend via store dirty so next sync tick picks it up
             from onemancompany.core.store import mark_dirty
@@ -249,7 +249,7 @@ async def async_create_project_from_task(
     return project_id, iter_id
 
 
-def _update_project_name(project_id: str, new_name: str) -> None:
+def update_project_name(project_id: str, new_name: str) -> None:
     """Update the display name of an existing named project."""
     path = PROJECTS_DIR / project_id / "project.yaml"
     lock = _get_project_lock(project_id)
@@ -480,10 +480,10 @@ def get_project_workspace(project_id: str) -> str:
             if latest_doc and latest_doc.get("project_dir"):
                 iter_dir = _rebase_project_dir(latest_doc["project_dir"])
                 ws = iter_dir / "workspace"
-                if ws.exists():
+                if ws.is_dir():
                     return str(ws)
                 # Backward compat: old iterations stored files directly in iter_dir
-                if iter_dir.exists() and any(iter_dir.iterdir()):
+                if iter_dir.is_dir() and any(iter_dir.iterdir()):
                     logger.debug("get_project_workspace: legacy layout, using iter_dir as workspace for {}", project_id)
                     return str(iter_dir)
                 ws.mkdir(parents=True, exist_ok=True)
@@ -562,10 +562,10 @@ def _resolve_workspace(project_id: str) -> Path:
             if iter_doc and iter_doc.get("project_dir"):
                 iter_dir = _rebase_project_dir(iter_doc["project_dir"])
                 ws = iter_dir / "workspace"
-                if ws.exists():
+                if ws.is_dir():
                     return ws
                 # Backward compat: old iterations stored files directly in iter_dir
-                if iter_dir.exists() and any(iter_dir.iterdir()):
+                if iter_dir.is_dir() and any(iter_dir.iterdir()):
                     return iter_dir
                 ws.mkdir(parents=True, exist_ok=True)
                 return ws

--- a/tests/unit/api/test_routes.py
+++ b/tests/unit/api/test_routes.py
@@ -4924,7 +4924,7 @@ class TestProjectFileServing:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.core.project_archive.get_project_dir", return_value=str(ws)):
+             patch("onemancompany.core.project_archive.get_project_workspace", return_value=str(ws)):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/projects/proj1/files/main.py")
@@ -4943,7 +4943,7 @@ class TestProjectFileServing:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.core.project_archive.get_project_dir", return_value=str(ws)):
+             patch("onemancompany.core.project_archive.get_project_workspace", return_value=str(ws)):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/projects/proj1/files/index.html")
@@ -4962,7 +4962,7 @@ class TestProjectFileServing:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.core.project_archive.get_project_dir", return_value=str(ws)):
+             patch("onemancompany.core.project_archive.get_project_workspace", return_value=str(ws)):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/projects/proj1/files/data.json")
@@ -4981,7 +4981,7 @@ class TestProjectFileServing:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.core.project_archive.get_project_dir", return_value=str(ws)):
+             patch("onemancompany.core.project_archive.get_project_workspace", return_value=str(ws)):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/projects/proj1/files/README.md")
@@ -5000,7 +5000,7 @@ class TestProjectFileServing:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.core.project_archive.get_project_dir", return_value=str(ws)):
+             patch("onemancompany.core.project_archive.get_project_workspace", return_value=str(ws)):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/projects/proj1/files/image.png")
@@ -5019,7 +5019,7 @@ class TestProjectFileServing:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.core.project_archive.get_project_dir", return_value=str(ws)):
+             patch("onemancompany.core.project_archive.get_project_workspace", return_value=str(ws)):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/projects/proj1/files/photo.jpg")
@@ -5038,7 +5038,7 @@ class TestProjectFileServing:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.core.project_archive.get_project_dir", return_value=str(ws)):
+             patch("onemancompany.core.project_archive.get_project_workspace", return_value=str(ws)):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/projects/proj1/files/anim.gif")
@@ -5057,7 +5057,7 @@ class TestProjectFileServing:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.core.project_archive.get_project_dir", return_value=str(ws)):
+             patch("onemancompany.core.project_archive.get_project_workspace", return_value=str(ws)):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/projects/proj1/files/icon.svg")
@@ -5076,7 +5076,7 @@ class TestProjectFileServing:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.core.project_archive.get_project_dir", return_value=str(ws)):
+             patch("onemancompany.core.project_archive.get_project_workspace", return_value=str(ws)):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/projects/proj1/files/doc.pdf")
@@ -5095,7 +5095,7 @@ class TestProjectFileServing:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.core.project_archive.get_project_dir", return_value=str(ws)):
+             patch("onemancompany.core.project_archive.get_project_workspace", return_value=str(ws)):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/projects/proj1/files/data.bin")
@@ -5113,7 +5113,7 @@ class TestProjectFileServing:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.core.project_archive.get_project_dir", return_value=str(ws)):
+             patch("onemancompany.core.project_archive.get_project_workspace", return_value=str(ws)):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/projects/proj1/files/nonexistent.py")
@@ -5718,7 +5718,7 @@ class TestProjectFileTraversal:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.core.project_archive.get_project_dir", return_value=str(ws)):
+             patch("onemancompany.core.project_archive.get_project_workspace", return_value=str(ws)):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/projects/proj1/files/../secret.txt")
@@ -6011,7 +6011,7 @@ class TestProjectFilePathEscape:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.core.project_archive.get_project_dir", return_value=str(ws)):
+             patch("onemancompany.core.project_archive.get_project_workspace", return_value=str(ws)):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/projects/proj1/files/escape/secret.txt")

--- a/tests/unit/core/test_project_archive.py
+++ b/tests/unit/core/test_project_archive.py
@@ -82,8 +82,8 @@ class TestCreateNamedProject:
         slug = pa.create_named_project("My App")
         proj_dir = tmp_path / slug
         assert proj_dir.exists()
-        assert (proj_dir / "workspace").exists()
         assert (proj_dir / "iterations").exists()
+        # workspace is now per-iteration, not at project root
         assert (proj_dir / "project.yaml").exists()
 
     def test_project_yaml_content(self, tmp_path):
@@ -148,14 +148,14 @@ class TestCreateIteration:
     def test_iteration_copies_previous_workspace(self, tmp_path):
         slug = pa.create_named_project("CopyWS")
         iter_id1 = pa.create_iteration(slug, "task1", "COO")
-        # Write a file to iter_001 workspace
+        # Write a file to iter_001 workspace subdirectory
         doc1 = pa.load_iteration(slug, iter_id1)
-        ws1 = Path(doc1["project_dir"])
+        ws1 = Path(doc1["project_dir"]) / "workspace"
         (ws1 / "hello.txt").write_text("hello")
-        # Create second iteration — should copy hello.txt
+        # Create second iteration — should copy hello.txt into new workspace
         iter_id2 = pa.create_iteration(slug, "task2", "COO")
         doc2 = pa.load_iteration(slug, iter_id2)
-        ws2 = Path(doc2["project_dir"])
+        ws2 = Path(doc2["project_dir"]) / "workspace"
         assert (ws2 / "hello.txt").exists()
         assert (ws2 / "hello.txt").read_text() == "hello"
 
@@ -685,7 +685,7 @@ class TestResolveWorkspace:
         assert "iter_001" in d
 
     def test_iteration_without_project_dir(self, tmp_path):
-        """Fallback to shared workspace when iteration has no project_dir."""
+        """Fallback to iteration dir when iteration has no project_dir."""
         slug = pa.create_named_project("Fallback WS")
         iter_id = pa.create_iteration(slug, "task", "COO")
         # Remove project_dir from iteration doc
@@ -694,7 +694,7 @@ class TestResolveWorkspace:
         pa._save_iteration(slug, iter_id, doc)
 
         d = pa.get_project_dir(iter_id)
-        assert "workspace" in d
+        assert "iter_001" in d
 
 
 
@@ -748,7 +748,7 @@ class TestCreateIterationCopytree:
 
         # Add a directory with files to the first iteration workspace
         doc1 = pa.load_iteration(slug, iter_id1)
-        ws1 = Path(doc1["project_dir"])
+        ws1 = Path(doc1["project_dir"]) / "workspace"
         sub_dir = ws1 / "src" / "components"
         sub_dir.mkdir(parents=True)
         (sub_dir / "main.py").write_text("print('hello')")
@@ -757,7 +757,7 @@ class TestCreateIterationCopytree:
         # Create second iteration — should copy both files and directories
         iter_id2 = pa.create_iteration(slug, "task2", "COO")
         doc2 = pa.load_iteration(slug, iter_id2)
-        ws2 = Path(doc2["project_dir"])
+        ws2 = Path(doc2["project_dir"]) / "workspace"
 
         assert (ws2 / "src" / "components" / "main.py").exists()
         assert (ws2 / "src" / "components" / "main.py").read_text() == "print('hello')"

--- a/tests/unit/core/test_project_archive.py
+++ b/tests/unit/core/test_project_archive.py
@@ -159,6 +159,26 @@ class TestCreateIteration:
         assert (ws2 / "hello.txt").exists()
         assert (ws2 / "hello.txt").read_text() == "hello"
 
+    def test_iteration_copies_legacy_layout_workspace(self, tmp_path):
+        """Old iterations stored files directly in iter_dir (no workspace/ subdir).
+        create_iteration should still copy those files into the new workspace."""
+        slug = pa.create_named_project("LegacyCopy")
+        iter_id1 = pa.create_iteration(slug, "task1", "COO")
+        doc1 = pa.load_iteration(slug, iter_id1)
+        iter_dir1 = Path(doc1["project_dir"])
+        # Simulate old layout: remove workspace/, put files directly in iter_dir
+        ws1 = iter_dir1 / "workspace"
+        if ws1.exists():
+            import shutil
+            shutil.rmtree(ws1)
+        (iter_dir1 / "legacy.txt").write_text("old-data")
+        # Create second iteration — should copy legacy.txt
+        iter_id2 = pa.create_iteration(slug, "task2", "COO")
+        doc2 = pa.load_iteration(slug, iter_id2)
+        ws2 = Path(doc2["project_dir"]) / "workspace"
+        assert (ws2 / "legacy.txt").exists()
+        assert (ws2 / "legacy.txt").read_text() == "old-data"
+
 
 # ---------------------------------------------------------------------------
 # load / list helpers


### PR DESCRIPTION
## Summary
- Fix project detail Documents section showing empty — render files list in iteration detail view
- Move project workspace from `{project}/workspace/` to `{project}/iterations/{iter}/workspace/` — workspace is now under iteration, not sibling to it
- Separate `get_project_dir()` (iteration root for task_tree.yaml) from `get_project_workspace()` (workspace subdir for user files)
- Unify Project Wall modal to use same iteration split view as sidebar (`_renderProjectDetail` shared method)
- Project Wall list now uses `/api/projects/named` for consistent data with iteration count and file count
- Add Back button in project detail header for navigation

## Test plan
- [x] All 1926 unit tests pass
- [ ] Verify Documents section shows files in project detail
- [ ] Verify Project Wall modal shows same iteration split view as sidebar
- [ ] Verify workspace files are saved under `iterations/{iter}/workspace/`
- [ ] Verify task_tree.yaml is saved in iteration root (not workspace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)