### PR TITLE
feat: add web search tool using Claude's built-in web search

### DIFF
--- a/company/assets/tools/web_search/tool.yaml
+++ b/company/assets/tools/web_search/tool.yaml
@@ -1,0 +1,12 @@
+id: web_search
+name: Web Search
+description: >
+  Search the web for real-time information using Claude's built-in web search.
+  USE THIS whenever a task requires current information, market research, competitor
+  analysis, technical documentation lookup, news, pricing data, or any knowledge
+  that may be newer than your training data. Call web_search(query) or
+  web_search(query, max_results=10) for more results.
+  Automatically uses the ANTHROPIC_API_KEY from your company .env file.
+added_by: CEO
+type: langchain_module
+sprite: desk_equipment

--- a/company/assets/tools/web_search/web_search.py
+++ b/company/assets/tools/web_search/web_search.py
@@ -39,10 +39,20 @@ _API_URL = "https://api.anthropic.com/v1/messages"
 _MODEL = "claude-sonnet-4-20250514"
 _API_VERSION = "2025-01-01"
 _USER_AGENT = "OneManCompany-WebSearch/1.0"
+_TOOL_TYPE = "web_search_20250305"
+
+# Claude API response block types
 _BLOCK_TYPE_SEARCH_RESULT = "web_search_tool_result"
 _BLOCK_TYPE_RESULT_ITEM = "web_search_result"
 _BLOCK_TYPE_TEXT = "text"
-_TOOL_TYPE = "web_search_20250305"
+
+# Response field keys
+_FIELD_CONTENT = "content"
+_FIELD_TYPE = "type"
+_FIELD_TEXT = "text"
+_FIELD_TITLE = "title"
+_FIELD_URL = "url"
+_FIELD_PAGE_SNIPPET = "page_snippet"
 
 
 def _post_json(url: str, headers: dict, payload: dict, timeout: int = 30) -> tuple[dict | None, str | None]:
@@ -69,14 +79,14 @@ def _post_json(url: str, headers: dict, payload: dict, timeout: int = 30) -> tup
 def _extract_search_results(response: dict) -> list[dict]:
     """Extract web search results from Claude API response content blocks."""
     results = []
-    for block in response.get("content", []):
-        if block.get("type") == _BLOCK_TYPE_SEARCH_RESULT:
-            for item in block.get("content", []):
-                if item.get("type") == _BLOCK_TYPE_RESULT_ITEM:
+    for block in response.get(_FIELD_CONTENT, []):
+        if block.get(_FIELD_TYPE) == _BLOCK_TYPE_SEARCH_RESULT:
+            for item in block.get(_FIELD_CONTENT, []):
+                if item.get(_FIELD_TYPE) == _BLOCK_TYPE_RESULT_ITEM:
                     results.append({
-                        "title": item.get("title", ""),
-                        "url": item.get("url", ""),
-                        "snippet": item.get("page_snippet", ""),
+                        _FIELD_TITLE: item.get(_FIELD_TITLE, ""),
+                        _FIELD_URL: item.get(_FIELD_URL, ""),
+                        _FIELD_PAGE_SNIPPET: item.get(_FIELD_PAGE_SNIPPET, ""),
                     })
     return results
 
@@ -84,9 +94,9 @@ def _extract_search_results(response: dict) -> list[dict]:
 def _extract_text_answer(response: dict) -> str:
     """Extract the text summary from Claude's response."""
     parts = []
-    for block in response.get("content", []):
-        if block.get("type") == _BLOCK_TYPE_TEXT:
-            parts.append(block.get("text", ""))
+    for block in response.get(_FIELD_CONTENT, []):
+        if block.get(_FIELD_TYPE) == _BLOCK_TYPE_TEXT:
+            parts.append(block.get(_FIELD_TEXT, ""))
     return "\n".join(parts).strip()
 
 

--- a/company/assets/tools/web_search/web_search.py
+++ b/company/assets/tools/web_search/web_search.py
@@ -12,6 +12,8 @@ import urllib.error
 import urllib.request
 
 from langchain_core.tools import tool
+from loguru import logger
+
 
 def _load_key_from_dotenv() -> str:
     """Try to load ANTHROPIC_API_KEY from the company .env file."""
@@ -27,8 +29,8 @@ def _load_key_from_dotenv() -> str:
             key, _, val = line.partition("=")
             if key.strip() == "ANTHROPIC_API_KEY":
                 return val.strip().strip("\"'")
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.debug("[web_search] failed to load API key from .env: {}", exc)
     return ""
 
 
