### PR TITLE
feat: hire employee directly from CV JSON

### DIFF
--- a/company/human_resource/employees/00002/manifest.json
+++ b/company/human_resource/employees/00002/manifest.json
@@ -28,25 +28,6 @@
         ]
       },
       {
-        "id": "cv_hire",
-        "title": "Hire from CV",
-        "fields": [
-          {
-            "key": "_cv_json",
-            "type": "textarea",
-            "label": "CV (JSON)",
-            "placeholder": "Paste talent CV JSON here..."
-          },
-          {
-            "key": "_cv_hire",
-            "type": "action_button",
-            "label": "Hire",
-            "action": "hire_from_cv",
-            "cv_field": "_cv_json"
-          }
-        ]
-      },
-      {
         "id": "llm",
         "title": "LLM Configuration",
         "fields": [
@@ -64,6 +45,25 @@
             "min": 0,
             "max": 2,
             "step": 0.1
+          }
+        ]
+      },
+      {
+        "id": "cv_hire",
+        "title": "Hire from CV",
+        "fields": [
+          {
+            "key": "_cv_json",
+            "type": "textarea",
+            "label": "CV (JSON)",
+            "placeholder": "Paste talent CV JSON here..."
+          },
+          {
+            "key": "_cv_hire",
+            "type": "action_button",
+            "label": "Hire",
+            "action": "hire_from_cv",
+            "cv_field": "_cv_json"
           }
         ]
       }

