### PR TITLE
fix: citation block wraps on narrow screens

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -771,7 +771,7 @@
     <h2 id="citation-title" class="section-title">Cite This Project</h2>
     <p class="section-desc">If you use OneManCompany in your research or project, please cite it:</p>
     <div class="quickstart-box" style="text-align: left;">
-      <code style="white-space: pre; font-size: 10px; text-align: left;">@software{onemancompany2026,
+      <code style="white-space: pre-wrap; word-break: break-all; font-size: 10px; text-align: left;">@software{onemancompany2026,
   title = {OneManCompany: The AI Operating System for One-Person Companies},
   author = {Zhengxu Yu, Fu Yu, Zhiyuan He, Yuxuan Huang, Lee Ka Yiu, Meng Fang, Weilin Luo, Jun Wang},
   email = {yuzxfred@gmail.com},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.427",
+  "version": "0.2.428",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.427"
+version = "0.2.428"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Change `white-space: pre` to `pre-wrap` + `word-break: break-all` on citation code block
- Prevents horizontal overflow on mobile / narrow viewports

## Test plan
- [ ] Verify citation block wraps correctly on mobile-width browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)