@@ -69,7 +71,7 @@ def _extract_search_results(response: dict) -> list[dict]:
                     results.append({
                         "title": item.get("title", ""),
                         "url": item.get("url", ""),
-                        "snippet": item.get("encrypted_content", item.get("page_snippet", "")),
+                        "snippet": item.get("page_snippet", ""),
                     })
     return results
 
@@ -133,9 +135,8 @@ def web_search(query: str, max_results: int = 5) -> dict:
     }
 
     resp_json, err = _post_json(_API_URL, headers, payload, timeout=60)
-    if err:
-        return {"status": "error", "message": err}
-    assert resp_json is not None
+    if err or resp_json is None:
+        return {"status": "error", "message": err or "empty response from API"}
 
     answer = _extract_text_answer(resp_json)
     sources = _extract_search_results(resp_json)

--- a/company/assets/tools/web_search/web_search.py
+++ b/company/assets/tools/web_search/web_search.py
@@ -27,17 +27,22 @@ def _load_key_from_dotenv() -> str:
             if line.startswith("#") or "=" not in line:
                 continue
             key, _, val = line.partition("=")
-            if key.strip() == "ANTHROPIC_API_KEY":
+            if key.strip() == _ENV_KEY_NAME:
                 return val.strip().strip("\"'")
     except Exception as exc:
         logger.debug("[web_search] failed to load API key from .env: {}", exc)
     return ""
 
 
+_ENV_KEY_NAME = "ANTHROPIC_API_KEY"
 _API_URL = "https://api.anthropic.com/v1/messages"
 _MODEL = "claude-sonnet-4-20250514"
 _API_VERSION = "2025-01-01"
 _USER_AGENT = "OneManCompany-WebSearch/1.0"
+_BLOCK_TYPE_SEARCH_RESULT = "web_search_tool_result"
+_BLOCK_TYPE_RESULT_ITEM = "web_search_result"
+_BLOCK_TYPE_TEXT = "text"
+_TOOL_TYPE = "web_search_20250305"
 
 
 def _post_json(url: str, headers: dict, payload: dict, timeout: int = 30) -> tuple[dict | None, str | None]:
@@ -65,9 +70,9 @@ def _extract_search_results(response: dict) -> list[dict]:
     """Extract web search results from Claude API response content blocks."""
     results = []
     for block in response.get("content", []):
-        if block.get("type") == "web_search_tool_result":
+        if block.get("type") == _BLOCK_TYPE_SEARCH_RESULT:
             for item in block.get("content", []):
