### PR TITLE
fix: store.save_project_status creates stray iter dirs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.406",
+  "version": "0.2.407",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.406"
+version = "0.2.407"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -516,6 +516,17 @@ def complete_project(project_id: str, output: str = "") -> None:
     mark_dirty("task_queue")
 
 
+def update_project_status(project_id: str, status: str, **extra) -> None:
+    """Update status (and optional extra fields) on a project/iteration via resolve."""
+    version, doc, key = _resolve_and_load(project_id)
+    if not doc:
+        logger.debug("[update_project_status] No doc found for {}", project_id)
+        return
+    doc["status"] = status
+    doc.update(extra)
+    _save_resolved(version, key, doc)
+
+
 def load_project(project_id: str) -> dict | None:
     """Load a project or iteration record."""
     version, doc, _key = _resolve_and_load(project_id)

--- a/src/onemancompany/core/store.py
+++ b/src/onemancompany/core/store.py
@@ -232,16 +232,13 @@ def _rooms_dir() -> Path:
 # ---------------------------------------------------------------------------
 
 def load_project(project_id: str) -> dict:
-    return _read_yaml(PROJECTS_DIR / project_id / "project.yaml")
+    from onemancompany.core.project_archive import load_project as _load_project
+    return _load_project(project_id) or {}
 
 
 async def save_project_status(project_id: str, status: str, **extra) -> None:
-    path = PROJECTS_DIR / project_id / "project.yaml"
-    async with _get_lock(str(path)):
-        data = _read_yaml(path)
-        data["status"] = status
-        data.update(extra)
-        _write_yaml(path, data)
+    from onemancompany.core.project_archive import update_project_status
+    update_project_status(project_id, status, **extra)
     mark_dirty("task_queue")
 
 

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2135,11 +2135,10 @@ class EmployeeManager:
             label = node.description or "Task completed"
             if agent_error:
                 label = f"{label} (with errors)"
-            complete_project(project_id, label)
-            status = "failed" if agent_error else "completed"
-            await _store.save_project_status(
-                project_id, status, completed_at=datetime.now().isoformat()
-            )
+            if agent_error:
+                await _store.save_project_status(project_id, "failed")
+            else:
+                complete_project(project_id, label)
 
         from onemancompany.core.state import flush_pending_reload
         flush_result = flush_pending_reload()

--- a/tests/unit/core/test_agent_loop.py
+++ b/tests/unit/core/test_agent_loop.py
@@ -1436,6 +1436,7 @@ class TestEmployeeManagerFullCleanup:
     @patch("onemancompany.core.vessel.company_state")
     @patch("onemancompany.core.vessel.event_bus")
     async def test_full_cleanup_agent_error_label(self, mock_bus, mock_state, mock_store):
+        """On agent error, save_project_status("failed") is called instead of complete_project."""
         mock_bus.publish = AsyncMock()
         mock_state.employees = {}
         mock_state.active_tasks = []
@@ -1453,8 +1454,9 @@ class TestEmployeeManagerFullCleanup:
                         with patch("onemancompany.core.state.flush_pending_reload", return_value=None):
                             with patch("onemancompany.core.config.FOUNDING_LEVEL", 4):
                                 await mgr._full_cleanup("emp01", node, True, "proj1")
-                                call_args = mock_complete.call_args
-                                assert "with errors" in call_args[0][1]
+                                # On error: save_project_status is called with "failed", not complete_project
+                                mock_complete.assert_not_called()
+                                mock_store.save_project_status.assert_awaited_once_with("proj1", "failed")
 
     @pytest.mark.asyncio
     @patch("onemancompany.core.vessel._store")

--- a/tests/unit/core/test_store.py
+++ b/tests/unit/core/test_store.py
@@ -122,13 +122,18 @@ def test_read_yaml_list_non_list_returns_empty(tmp_path):
 
 @pytest.mark.asyncio
 async def test_save_project_status_updates_yaml(tmp_path, monkeypatch):
-    from onemancompany.core import store
+    from onemancompany.core import store, project_archive
     monkeypatch.setattr(store, "PROJECTS_DIR", tmp_path)
+    monkeypatch.setattr(project_archive, "PROJECTS_DIR", tmp_path)
     pdir = tmp_path / "proj-001"
     pdir.mkdir()
-    (pdir / "project.yaml").write_text("task: Build thing\nstatus: in_progress\n")
+    # Set up as a v2 named project with an iteration
+    (pdir / "project.yaml").write_text("name: Test\nstatus: active\niterations: [iter_001]\n")
+    iter_dir = pdir / "iterations"
+    iter_dir.mkdir()
+    (iter_dir / "iter_001.yaml").write_text("task: Build thing\nstatus: in_progress\n")
     await store.save_project_status("proj-001", "completed", completed_at="2026-03-11")
-    data = yaml.safe_load((pdir / "project.yaml").read_text())
+    data = yaml.safe_load((iter_dir / "iter_001.yaml").read_text())
     assert data["status"] == "completed"
     assert data["completed_at"] == "2026-03-11"
     assert data["task"] == "Build thing"


### PR DESCRIPTION
## Summary
- `store.save_project_status` used raw `PROJECTS_DIR / project_id / "project.yaml"` which creates stray directories like `projects/slug/iter_001/project.yaml` when `project_id` is a qualified iteration ID (`slug/iter_001`)
- Delegate to new `project_archive.update_project_status()` which uses `_resolve_and_load` / `_save_resolved` to write to the correct `iterations/iter_001.yaml`
- Remove redundant double-write in `vessel._full_cleanup`: `complete_project` already handles success; only call `save_project_status` for failure case

## Test plan
- [x] All 1946 tests pass
- [ ] Verify no stray `iter_NNN/` dirs created under project root after running a project

🤖 Generated with [Claude Code](https://claude.com/claude-code)