### PR TITLE
fix: watchdog_nudge should not trigger project completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.404",
+  "version": "0.2.405",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.403",
+  "version": "0.2.404",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.404"
+version = "0.2.405"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.403"
+version = "0.2.404"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -258,7 +258,7 @@ async def project_progress_watchdog() -> list | None:
     review the task tree and drive the project forward.
     """
     from onemancompany.core.config import EA_ID, PROJECTS_DIR
-    from onemancompany.core.task_lifecycle import TaskPhase, TERMINAL
+    from onemancompany.core.task_lifecycle import TaskPhase, RESOLVED
     from onemancompany.core.task_tree import get_tree, get_tree_lock, save_tree_async
     from onemancompany.core.vessel import employee_manager
 
@@ -295,11 +295,11 @@ async def project_progress_watchdog() -> list | None:
         if any(n.status == TaskPhase.PROCESSING.value for n in active_nodes):
             continue
 
-        # Skip if all active nodes are terminal (project is done)
-        all_terminal = all(
-            TaskPhase(n.status) in TERMINAL for n in active_nodes
+        # Skip if all active nodes are resolved (project is done)
+        all_resolved = all(
+            TaskPhase(n.status) in RESOLVED for n in active_nodes
         )
-        if all_terminal:
+        if all_resolved:
             continue
 
         # --- Project is stuck — nudge EA ---

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1761,7 +1761,12 @@ class EmployeeManager:
             return
 
         # --- Propagate upward: review / auto-complete parent ---
+        # CEO prompt nodes are containers — they don't need review or auto-complete.
+        # Their child (EA) completing is handled by the project completion check below.
         parent_node = tree.get_node(node.parent_id) if node.parent_id else None
+        if parent_node and parent_node.is_ceo_node:
+            logger.debug("[ON_CHILD_COMPLETE] parent {} is CEO node — skipping review/auto-complete", parent_node.id)
+            parent_node = None  # Skip propagation, fall through to project completion check
         if parent_node and TaskPhase(parent_node.status) not in RESOLVED:
             children = tree.get_active_children(parent_node.id)
             if tree.all_children_done(parent_node.id):

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1797,7 +1797,10 @@ class EmployeeManager:
         # --- Bottom-up project completion check ---
         # After any status change, check if the entire project tree is resolved.
         # EA done executing + all child subtrees RESOLVED → trigger retrospective.
-        if tree.is_project_complete():
+        # watchdog_nudge nodes are housekeeping probes — they must NOT trigger
+        # project completion. Their purpose is to nudge stalled projects, not
+        # to be the final event that marks a project done.
+        if node.node_type != "watchdog_nudge" and tree.is_project_complete():
             ea_node = tree.get_ea_node()
             logger.info(
                 "[PROJECT COMPLETE] EA node {} done + all subtrees resolved — triggering retrospective",


### PR DESCRIPTION
## Summary
- Watchdog nudge nodes auto-skip to FINISHED (RESOLVED), which could satisfy `is_project_complete()` and trigger premature retrospective
- Added guard: `node.node_type != "watchdog_nudge"` before the project completion check
- Review and ceo_request nodes still correctly trigger the check

## Test plan
- [x] 1954 tests pass
- [ ] Manual: deploy and verify watchdog nudge no longer triggers retrospective

🤖 Generated with [Claude Code](https://claude.com/claude-code)