### PR TITLE
fix: onboard init -y skip and .env search from CWD

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -392,10 +392,22 @@ ${green("What gets installed automatically:")}
   if (isInitCmd || !initComplete) {
     if (isAutoInit) {
       // ── Auto-init: read .env, confirm with user, then run ──────────
-      const envPath = path.join(installDir, ".env");
-      if (!fs.existsSync(envPath)) {
+      // Search .env: user CWD first, then installDir
+      const cwdEnvPath = path.join(process.cwd(), ".env");
+      const installEnvPath = path.join(installDir, ".env");
+      let envPath;
+      if (fs.existsSync(cwdEnvPath)) {
+        envPath = cwdEnvPath;
+        // Copy to installDir so Python onboard.py can find it
+        if (cwdEnvPath !== installEnvPath) {
+          fs.copyFileSync(cwdEnvPath, installEnvPath);
+          info(`Copied .env from ${process.cwd()} to ${installDir}`);
+        }
+      } else if (fs.existsSync(installEnvPath)) {
+        envPath = installEnvPath;
+      } else {
         fail(
-          `.env file not found at ${envPath}\n` +
+          `.env file not found in ${process.cwd()} or ${installDir}\n` +
           "  Auto-init requires a .env file with your configuration.\n" +
           "  Run interactive setup instead:  npx @1mancompany/onemancompany init"
         );
@@ -461,7 +473,9 @@ ${green("What gets installed automatically:")}
       }
 
       info("Running auto-init from .env...\n");
-      const initResult = spawnSync(pythonBin, ["-m", "onemancompany.onboard", "--auto"], {
+      // Always pass -y: JS already handled confirmation (or user passed -y)
+      const initArgs = ["-m", "onemancompany.onboard", "--auto", "-y"];
+      const initResult = spawnSync(pythonBin, initArgs, {
         cwd: installDir,
         stdio: "inherit",
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.399",
+  "version": "0.2.400",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.399"
+version = "0.2.400"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Fix `-y` flag not skipping Python's secondary confirmation prompt — JS now always passes `-y` to Python since JS already handles the confirmation gate
- Search `.env` from user's CWD first (where `npx` runs), then `installDir`; auto-copy to `installDir` so Python `onboard.py` can find it
- Improved error message shows both searched locations

## Test plan
- [ ] `npx @1mancompany/onemancompany init --auto -y` skips all confirmation prompts
- [ ] `.env` in user's CWD is found and copied to install directory
- [ ] Missing `.env` shows helpful error with both search paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)