### PR TITLE
feat: align agent tools with Claude Code + eliminate hardcoded IDs

### DIFF
--- a/company/shared_prompts/tool_usage.md
+++ b/company/shared_prompts/tool_usage.md
@@ -1,9 +1,11 @@
 ## Tool Usage
-- ls: ALWAYS call this first to see existing project files.
-- read / ls: Read existing files to understand context before working.
-- write: Save ALL deliverables to the project workspace.
-- edit: Modify existing files (partial edits).
-- bash: Run shell commands (build, test, deploy, etc.).
+- ls: List files and directories. Use absolute paths or relative paths under company root.
+- read: Read file contents. Supports `offset` and `limit` for large files. You MUST read a file before using write() or edit() on it.
+- write: Create new files or overwrite existing ones. You MUST read the file first if it already exists.
+- edit: Exact string replacement in files — specify `old_string` and `new_string`. Use `replace_all=True` for multiple replacements. Prefer this over write() for modifying existing files.
+- glob_files: Search for files by pattern (e.g. `**/*.py`, `*.yaml`). Use this instead of `bash('find ...')`.
+- grep_search: Search file contents by regex pattern. Use this instead of `bash('grep ...')`.
+- bash: Run shell commands (build, test, deploy, etc.). Prefer dedicated tools (read, ls, edit, grep_search, glob_files) over shell equivalents.
 - dispatch_child: Delegate sub-work to colleagues if needed.
 - pull_meeting: ONLY for multi-person communication/discussion (2+ colleagues). Never call a meeting with yourself alone — if you need to think, just think internally.
 - use_tool: Access company equipment/tools registered by COO.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.414",
+  "version": "0.2.415",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.415",
+  "version": "0.2.416",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.416",
+  "version": "0.2.417",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.416"
+version = "0.2.417"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.414"
+version = "0.2.415"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.415"
+version = "0.2.416"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -45,8 +45,9 @@ async def _chat(room_id: str, speaker: str, role: str, message: str) -> None:
     await append_room_chat(room_id, entry)
 
 
-# Track files read in current agent session — write/edit safety check
-_files_read_in_session: set[str] = set()
+# Track files read per employee — write/edit safety check
+# Key: employee_id, Value: set of resolved file paths
+_files_read_by_employee: dict[str, set[str]] = {}
 
 
 def _resolve_employee_path(file_path: str, employee_id: str = ""):
@@ -101,7 +102,7 @@ def read(file_path: str, employee_id: str = "", offset: int = 0, limit: int = 0)
             lines = lines[start:end]
             content = "".join(lines)
 
