### PR TITLE
docs: add citation section to homepage

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -762,6 +762,27 @@
   </div>
 </section>
 
+<div class="divider"></div>
+
+<!-- ── Citation ─────────────────────────────────────────────── -->
+<section aria-labelledby="citation-title">
+  <div class="container">
+    <div class="section-label">Citation</div>
+    <h2 id="citation-title" class="section-title">Cite This Project</h2>
+    <p class="section-desc">If you use OneManCompany in your research or project, please cite it:</p>
+    <div class="quickstart-box" style="text-align: left;">
+      <code style="white-space: pre; font-size: 10px; text-align: left;">@software{onemancompany2026,
+  title = {OneManCompany: The AI Operating System for One-Person Companies},
+  author = {Zhengxu Yu, Fu Yu, Zhiyuan He, Yuxuan Huang, Lee Ka Yiu, Meng Fang, Weilin Luo, Jun Wang},
+  email = {yuzxfred@gmail.com},
+  url = {https://github.com/1mancompany/OneManCompany},
+  year = {2026},
+  license = {Apache-2.0}
+}</code>
+    </div>
+  </div>
+</section>
+
 </main>
 
 <!-- ── Footer ──────────────────────────────────────────────── -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.426",
+  "version": "0.2.427",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.426"
+version = "0.2.427"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Add Citation / bibtex section to the GitHub Pages homepage (docs/index.html)
- Matches existing README.md citation block with all authors

## Test plan
- [ ] Verify https://1mancompany.github.io/OneManCompany/ renders the citation section correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)