### PR TITLE
fix: agent directory map + watchdog nudge blocking EA

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.412",
+  "version": "0.2.413",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.413",
+  "version": "0.2.414",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.412"
+version = "0.2.413"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.413"
+version = "0.2.414"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -881,6 +881,19 @@ class EmployeeAgent(BaseAgentRunner):
                       ))
         pb.add("tool_usage", tool_usage, priority=20)
 
+        # 3.5. Company directory map — so agents know where files live
+        from onemancompany.core.config import COMPANY_DIR, WORKFLOWS_DIR, PROJECTS_DIR
+        dir_map = (
+            "## Company Directory Map\n"
+            f"- Company root: {COMPANY_DIR}\n"
+            f"- Workflows / SOPs: {WORKFLOWS_DIR}\n"
+            f"- Projects: {PROJECTS_DIR}\n"
+            "- Use `ls()` with these absolute paths or relative paths under company root (e.g. `ls('business/workflows')`).\n"
+            "- Use `read()` with absolute paths to read any file.\n"
+            "- Project deliverables go in the project workspace path given in your task description.\n"
+        )
+        pb.add("directory_map", dir_map, priority=21)
+
         # 4. Unauthorized tools section
         pb.add("unauthorized_tools", self._get_unauthorized_tools_section(), priority=36)
 

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -357,7 +357,7 @@ async def project_progress_watchdog() -> list | None:
         lock = get_tree_lock(tree_path_str)
         with lock:
             nudge_node = tree.add_child(
-                parent_id=ea_node.id,
+                parent_id=tree.root_id,
                 employee_id=EA_ID,
                 description=nudge_desc,
                 acceptance_criteria=[],

--- a/src/onemancompany/core/task_tree.py
+++ b/src/onemancompany/core/task_tree.py
@@ -305,8 +305,16 @@ class TaskTree:
         return [c for c in self.get_children(node_id) if c.branch_active]
 
     def all_children_done(self, node_id: str) -> bool:
-        """All active children have finished executing (DONE_EXECUTING set)."""
-        children = self.get_active_children(node_id)
+        """All substantive active children have finished executing.
+
+        System node types (REVIEW, CEO_REQUEST, WATCHDOG_NUDGE, ADHOC, SYSTEM)
+        are excluded — they must not block parent completion.
+        """
+        from onemancompany.core.task_lifecycle import SYSTEM_NODE_TYPES
+        children = [
+            c for c in self.get_active_children(node_id)
+            if c.node_type not in SYSTEM_NODE_TYPES
+        ]
         if not children:
             return True
         return all(c.is_done_executing for c in children)


### PR DESCRIPTION
## Summary
- Agents now see absolute paths for company root, workflows dir, and projects dir in their system prompt
- Fix watchdog nudge nodes blocking EA from completing — nudge was added as EA's child, causing `all_children_done()` to never return True
- `all_children_done()` now skips system node types (REVIEW, CEO_REQUEST, WATCHDOG_NUDGE, ADHOC, SYSTEM)

## Changes
- `base.py`: Add "Company Directory Map" section to every agent's system prompt with absolute paths
- `system_cron.py`: Watchdog nudge nodes now hang under CEO root node instead of EA node
- `task_tree.py`: `all_children_done()` filters out SYSTEM_NODE_TYPES so they never block parent auto-complete

## Root cause (watchdog bug)
1. EA dispatches work, enters HOLDING
2. Watchdog creates nudge as EA's child → EA now has unfinished children
3. `all_children_done()` returns False because nudge is processing
4. EA can never auto-complete → stays HOLDING forever
5. Watchdog sees project still stuck → creates another nudge → infinite loop

## Test plan
- [x] 1950 tests pass
- [x] Verified directory map renders correct absolute paths
- [x] Watchdog nudge no longer appears in EA's children list

🤖 Generated with [Claude Code](https://claude.com/claude-code)