--- a/company/human_resource/employees/00002/manifest.json
+++ b/company/human_resource/employees/00002/manifest.json
@@ -28,6 +28,25 @@
         ]
       },
       {
+        "id": "cv_hire",
+        "title": "Hire from CV",
+        "fields": [
+          {
+            "key": "_cv_json",
+            "type": "textarea",
+            "label": "CV (JSON)",
+            "placeholder": "Paste talent CV JSON here..."
+          },
+          {
+            "key": "_cv_hire",
+            "type": "action_button",
+            "label": "Hire",
+            "action": "hire_from_cv",
+            "cv_field": "_cv_json"
+          }
+        ]
+      },
+      {
         "id": "llm",
         "title": "LLM Configuration",
         "fields": [

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2544,8 +2544,9 @@ class AppController {
     }
   }
 
-  async _handleManifestAction(field, empId) {
-    if (field.action === 'hire_from_cv') {
+  /** Registry of manifest action handlers keyed by action name. */
+  _manifestActions = {
+    hire_from_cv: async (field, empId) => {
       const container = document.getElementById('emp-settings-container');
       const cvEl = container.querySelector(`[data-field-key="${field.cv_field}"]`);
       if (!cvEl || !cvEl.value.trim()) {
@@ -2569,18 +2570,27 @@ class AppController {
           body: JSON.stringify({ cv }),
         }).then(r => r.json());
         if (resp.error) {
-          this.logEntry('SYSTEM', `Hire failed: ${resp.error}`, 'system');
+          this.logEntry('SYSTEM', `Hire failed: ${this._escHtml(resp.error)}`, 'system');
         } else {
-          this.logEntry('CEO', `Onboarding started for ${resp.name} (${resp.role})`, 'ceo');
+          this.logEntry('CEO', `Onboarding started for ${this._escHtml(resp.name)} (${this._escHtml(resp.role)})`, 'ceo');
           cvEl.value = '';
         }
       } catch (err) {
-        this.logEntry('SYSTEM', `Hire request failed: ${err.message}`, 'system');
+        this.logEntry('SYSTEM', `Hire request failed: ${this._escHtml(err.message)}`, 'system');
       } finally {
         btn.disabled = false;
         btn.textContent = field.label || 'Hire';
       }
+    },
+  };
+
+  async _handleManifestAction(field, empId) {
+    const handler = this._manifestActions[field.action];
+    if (!handler) {
+      console.error(`[manifest] Unknown action: ${field.action}`);
+      return;
     }
+    await handler(field, empId);
   }
 
   _renderSelfHostedSection(empId, empData, container) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2295,7 +2295,7 @@ class AppController {
             sectionEl.innerHTML = `<div class="emp-settings-title">${this._escHtml(section.title)}</div>`;
           }
           for (const field of section.fields) {
-            const fieldEl = this._renderManifestField(field, empResp);
+            const fieldEl = this._renderManifestField(field, empResp, empId);
             sectionEl.appendChild(fieldEl);
           }
           container.appendChild(sectionEl);
@@ -2317,7 +2317,7 @@ class AppController {
     }
   }
 
-  _renderManifestField(field, empData) {
+  _renderManifestField(field, empData, empId) {
     const row = document.createElement('div');
     row.className = 'emp-settings-field';
     row.style.cssText = 'display:flex;align-items:center;gap:4px;width:100%;margin:2px 0;';
@@ -2422,6 +2422,16 @@ class AppController {
       btn.dataset.fieldType = 'oauth_button';
       btn.addEventListener('click', () => this.startOAuthLogin());
       row.appendChild(btn);
+    } else if (field.type === 'action_button') {
+      const btn = document.createElement('button');
+      btn.className = 'pixel-btn small';
+      btn.textContent = field.label || 'Run';
+      btn.dataset.fieldKey = field.key;
+      btn.dataset.fieldType = 'action_button';
+      btn.dataset.action = field.action || '';
+      btn.dataset.cvField = field.cv_field || '';
+      btn.addEventListener('click', () => this._handleManifestAction(field, empId));
+      row.appendChild(btn);
     } else {
       // Default: text input
       const input = document.createElement('input');
@@ -2463,6 +2473,8 @@ class AppController {
       const key = el.dataset.fieldKey;
       const type = el.dataset.fieldType;
       if (type === 'readonly') continue;
+      if (type === 'action_button') continue;
+      if (key.startsWith('_')) continue;  // internal/ephemeral fields (e.g. _cv_json)
       if (type === 'secret') {
         if (el.value) payload[key] = el.value; // only send if changed
       } else if (type === 'toggle') {
@@ -2529,6 +2541,45 @@ class AppController {
     } finally {
       saveBtn.disabled = false;
       saveBtn.textContent = 'Save';
+    }
+  }
+
+  async _handleManifestAction(field, empId) {
+    if (field.action === 'hire_from_cv') {
+      const container = document.getElementById('emp-settings-container');
+      const cvEl = container.querySelector(`[data-field-key="${field.cv_field}"]`);
+      if (!cvEl || !cvEl.value.trim()) {
+        this.logEntry('SYSTEM', 'Please paste a CV JSON before clicking Hire.', 'system');
+        return;
+      }
+      let cv;
+      try {
+        cv = JSON.parse(cvEl.value.trim());
+      } catch {
+        this.logEntry('SYSTEM', 'Invalid JSON in CV field.', 'system');
+        return;
+      }
+      const btn = container.querySelector(`[data-field-key="${field.key}"]`);
+      btn.disabled = true;
+      btn.textContent = 'Hiring...';
+      try {
+        const resp = await fetch('/api/candidates/hire-from-cv', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ cv }),
+        }).then(r => r.json());
+        if (resp.error) {
+          this.logEntry('SYSTEM', `Hire failed: ${resp.error}`, 'system');
+        } else {
+          this.logEntry('CEO', `Onboarding started for ${resp.name} (${resp.role})`, 'ceo');
+          cvEl.value = '';
+        }
+      } catch (err) {
+        this.logEntry('SYSTEM', `Hire request failed: ${err.message}`, 'system');
+      } finally {
+        btn.disabled = false;
+        btn.textContent = field.label || 'Hire';
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.383",
+  "version": "0.2.384",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.383"
+version = "0.2.384"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -4037,6 +4037,77 @@ async def _do_hire_single(
         await _cleanup_single_hire_failure(batch_id, candidate_id, candidate, str(e))
 
 
+@router.post("/api/candidates/hire-from-cv")
+async def hire_from_cv(body: dict) -> dict:
+    """Hire an employee directly from a CV JSON (bypasses talent market search).
+
+    The CV JSON format mirrors the Talent Market profile schema. Required fields:
+      name, role. Optional: skills, llm_model, api_provider, hosting, auth_method,
+      temperature, salary_per_1m_tokens, system_prompt_template, talent_id.
+    """
+    from onemancompany.agents.onboarding import execute_hire, generate_nickname
+
+    cv = body.get("cv")
+    if not cv or not isinstance(cv, dict):
+        return {"error": "Missing or invalid 'cv' field"}
+
+    name = cv.get("name", "").strip()
+    role = cv.get("role", "").strip()
+    if not name:
+        return {"error": "CV missing required field: name"}
+    if not role:
+        return {"error": "CV missing required field: role"}
+
+    hosting = cv.get("hosting", "company")
+    is_self = hosting == "self"
+    skills = [s if isinstance(s, str) else s.get("name", "") for s in cv.get("skills", [])]
+    talent_id = cv.get("talent_id", "")
+
+    try:
+        nickname = await asyncio.wait_for(
+            generate_nickname(name, role, is_founding=False), timeout=120
+        )
+    except asyncio.TimeoutError:
+        nickname = ""
+
+    batch_id = f"cv_{talent_id or name.lower().replace(' ', '_')}_{int(asyncio.get_event_loop().time())}"
+
+    async def _cv_progress(step, message):
+        step_order = ["assigning_id", "copying_skills", "registering_agent", "completed"]
+        step_index = step_order.index(step) if step in step_order else -1
+        await event_bus.publish(CompanyEvent(
+            type="onboarding_progress",
+            payload={"batch_id": batch_id, "candidate_id": talent_id or name,
+                     "name": name, "step": step, "step_index": step_index,
+                     "total_steps": 4, "current": 1, "total": 1, "message": message},
+            agent="HR",
+        ))
+
+    async def _do_cv_hire():
+        try:
+            emp = await execute_hire(
+                name=name,
+                nickname=nickname,
+                role=role,
+                skills=skills,
+                talent_id=talent_id,
+                llm_model="" if is_self else cv.get("llm_model", ""),
+                temperature=float(cv.get("temperature", 0.7)),
+                api_provider="" if is_self else cv.get("api_provider", "openrouter"),
+                hosting=hosting,
+                auth_method=cv.get("auth_method", "api_key"),
+                remote=False,
+                progress_callback=_cv_progress,
+            )
+            await event_bus.publish(CompanyEvent(type="state_snapshot", payload={}, agent="CEO"))
+            logger.info("[cv_hire] Hired {} ({})", name, emp.id)
+        except Exception:
+            logger.exception("[cv_hire] Failed to hire {}", name)
+
+    spawn_background(_do_cv_hire())
+    return {"status": "onboarding", "name": name, "role": role, "message": "Onboarding started in background"}
+
+
 @router.post("/api/candidates/dismiss")
 async def dismiss_shortlist(body: dict) -> dict:
     """CEO dismissed the shortlist — cancel this recruitment round."""

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -4062,6 +4062,13 @@ async def hire_from_cv(body: dict) -> dict:
     is_self = hosting == "self"
     skills = [s if isinstance(s, str) else s.get("name", "") for s in cv.get("skills", [])]
     talent_id = cv.get("talent_id", "")
+    try:
+        temperature = float(cv.get("temperature", 0.7))
+    except (ValueError, TypeError):
+        temperature = 0.7
+
+    logger.debug("[cv_hire] Received CV: name={}, role={}, hosting={}, skills={}, talent_id={}",
+                 name, role, hosting, skills, talent_id)
 
     try:
         nickname = await asyncio.wait_for(
@@ -4069,8 +4076,10 @@ async def hire_from_cv(body: dict) -> dict:
         )
     except asyncio.TimeoutError:
         nickname = ""
+    logger.debug("[cv_hire] Generated nickname={} for {}", nickname, name)
 
-    batch_id = f"cv_{talent_id or name.lower().replace(' ', '_')}_{int(asyncio.get_event_loop().time())}"
+    import time as _time
+    batch_id = f"cv_{talent_id or name.lower().replace(' ', '_')}_{int(_time.time())}"
 
     async def _cv_progress(step, message):
         step_order = ["assigning_id", "copying_skills", "registering_agent", "completed"]
@@ -4092,7 +4101,7 @@ async def hire_from_cv(body: dict) -> dict:
                 skills=skills,
                 talent_id=talent_id,
                 llm_model="" if is_self else cv.get("llm_model", ""),
-                temperature=float(cv.get("temperature", 0.7)),
+                temperature=temperature,
                 api_provider="" if is_self else cv.get("api_provider", "openrouter"),
                 hosting=hosting,
                 auth_method=cv.get("auth_method", "api_key"),
@@ -4101,6 +4110,8 @@ async def hire_from_cv(body: dict) -> dict:
             )
             await event_bus.publish(CompanyEvent(type="state_snapshot", payload={}, agent="CEO"))
             logger.info("[cv_hire] Hired {} ({})", name, emp.id)
+        except asyncio.CancelledError:
+            raise
         except Exception:
             logger.exception("[cv_hire] Failed to hire {}", name)
 

--- a/tests/unit/api/test_routes.py
+++ b/tests/unit/api/test_routes.py
@@ -6826,3 +6826,86 @@ class TestCleanupSingleHireFailure:
         mock_em.resume_held_task.assert_called_once_with(
             "00002", "node-123", "Hire failed: clone error"
         )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/candidates/hire-from-cv
+# ---------------------------------------------------------------------------
+
+class TestHireFromCV:
+    @pytest.mark.asyncio
+    async def test_missing_cv_field(self):
+        app = _make_test_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/api/candidates/hire-from-cv", json={})
+            assert resp.status_code == 200
+            assert resp.json()["error"] == "Missing or invalid 'cv' field"
+
+    @pytest.mark.asyncio
+    async def test_missing_name(self):
+        app = _make_test_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/api/candidates/hire-from-cv", json={"cv": {"role": "Dev"}})
+            assert resp.json()["error"] == "CV missing required field: name"
+
+    @pytest.mark.asyncio
+    async def test_missing_role(self):
+        app = _make_test_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/api/candidates/hire-from-cv", json={"cv": {"name": "Alice"}})
+            assert resp.json()["error"] == "CV missing required field: role"
+
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        app = _make_test_app()
+        transport = ASGITransport(app=app)
+
+        mock_emp = MagicMock(id="00010")
+
+        async def fake_nickname(*a, **kw):
+            return "小明"
+
+        async def fake_hire(**kw):
+            return mock_emp
+
+        with patch("onemancompany.api.routes.event_bus", MagicMock(publish=AsyncMock())), \
+             patch("onemancompany.agents.onboarding.generate_nickname", fake_nickname), \
+             patch("onemancompany.agents.onboarding.execute_hire", fake_hire), \
+             patch("onemancompany.api.routes.spawn_background") as mock_spawn:
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post("/api/candidates/hire-from-cv", json={
+                    "cv": {"name": "Alice", "role": "Developer", "skills": ["python"]}
+                })
+                data = resp.json()
+                assert data["status"] == "onboarding"
+                assert data["name"] == "Alice"
+                assert data["role"] == "Developer"
+                mock_spawn.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_invalid_temperature_fallback(self):
+        """Non-numeric temperature should fallback to 0.7, not crash."""
+        app = _make_test_app()
+        transport = ASGITransport(app=app)
+
+        mock_emp = MagicMock(id="00010")
+
+        async def fake_nickname(*a, **kw):
+            return ""
+
+        async def fake_hire(**kw):
+            assert kw["temperature"] == 0.7  # fallback value
+            return mock_emp
+
+        with patch("onemancompany.api.routes.event_bus", MagicMock(publish=AsyncMock())), \
+             patch("onemancompany.agents.onboarding.generate_nickname", fake_nickname), \
+             patch("onemancompany.agents.onboarding.execute_hire", fake_hire), \
+             patch("onemancompany.api.routes.spawn_background"):
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post("/api/candidates/hire-from-cv", json={
+                    "cv": {"name": "Bob", "role": "PM", "temperature": "hot"}
+                })
+                assert resp.json()["status"] == "onboarding"


### PR DESCRIPTION
## Summary
- Add a **Hire from CV** section to the HR employee settings panel
- Paste any Talent Market CV JSON into the textarea and click **Hire** to onboard immediately — no talent market search, shortlist, or CEO approval needed
- New `POST /api/candidates/hire-from-cv` endpoint maps CV fields directly to `execute_hire()`

## Changes
- `company/human_resource/employees/00002/manifest.json` — new `cv_hire` section with `textarea` + `action_button` fields
- `src/onemancompany/api/routes.py` — new endpoint parses CV JSON and runs onboarding in background
- `frontend/app.js` — new `action_button` field type, `_handleManifestAction` handler, fix `empId` not passed into `_renderManifestField`

## Test plan
- [ ] Open HR employee settings → confirm "Hire from CV" section appears
- [ ] Paste a valid CV JSON and click Hire → onboarding progress events appear in activity log
- [ ] New employee shows up in the office after onboarding completes
- [ ] Invalid JSON shows an error message in the activity log
- [ ] Missing `name`/`role` fields return an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)