-        _files_read_in_session.add(str(resolved))
+        _files_read_by_employee.setdefault(employee_id, set()).add(str(resolved))
         return {
             "status": "ok",
             "path": file_path,
@@ -196,7 +197,7 @@ async def write(
 
     # Safety: must read before overwriting existing files
     if is_update:
-        if str(resolved) not in _files_read_in_session:
+        if str(resolved) not in _files_read_by_employee.get(employee_id, set()):
             return {
                 "status": "error",
                 "message": f"You must read '{file_path}' before overwriting it. Use read() first.",
@@ -205,7 +206,7 @@ async def write(
 
     resolved.parent.mkdir(parents=True, exist_ok=True)
     resolved.write_text(content, encoding="utf-8")
-    _files_read_in_session.add(str(resolved))
+    _files_read_by_employee.setdefault(employee_id, set()).add(str(resolved))
 
     result: dict = {
         "status": "ok",
@@ -253,7 +254,7 @@ async def edit(
         return {"status": "error", "message": f"File not found: {file_path}"}
 
     # Safety: must read before editing
-    if str(resolved) not in _files_read_in_session:
+    if str(resolved) not in _files_read_by_employee.get(employee_id, set()):
         return {
             "status": "error",
             "message": f"You must read '{file_path}' before editing it. Use read() first.",

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -45,8 +45,29 @@ async def _chat(room_id: str, speaker: str, role: str, message: str) -> None:
     await append_room_chat(room_id, entry)
 
 
+# Track files read in current agent session — write/edit safety check
+_files_read_in_session: set[str] = set()
+
+
+def _resolve_employee_path(file_path: str, employee_id: str = ""):
+    """Resolve a file path using employee permissions. Returns Path or None."""
+    from pathlib import Path
+    from onemancompany.core.file_editor import _resolve_path
+
+    if file_path.startswith("workspace/") and employee_id:
+        return (get_workspace_dir(employee_id) / file_path[len("workspace/"):]).resolve()
+    if file_path and Path(file_path).is_absolute():
+        return Path(file_path).resolve()
+    permissions = []
+    if employee_id:
+        emp_data = load_employee(employee_id)
+        if emp_data:
+            permissions = emp_data.get("permissions", [])
+    return _resolve_path(file_path, permissions=permissions)
+
+
 @tool
-def read(file_path: str, employee_id: str = "") -> dict:
+def read(file_path: str, employee_id: str = "", offset: int = 0, limit: int = 0) -> dict:
     """Read the contents of a file.
 
     Accessible paths:
@@ -58,24 +79,10 @@ def read(file_path: str, employee_id: str = "") -> dict:
     Args:
         file_path: File path to read.
         employee_id: Your employee ID.
+        offset: Line number to start reading from (1-based). 0 = start of file.
+        limit: Max number of lines to read. 0 = read all.
     """
-    from onemancompany.core.file_editor import _resolve_path
-
-    from pathlib import Path
-
-    # Handle "workspace/..." shortcut → resolve to employee's workspace dir
-    if file_path.startswith("workspace/") and employee_id:
-        resolved = (get_workspace_dir(employee_id) / file_path[len("workspace/"):]).resolve()
-    # Handle absolute paths — read-only, safe to allow any path
-    elif file_path and Path(file_path).is_absolute():
-        resolved = Path(file_path).resolve()
-    else:
-        permissions = []
-        if employee_id:
-            emp_data = load_employee(employee_id)
-            if emp_data:
-                permissions = emp_data.get("permissions", [])
-        resolved = _resolve_path(file_path, permissions=permissions)
+    resolved = _resolve_employee_path(file_path, employee_id)
 
     if resolved is None:
         return {"status": "error", "message": f"Access denied or invalid path: {file_path}"}
@@ -85,7 +92,22 @@ def read(file_path: str, employee_id: str = "") -> dict:
         return {"status": "error", "message": f"Not a file: {file_path}"}
     try:
         content = resolved.read_text(encoding="utf-8")
-        return {"status": "ok", "path": file_path, "content": content}
+        lines = content.splitlines(keepends=True)
+        total_lines = len(lines)
+
+        if offset > 0 or limit > 0:
+            start = max(0, offset - 1) if offset > 0 else 0
+            end = start + limit if limit > 0 else total_lines
+            lines = lines[start:end]
+            content = "".join(lines)
+
+        _files_read_in_session.add(str(resolved))
+        return {
+            "status": "ok",
+            "path": file_path,
+            "content": content,
+            "total_lines": total_lines,
+        }
     except Exception as e:
         return {"status": "error", "message": f"Read failed: {e}"}
 
@@ -153,6 +175,9 @@ async def write(
 ) -> dict:
     """Write content to a file. Creates the file if it doesn't exist.
 
+    If the file already exists, you MUST read it first using the read() tool.
+    This prevents accidental overwrites. Prefer edit() for modifying existing files.
+
     Args:
         file_path: File path to write.
         content: The text content to write.
@@ -160,34 +185,40 @@ async def write(
         project_dir: Current project workspace path (auto-filled from task context).
     """
     from pathlib import Path
-    from onemancompany.core.file_editor import _resolve_path, is_in_free_zone
 
-    # Resolve path
-    if file_path.startswith("workspace/") and employee_id:
-        resolved = (get_workspace_dir(employee_id) / file_path[len("workspace/"):]).resolve()
-    elif Path(file_path).is_absolute():
-        resolved = Path(file_path).resolve()
-    else:
-        permissions = []
-        if employee_id:
-            emp_data = load_employee(employee_id)
-            if emp_data:
-                permissions = emp_data.get("permissions", [])
-        resolved = _resolve_path(file_path, permissions=permissions)
+    resolved = _resolve_employee_path(file_path, employee_id)
 
     if resolved is None:
         return {"status": "error", "message": f"Access denied or invalid path: {file_path}"}
 
-    # Check if in free zone → direct write
-    if is_in_free_zone(resolved, employee_id=employee_id, project_dir=project_dir):
-        resolved.parent.mkdir(parents=True, exist_ok=True)
-        resolved.write_text(content, encoding="utf-8")
-        return {"status": "ok", "path": str(resolved)}
+    is_update = resolved.exists()
+    original_content = ""
 
-    # Not in free zone → direct write (no approval needed)
+    # Safety: must read before overwriting existing files
+    if is_update:
+        if str(resolved) not in _files_read_in_session:
+            return {
+                "status": "error",
+                "message": f"You must read '{file_path}' before overwriting it. Use read() first.",
+            }
+        original_content = resolved.read_text(encoding="utf-8")
+
     resolved.parent.mkdir(parents=True, exist_ok=True)
     resolved.write_text(content, encoding="utf-8")
-    return {"status": "ok", "path": str(resolved)}
+    _files_read_in_session.add(str(resolved))
+
+    result: dict = {
+        "status": "ok",
+        "path": str(resolved),
+        "type": "update" if is_update else "create",
+    }
+    if is_update and original_content != content:
+        # Compute a simple line-level diff summary
+        old_lines = original_content.splitlines()
+        new_lines = content.splitlines()
+        result["lines_before"] = len(old_lines)
+        result["lines_after"] = len(new_lines)
+    return result
 
 
 
@@ -195,67 +226,93 @@ async def write(
 @tool
 async def edit(
     file_path: str,
-    new_content: str,
-    reason: str = "",
+    old_string: str,
+    new_string: str,
+    replace_all: bool = False,
     employee_id: str = "",
-    project_dir: str = "",
 ) -> dict:
-    """Edit (overwrite) an existing file.
+    """Perform exact string replacement in a file.
+
+    You MUST read the file first using read() before editing.
+    The old_string must match exactly (including whitespace/indentation).
+    If old_string appears multiple times, either provide more context to make
+    it unique, or set replace_all=True.
 
     Args:
         file_path: File path to edit.
-        new_content: The complete new file content.
-        reason: Explanation for the edit.
+        old_string: The exact text to find and replace.
+        new_string: The replacement text (must differ from old_string).
+        replace_all: If True, replace all occurrences. Default False.
         employee_id: Your employee ID.
-        project_dir: Current project workspace path (auto-filled from task context).
     """
-    from pathlib import Path
-    from onemancompany.core.file_editor import _resolve_path, is_in_free_zone
-
-    # Resolve path
-    if file_path.startswith("workspace/") and employee_id:
-        resolved = (get_workspace_dir(employee_id) / file_path[len("workspace/"):]).resolve()
-    elif Path(file_path).is_absolute():
-        resolved = Path(file_path).resolve()
-    else:
-        permissions = []
-        if employee_id:
-            emp_data = load_employee(employee_id)
-            if emp_data:
-                permissions = emp_data.get("permissions", [])
-        resolved = _resolve_path(file_path, permissions=permissions)
+    resolved = _resolve_employee_path(file_path, employee_id)
 
     if resolved is None:
         return {"status": "error", "message": f"Access denied or invalid path: {file_path}"}
+    if not resolved.exists():
+        return {"status": "error", "message": f"File not found: {file_path}"}
 
-    # Check if in free zone → direct write
-    if is_in_free_zone(resolved, employee_id=employee_id, project_dir=project_dir):
-        resolved.parent.mkdir(parents=True, exist_ok=True)
-        resolved.write_text(new_content, encoding="utf-8")
-        return {"status": "ok", "path": str(resolved)}
+    # Safety: must read before editing
+    if str(resolved) not in _files_read_in_session:
+        return {
+            "status": "error",
+            "message": f"You must read '{file_path}' before editing it. Use read() first.",
+        }
 
-    # Not in free zone → direct write (no approval needed)
-    resolved.parent.mkdir(parents=True, exist_ok=True)
+    if old_string == new_string:
+        return {"status": "error", "message": "old_string and new_string are identical."}
+
+    content = resolved.read_text(encoding="utf-8")
+    count = content.count(old_string)
+
+    if count == 0:
+        return {"status": "error", "message": "old_string not found in the file."}
+    if count > 1 and not replace_all:
+        return {
+            "status": "error",
+            "message": f"old_string appears {count} times. Provide more context to make "
+                       f"it unique, or set replace_all=True.",
+        }
+
+    if replace_all:
+        new_content = content.replace(old_string, new_string)
+        replacements = count
+    else:
+        new_content = content.replace(old_string, new_string, 1)
+        replacements = 1
+
     resolved.write_text(new_content, encoding="utf-8")
-    return {"status": "ok", "path": str(resolved)}
+    return {
+        "status": "ok",
+        "path": str(resolved),
+        "replacements": replacements,
+    }
 
 
 @tool
-async def bash(command: str, employee_id: str = "", timeout_seconds: int = 30) -> dict:
+async def bash(
+    command: str,
+    employee_id: str = "",
+    timeout_seconds: int = 120,
+    description: str = "",
+) -> dict:
     """Execute a shell command and return stdout/stderr.
 
     Use for running scripts, checking system state, or executing build commands.
     Commands run in the project root directory.
+    Prefer dedicated tools (read, ls, edit, grep, glob) over shell equivalents
+    (cat, find, sed, awk) when possible.
 
     Args:
         command: The shell command to execute.
         employee_id: Your employee ID.
-        timeout_seconds: Max execution time in seconds (default 30, max 120).
+        timeout_seconds: Max execution time in seconds (default 120, max 600).
+        description: Brief human-readable description of what the command does.
     """
     import subprocess
     from onemancompany.core.config import SOURCE_ROOT
 
-    timeout_seconds = min(timeout_seconds, 120)
+    timeout_seconds = min(timeout_seconds, 600)
 
     try:
         proc = await asyncio.get_event_loop().run_in_executor(
@@ -279,6 +336,134 @@ async def bash(command: str, employee_id: str = "", timeout_seconds: int = 30) -
         return {"status": "error", "message": f"Command timed out after {timeout_seconds}s"}
     except Exception as e:
         return {"status": "error", "message": f"Execution failed: {e}"}
+
+
+@tool
+def glob_files(pattern: str, path: str = "", employee_id: str = "") -> dict:
+    """Fast file search by glob pattern. Returns matching file paths sorted by modification time.
+
+    Supports patterns like "**/*.py", "src/**/*.yaml", "*.md".
+
+    Args:
+        pattern: Glob pattern to match files against (e.g. "**/*.py").
+        path: Directory to search in. Defaults to company root if empty.
+        employee_id: Your employee ID.
+    """
+    from pathlib import Path
+
+    if path:
+        resolved = _resolve_employee_path(path, employee_id)
+    else:
+        from onemancompany.core.config import COMPANY_DIR
+        resolved = COMPANY_DIR
+
+    if resolved is None or not resolved.is_dir():
+        return {"status": "error", "message": f"Directory not found: {path}"}
+
+    try:
+        matches = sorted(resolved.glob(pattern), key=lambda p: p.stat().st_mtime, reverse=True)
+        MAX_RESULTS = 100
+        truncated = len(matches) > MAX_RESULTS
+        filenames = [str(m) for m in matches[:MAX_RESULTS]]
+        return {
+            "status": "ok",
+            "num_files": len(matches),
+            "filenames": filenames,
+            "truncated": truncated,
+        }
+    except Exception as e:
+        return {"status": "error", "message": f"Glob failed: {e}"}
+
+
+@tool
+def grep_search(
+    pattern: str,
+    path: str = "",
+    glob: str = "",
+    case_insensitive: bool = False,
+    context_lines: int = 0,
+    output_mode: str = "files_with_matches",
+    max_results: int = 50,
+    employee_id: str = "",
+) -> dict:
+    """Search file contents using regex patterns.
+
+    Args:
+        pattern: Regex pattern to search for (Python re syntax).
+        path: File or directory to search in. Defaults to company root.
+        glob: Glob pattern to filter files (e.g. "*.py", "*.yaml").
+        case_insensitive: Case insensitive search. Default False.
+        context_lines: Number of lines to show before and after each match.
+        output_mode: "files_with_matches" (file paths only), "content" (matching lines), "count" (match counts).
+        max_results: Max number of results to return. Default 50.
+        employee_id: Your employee ID.
+    """
+    from pathlib import Path
+
+    if path:
+        resolved = _resolve_employee_path(path, employee_id)
+    else:
+        from onemancompany.core.config import COMPANY_DIR
+        resolved = COMPANY_DIR
+
+    if resolved is None:
+        return {"status": "error", "message": f"Access denied or invalid path: {path}"}
+    if not resolved.exists():
+        return {"status": "error", "message": f"Path not found: {path}"}
+
+    flags = re.IGNORECASE if case_insensitive else 0
+    try:
+        compiled = re.compile(pattern, flags)
+    except re.error as e:
+        return {"status": "error", "message": f"Invalid regex: {e}"}
+
+    # Collect files to search
+    if resolved.is_file():
+        files = [resolved]
+    else:
+        file_glob = glob or "**/*"
+        files = [f for f in sorted(resolved.glob(file_glob)) if f.is_file()]
+
+    results: list = []
+    match_files: list[str] = []
+    count_map: dict[str, int] = {}
+
+    for fpath in files:
+        try:
+            text = fpath.read_text(encoding="utf-8", errors="replace")
+        except Exception as e:
+            logger.debug("grep_search: skipping unreadable file {}: {}", fpath, e)
+            continue
+
+        lines = text.splitlines()
+        file_matches: list[dict] = []
+
+        for i, line in enumerate(lines):
+            if compiled.search(line):
+                if output_mode == "content":
+                    start = max(0, i - context_lines)
+                    end = min(len(lines), i + context_lines + 1)
+                    ctx = [{"line": start + j + 1, "text": lines[start + j]} for j in range(end - start)]
+                    file_matches.append({"match_line": i + 1, "context": ctx})
+                else:
+                    file_matches.append({"line": i + 1})
+
+        if file_matches:
+            fpath_str = str(fpath)
+            match_files.append(fpath_str)
+            count_map[fpath_str] = len(file_matches)
+            if output_mode == "content":
+                results.append({"file": fpath_str, "matches": file_matches})
+
+        if len(match_files) >= max_results:
+            break
+
+    if output_mode == "files_with_matches":
+        return {"status": "ok", "num_files": len(match_files), "filenames": match_files}
+    elif output_mode == "count":
+        return {"status": "ok", "num_files": len(match_files), "counts": count_map}
+    else:
+        return {"status": "ok", "num_files": len(match_files), "results": results}
 
 
 @tool
@@ -1090,6 +1275,7 @@ def _register_all_internal_tools() -> None:
 
     _base = [
         list_colleagues, read, ls, write, edit, pull_meeting,
+        glob_files, grep_search,
         load_skill,
         resume_held_task, update_project_team,
         read_node_detail,

--- a/src/onemancompany/agents/coo_agent.py
+++ b/src/onemancompany/agents/coo_agent.py
@@ -17,7 +17,7 @@ from langchain_core.tools import tool
 from langgraph.prebuilt import create_react_agent
 
 from onemancompany.agents.base import BaseAgentRunner, extract_final_content, make_llm
-from onemancompany.core.config import COO_ID, MAX_SUMMARY_LEN, OrgDir, PROJECTS_DIR, ROOMS_DIR, STATUS_IDLE, STATUS_WORKING, TOOLS_DIR, WORKFLOWS_DIR, load_assets, save_company_direction, save_workflow, slugify_tool_name
+from onemancompany.core.config import COO_ID, HR_ID, MAX_SUMMARY_LEN, OrgDir, PROJECTS_DIR, ROOMS_DIR, STATUS_IDLE, STATUS_WORKING, TOOLS_DIR, WORKFLOWS_DIR, load_assets, save_company_direction, save_workflow, slugify_tool_name
 from onemancompany.core.events import CompanyEvent, event_bus
 from onemancompany.core.state import MeetingRoom, OfficeTool, company_state
 from onemancompany.core.store import append_activity_sync as _append_activity
@@ -26,7 +26,7 @@ from onemancompany.core.store import append_activity_sync as _append_activity
 # { hire_id: { role, reason, skills, requested_by, requested_at, ... } }
 pending_hiring_requests: dict[str, dict] = {}
 
-COO_SYSTEM_PROMPT = """You are the COO (Chief Operating Officer) of "One Man Company".
+COO_SYSTEM_PROMPT = f"""You are the COO (Chief Operating Officer) of "One Man Company".
 
 ## Who You Are — Identity (Most Important, Must Internalize)
 You are a manager, not an executor. Your job is:
@@ -53,7 +53,7 @@ You are a manager, not an executor. Your job is:
 1. Is this implementation work (code, design, writing, testing)? → dispatch_child(best_employee, ...)
 2. Can an existing employee handle it? → list_colleagues(), then dispatch.
 3. No suitable employee? → request_hiring(role, reason) to request new hires
-4. Is this a people/HR task? → dispatch_child("00002", ...)
+4. Is this a people/HR task? → dispatch_child("{HR_ID}", ...)
 5. Only coordination/planning left? → Handle it yourself (no deliverable output, only plans and dispatches).
 
 ## Project Execution Flow (Complex projects must follow; simple tasks may skip phases 2-3)
@@ -71,7 +71,7 @@ You are a manager, not an executor. Your job is:
 - If no hiring is needed, skip directly to Phase 3
 
 ### Phase 3 — Assemble Team & Align
-- update_project_team(members=[{employee_id, role}]) to register team members
+- update_project_team(members=[{{employee_id, role}}]) to register team members
 - pull_meeting(attendees=all team members) to discuss:
   - Project goals and scope
   - Acceptance criteria
@@ -91,7 +91,7 @@ You are a manager, not an executor. Your job is:
 
 ### Task Execution via Delegation
 When receiving CEO action plans:
-- HR-sourced actions → dispatch_child("00002", ...) immediately.
+- HR-sourced actions → dispatch_child("{HR_ID}", ...) immediately.
 - COO-sourced actions → find the best employee and dispatch.
 - Report a brief summary of all dispatches.
 
@@ -133,7 +133,7 @@ When receiving CEO action plans:
 
 ### Knowledge Management
 - deposit_company_knowledge(category, name, content) to preserve company knowledge:
-  - "workflow": All operational docs — business processes, SOPs, and employee guidance → saved as {name}.md under workflows directory
+  - "workflow": All operational docs — business processes, SOPs, and employee guidance → saved as {{name}}.md under workflows directory
   - "culture": Company values and culture statements → saved to company_culture.yaml
   - "direction": Company strategic direction → saved to company_direction.yaml
 - Use this for operational insights, process improvements, and lessons learned.

--- a/src/onemancompany/agents/cso_agent.py
+++ b/src/onemancompany/agents/cso_agent.py
@@ -11,17 +11,17 @@ from langchain_core.tools import tool
 from langgraph.prebuilt import create_react_agent
 
 from onemancompany.agents.base import BaseAgentRunner, extract_final_content, make_llm
-from onemancompany.core.config import COO_ID, CSO_ID, MAX_SUMMARY_LEN, STATUS_IDLE, STATUS_WORKING
+from onemancompany.core.config import COO_ID, CSO_ID, HR_ID, MAX_SUMMARY_LEN, STATUS_IDLE, STATUS_WORKING
 from onemancompany.core.store import append_activity_sync as _append_activity
 from onemancompany.core import store as _store
 
-CSO_SYSTEM_PROMPT = """You are the CSO (Chief Sales Officer) of "One Man Company".
+CSO_SYSTEM_PROMPT = f"""You are the CSO (Chief Sales Officer) of "One Man Company".
 You manage the sales pipeline, client relationships, and external task delivery.
 
 ## CORE PRINCIPLE — Delegate, Don't Execute
 Your job is to SELL, REVIEW, COORDINATE — NOT to implement.
 - dispatch_child() implementation work to employees.
-- No suitable employee? → dispatch_child("00002", "Hire a [role]...") via HR.
+- No suitable employee? → dispatch_child("{HR_ID}", "Hire a [role]...") via HR.
 - Only do work yourself as an absolute LAST RESORT.
 
 ## Sales Pipeline (follow this lifecycle)

--- a/src/onemancompany/agents/ea_agent.py
+++ b/src/onemancompany/agents/ea_agent.py
@@ -10,9 +10,9 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langgraph.prebuilt import create_react_agent
 
 from onemancompany.agents.base import BaseAgentRunner, extract_final_content, make_llm
-from onemancompany.core.config import EA_ID, MAX_SUMMARY_LEN, STATUS_IDLE, STATUS_WORKING
+from onemancompany.core.config import CEO_ID, COO_ID, CSO_ID, EA_ID, HR_ID, MAX_SUMMARY_LEN, STATUS_IDLE, STATUS_WORKING
 
-EA_SYSTEM_PROMPT = """You are the Executive Assistant (EA) of a startup called "One Man Company".
+EA_SYSTEM_PROMPT = f"""You are the Executive Assistant (EA) of a startup called "One Man Company".
 ALL CEO tasks come to you first. You are the ROOT node of the task tree.
 
 ## Your Role
@@ -21,7 +21,7 @@ review results when they complete, and decide whether to report to CEO or comple
 
 ## Autonomous Authority
 You have full authority to dispatch and complete **simple tasks** without CEO approval.
-Only escalate to CEO (via dispatch_child("00001", ...)) when you judge there is risk:
+Only escalate to CEO (via dispatch_child("{CEO_ID}", ...)) when you judge there is risk:
 
 **Dispatch and complete autonomously (NO CEO approval needed):**
 - Routine operations: sending emails, querying information, scheduling, data lookups
@@ -29,7 +29,7 @@ Only escalate to CEO (via dispatch_child("00001", ...)) when you judge there is 
 - Tasks where CEO intent is unambiguous and stakes are low
 - Status updates and progress reports — just complete the task with a summary.
 
-**Escalate to CEO (dispatch_child("00001", description)) ONLY when:**
+**Escalate to CEO (dispatch_child("{CEO_ID}", description)) ONLY when:**
 - Financial decisions: budgets, purchases, contracts, pricing
 - Personnel decisions: hiring, firing, promotions, salary changes
 - External-facing actions: public announcements, client communications with commitment
@@ -47,18 +47,18 @@ a low-stakes task slightly wrong.
    - Each child MUST have measurable acceptance_criteria.
    - For multi-domain tasks, dispatch multiple children (they run in parallel).
    - For sequential work, dispatch the first step; after accepting it, dispatch the next.
-   - **You may ONLY dispatch to O-level executives: HR(00002), COO(00003), CSO(00005), or CEO(00001).**
+   - **You may ONLY dispatch to O-level executives: HR({HR_ID}), COO({COO_ID}), CSO({CSO_ID}), or CEO({CEO_ID}).**
 3. **Wait for results** — the system will wake you when all children complete.
 4. **Review results** — for each child, call accept_child(node_id, notes) or reject_child(node_id, reason, retry).
    - reject with retry=True: same employee gets a correction task.
    - reject with retry=False: mark as failed.
 5. **Iterate** — after accepting results, proactively dispatch the NEXT phase:
    - After acceptance, if there is follow-up work (e.g., development, design, testing), **you MUST immediately dispatch_child to the corresponding O-level**.
-   - Example: requirements analysis accepted → dispatch_child("00003", "Organize team for development...") to COO.
+   - Example: requirements analysis accepted → dispatch_child("{COO_ID}", "Organize team for development...") to COO.
    - **NEVER mark a task as complete when there is still follow-up work remaining.**
 6. **Complete** — ONLY when ALL phases of work are done and accepted:
    - Simple/low-risk tasks → complete the task with a summary. No CEO escalation needed.
-   - Risky/ambiguous tasks → call dispatch_child("00001", description) to escalate to CEO and wait for decision.
+   - Risky/ambiguous tasks → call dispatch_child("{CEO_ID}", description) to escalate to CEO and wait for decision.
 
 ## Task Completion
 All tasks go through review. After you complete your work or after all dispatched children

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from langchain_core.tools import tool
 from loguru import logger
 
+from onemancompany.core.config import CEO_ID
 from onemancompany.core.task_lifecycle import NodeType, TaskPhase
 from onemancompany.core.task_tree import TaskTree
 
@@ -97,7 +98,7 @@ def _create_standalone_ceo_request(
     return {
         "status": "dispatched",
         "node_id": node_id,
-        "employee_id": "00001",
+        "employee_id": CEO_ID,
         "description": description,
         "node_type": NodeType.CEO_REQUEST,
         "ceo_request": True,
@@ -145,8 +146,7 @@ def dispatch_child(
 
     if not project_dir or not tree_path_str:
         # --- Standalone CEO request (no tree context, e.g. system/adhoc tasks) ---
-        CEO_EMPLOYEE_ID = "00001"
-        if employee_id == CEO_EMPLOYEE_ID:
+        if employee_id == CEO_ID:
             return _create_standalone_ceo_request(
                 description=description,
                 requester_task_id=task_id,
@@ -220,8 +220,7 @@ def dispatch_child(
                 }
 
         # --- CEO request interception (idempotency check BEFORE creating child) ---
-        CEO_EMPLOYEE_ID = "00001"
-        if employee_id == CEO_EMPLOYEE_ID:
+        if employee_id == CEO_ID:
             from onemancompany.core.task_lifecycle import TaskPhase as _TP
             existing = [
                 c for c in tree.get_children(task_id)
@@ -256,7 +255,7 @@ def dispatch_child(
         child.project_id = current_node.project_id
         child.project_dir = project_dir
 
-        if employee_id == CEO_EMPLOYEE_ID:
+        if employee_id == CEO_ID:
             child.node_type = NodeType.CEO_REQUEST
             # Signal vessel to auto-HOLD parent after execution (no_watchdog:
             # routes.py handles resume when CEO responds)

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -834,7 +834,7 @@ async def _handle_ea_approval(step: WorkflowStep, ctx: StepContext) -> dict:
 
         coo_task = (
             "EA has approved the following action plan. Please assign execution based on the source field:\n"
-            "- source=HR actions: Use dispatch_child() to assign to HR (employee_id='00002')\n"
+            f"- source=HR actions: Use dispatch_child() to assign to HR (employee_id='{HR_ID}')\n"
             "- source=COO actions: Execute yourself\n\n"
             "Action plan:\n" + "\n".join(action_lines)
         )
@@ -1417,7 +1417,7 @@ async def _ea_auto_approve_actions(
             action_lines = [f"- [{a.get('source', 'COO')}] {a['description']}" for a in remaining]
             coo_task = (
                 "EA has approved the following action plan. Please assign execution based on the source field:\n"
-                "- source=HR actions: Use dispatch_child() to assign to HR (employee_id='00002')\n"
+                f"- source=HR actions: Use dispatch_child() to assign to HR (employee_id='{HR_ID}')\n"
                 "- source=COO actions: Execute yourself\n\n"
                 "Action plan:\n" + "\n".join(action_lines)
             )
@@ -1935,7 +1935,7 @@ async def execute_approved_actions(report_id: str, approved_indices: list[int]) 
 
     coo_task = (
         "CEO has approved the following action plan. Please assign execution based on the source field:\n"
-        "- source=HR actions: Use dispatch_child() to assign to HR (employee_id='00002')\n"
+        f"- source=HR actions: Use dispatch_child() to assign to HR (employee_id='{HR_ID}')\n"
         "- source=COO actions: Execute yourself\n\n"
         "Action plan:\n" + "\n".join(action_lines)
     )

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -572,7 +572,8 @@ def _assign_default_avatars(console: Console) -> None:
         return
 
     employees_dir = DATA_ROOT / "company" / "human_resource" / "employees"
-    exec_ids = ["00001", "00002", "00003", "00004", "00005"]
+    from onemancompany.core.config import FOUNDING_IDS
+    exec_ids = sorted(FOUNDING_IDS)
     pool = list(avatars)
     random.shuffle(pool)
 
@@ -601,7 +602,8 @@ def _generate_mcp_configs(skillsmp_key: str) -> None:
     employees_dir = DATA_ROOT / "company" / "human_resource" / "employees"
     tools_dir = DATA_ROOT / "company" / "assets" / "tools"
     python_path = sys.executable
-    exec_ids = ["00002", "00003", "00004", "00005"]
+    from onemancompany.core.config import EXEC_IDS
+    exec_ids = sorted(EXEC_IDS)
 
     for emp_id in exec_ids:
         emp_dir = employees_dir / emp_id


### PR DESCRIPTION
## Summary
- Add `glob_files` and `grep_search` tools — agents can now search files by pattern and content without falling back to `bash`
- Rewrite `edit` tool as exact string replacement (`old_string → new_string`) instead of full file overwrite
- Add `offset`/`limit` params to `read` for large file pagination
- Add safety check to `write` — must `read()` first before overwriting existing files
- Increase `bash` max timeout to 600s, add `description` param
- Per-employee file read tracking (was global, caused cross-agent leakage)
- Replace all hardcoded founding employee IDs ("00001"-"00005") with config constants

## Changes
- `common_tools.py`: New tools (glob_files, grep_search), rewritten edit, enhanced read/write/bash
- `tool_usage.md`: Updated shared prompt documenting new tools
- `ea_agent.py`, `coo_agent.py`, `cso_agent.py`: Prompts use ID constants via f-strings
- `tree_tools.py`, `onboard.py`, `routine.py`: Hardcoded IDs → constants

## Test plan
- [x] 1950 tests pass
- [x] No hardcoded employee IDs remain in src/ (only definitions in config.py)
- [x] Tool compilation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)