-                if item.get("type") == "web_search_result":
+                if item.get("type") == _BLOCK_TYPE_RESULT_ITEM:
                     results.append({
                         "title": item.get("title", ""),
                         "url": item.get("url", ""),
@@ -80,7 +85,7 @@ def _extract_text_answer(response: dict) -> str:
     """Extract the text summary from Claude's response."""
     parts = []
     for block in response.get("content", []):
-        if block.get("type") == "text":
+        if block.get("type") == _BLOCK_TYPE_TEXT:
             parts.append(block.get("text", ""))
     return "\n".join(parts).strip()
 
@@ -100,12 +105,12 @@ def web_search(query: str, max_results: int = 5) -> dict:
     if not query:
         return {"status": "error", "message": "query is empty"}
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    api_key = os.environ.get(_ENV_KEY_NAME, "").strip()
     if not api_key:
         # Fallback: read from company .env file
         api_key = _load_key_from_dotenv()
     if not api_key:
-        return {"status": "error", "message": "ANTHROPIC_API_KEY not configured in .env"}
+        return {"status": "error", "message": f"{_ENV_KEY_NAME} not configured in .env"}
 
     max_results = max(1, min(int(max_results), 20))
 
@@ -121,7 +126,7 @@ def web_search(query: str, max_results: int = 5) -> dict:
         "max_tokens": 4096,
         "tools": [
             {
-                "type": "web_search_20250305",
+                "type": _TOOL_TYPE,
                 "name": "web_search",
                 "max_uses": max_results,
             }

--- a/company/assets/tools/web_search/web_search.py
+++ b/company/assets/tools/web_search/web_search.py
@@ -1,0 +1,149 @@
+"""Web search tool via Anthropic Claude API with built-in web search.
+
+Provides one LangChain @tool:
+- web_search(query, max_results=5)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+from langchain_core.tools import tool
+
+def _load_key_from_dotenv() -> str:
+    """Try to load ANTHROPIC_API_KEY from the company .env file."""
+    try:
+        from onemancompany.core.config import DATA_ROOT, DOT_ENV_FILENAME
+        env_path = DATA_ROOT / DOT_ENV_FILENAME
+        if not env_path.exists():
+            return ""
+        for line in env_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line.startswith("#") or "=" not in line:
+                continue
+            key, _, val = line.partition("=")
+            if key.strip() == "ANTHROPIC_API_KEY":
+                return val.strip().strip("\"'")
+    except Exception:
+        pass
+    return ""
+
+
+_API_URL = "https://api.anthropic.com/v1/messages"
+_MODEL = "claude-sonnet-4-20250514"
+_API_VERSION = "2025-01-01"
+_USER_AGENT = "OneManCompany-WebSearch/1.0"
+
+
+def _post_json(url: str, headers: dict, payload: dict, timeout: int = 30) -> tuple[dict | None, str | None]:
+    """POST JSON and return (json_body, error)."""
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", errors="replace")
+        return json.loads(raw), None
+    except urllib.error.HTTPError as e:
+        body_text = e.read().decode("utf-8", errors="replace") if e.fp else ""
+        return None, f"HTTP {e.code}: {body_text[:800]}"
+    except json.JSONDecodeError as e:
+        return None, f"Invalid JSON response: {e}"
+    except Exception as e:
+        return None, str(e)
+
+
+def _extract_search_results(response: dict) -> list[dict]:
+    """Extract web search results from Claude API response content blocks."""
+    results = []
+    for block in response.get("content", []):
+        if block.get("type") == "web_search_tool_result":
+            for item in block.get("content", []):
+                if item.get("type") == "web_search_result":
+                    results.append({
+                        "title": item.get("title", ""),
+                        "url": item.get("url", ""),
+                        "snippet": item.get("encrypted_content", item.get("page_snippet", "")),
+                    })
+    return results
+
+
+def _extract_text_answer(response: dict) -> str:
+    """Extract the text summary from Claude's response."""
+    parts = []
+    for block in response.get("content", []):
+        if block.get("type") == "text":
+            parts.append(block.get("text", ""))
+    return "\n".join(parts).strip()
+
+
+@tool
+def web_search(query: str, max_results: int = 5) -> dict:
+    """Search the web for real-time information. USE THIS for any task needing current data.
+
+    Suitable for: market research, competitor analysis, tech docs, news, pricing,
+    regulations, trends, or any knowledge that may have changed after training.
+
+    Args:
+        query: Search query describing what information you need.
+        max_results: Maximum number of search results to return (default 5, max 20).
+    """
+    query = (query or "").strip()
+    if not query:
+        return {"status": "error", "message": "query is empty"}
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if not api_key:
+        # Fallback: read from company .env file
+        api_key = _load_key_from_dotenv()
+    if not api_key:
+        return {"status": "error", "message": "ANTHROPIC_API_KEY not configured in .env"}
+
+    max_results = max(1, min(int(max_results), 20))
+
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": _API_VERSION,
+        "content-type": "application/json",
+        "User-Agent": _USER_AGENT,
+    }
+
+    payload = {
+        "model": _MODEL,
+        "max_tokens": 4096,
+        "tools": [
+            {
+                "type": "web_search_20250305",
+                "name": "web_search",
+                "max_uses": max_results,
+            }
+        ],
+        "messages": [
+            {
+                "role": "user",
+                "content": f"Search the web and provide a comprehensive answer: {query}",
+            }
+        ],
+    }
+
+    resp_json, err = _post_json(_API_URL, headers, payload, timeout=60)
+    if err:
+        return {"status": "error", "message": err}
+    assert resp_json is not None
+
+    answer = _extract_text_answer(resp_json)
+    sources = _extract_search_results(resp_json)
+
+    return {
+        "status": "ok",
+        "query": query,
+        "answer": answer,
+        "sources": sources[:max_results],
+        "source_count": len(sources),
+    }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.444",
+  "version": "0.2.445",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.446",
+  "version": "0.2.447",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.445",
+  "version": "0.2.446",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.443",
+  "version": "0.2.444",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.444"
+version = "0.2.445"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.445"
+version = "0.2.446"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.446"
+version = "0.2.447"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.443"
+version = "0.2.444"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Add shared web search tool to `company/assets/tools/web_search/`
- Uses Claude API's built-in `web_search_20250305` tool type for real-time web searches
- Auto-reuses `ANTHROPIC_API_KEY` from company `.env` file — no extra configuration needed

## Test plan
- [ ] Verify tool is auto-discovered by `tool_registry.load_asset_tools()`
- [ ] Test `web_search("test query")` returns structured results with answer + sources
- [ ] Confirm API key fallback reads from `.env` when not in environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)