### PR TITLE
feat: Talent Market MCP keepalive cron (15s)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.405",
+  "version": "0.2.406",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.405"
+version = "0.2.406"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -238,6 +238,38 @@ async def config_reload_check() -> list | None:
 
 
 # ---------------------------------------------------------------------------
+# Talent Market keepalive — maintain MCP connection
+# ---------------------------------------------------------------------------
+
+
+@system_cron("talent_market_keepalive", interval="15s", description="Talent Market MCP 连接保活")
+async def talent_market_keepalive() -> list | None:
+    """Ping the Talent Market MCP server; reconnect if the session is dead."""
+    from onemancompany.agents.recruitment import talent_market, start_talent_market
+
+    if not talent_market.connected:
+        return None
+
+    try:
+        await talent_market._session.send_ping()
+        logger.debug("[talent_market_keepalive] ping OK")
+    except Exception as e:
+        logger.warning("[talent_market_keepalive] ping failed ({}), reconnecting...", e)
+        try:
+            await talent_market.disconnect()
+        except Exception:
+            # Force-clear stale state even if disconnect fails
+            talent_market._session = None
+            talent_market._stack = None
+        try:
+            await start_talent_market()
+            logger.info("[talent_market_keepalive] reconnected successfully")
+        except Exception as e2:
+            logger.error("[talent_market_keepalive] reconnect failed: {}", e2)
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Project progress watchdog — prevent projects from getting stuck
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `talent_market_keepalive` system cron (15s interval) that pings the MCP SSE session and auto-reconnects on failure
- Prevents silent `ClosedResourceError` disconnects from going undetected

## Test plan
- [ ] Start company with Talent Market connected, verify keepalive ping logs appear every 15s
- [ ] Kill the MCP server, verify reconnect attempt in logs
- [ ] Verify no keepalive runs when Talent Market is not connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)