### PR TITLE
fix: talent market AI-generated candidates fail to hire

### DIFF
--- a/company/human_resource/employees/00002/manifest.json
+++ b/company/human_resource/employees/00002/manifest.json
@@ -66,25 +66,6 @@
             "step": 0.1
           }
         ]
-      },
-      {
-        "id": "cv_hire",
-        "title": "Hire from CV",
-        "fields": [
-          {
-            "key": "_cv_json",
-            "type": "textarea",
-            "label": "CV (JSON)",
-            "placeholder": "Paste talent CV JSON here..."
-          },
-          {
-            "key": "_cv_hire",
-            "type": "action_button",
-            "label": "Hire",
-            "action": "hire_from_cv",
-            "cv_field": "_cv_json"
-          }
-        ]
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.447",
+  "version": "0.2.448",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.447"
+version = "0.2.448"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -3954,30 +3954,25 @@ async def _do_hire_single(
                 clone_error = str(e)
                 logger.warning("[hiring] Failed to clone talent {}: {}", talent_id, e)
 
-        # Read authoritative fields from the talent profile
+        # Read authoritative fields from the talent profile on disk;
+        # fall back to candidate dict for AI-generated / repo-less talents.
         talent_data: dict = {}
         if talent_id:
             from onemancompany.core.config import load_talent_profile
             talent_data = load_talent_profile(talent_id)
 
-        # Validate required fields from talent profile
-        if talent_id and not talent_data:
-            source_repo = candidate.get("source_repo", "")
-            detail = f"Talent profile not found: {talent_id}"
-            if clone_error:
-                detail += f" (clone failed: {clone_error})"
-            await _publish_talent_profile_error(talent_id, [], source_repo, is_missing=True, clone_error=clone_error)
-            await _cleanup_single_hire_failure(batch_id, candidate_id, candidate, detail)
-            return
-        if talent_id:
-            missing = _check_talent_required_fields(talent_data)
-            if missing:
-                source_repo = candidate.get("source_repo", "")
-                await _publish_talent_profile_error(talent_id, missing, source_repo)
-                await _cleanup_single_hire_failure(batch_id, candidate_id, candidate, f"Talent profile missing fields: {', '.join(missing)}")
-                return
         if not talent_data:
+            # No on-disk profile — use candidate data from Talent Market API
+            logger.debug("[hiring] No local profile for talent {}, using candidate data", talent_id)
             talent_data = candidate
+
+        # Validate required fields
+        missing = _check_talent_required_fields(talent_data)
+        if missing:
+            source_repo = candidate.get("source_repo", "")
+            await _publish_talent_profile_error(talent_id or candidate_id, missing, source_repo)
+            await _cleanup_single_hire_failure(batch_id, candidate_id, candidate, f"Talent profile missing fields: {', '.join(missing)}")
+            return
 
         skill_names = [s["name"] if isinstance(s, dict) else s for s in candidate.get("skill_set", [])]
 
@@ -4387,23 +4382,19 @@ async def _do_batch_hire(
             if talent_id:
                 talent_data = load_talent_profile(talent_id)
 
-            # Validate required fields from talent profile
-            if talent_id and not talent_data:
-                source_repo = candidate.get("source_repo", "")
-                await _publish_talent_profile_error(talent_id, [], source_repo, is_missing=True)
-                results.append({"candidate_id": candidate_id, "status": "error", "name": cand_name,
-                                "error": f"Talent profile not found for {talent_id}"})
-                continue
-            if talent_id:
-                missing = _check_talent_required_fields(talent_data)
-                if missing:
-                    source_repo = candidate.get("source_repo", "")
-                    await _publish_talent_profile_error(talent_id, missing, source_repo)
-                    results.append({"candidate_id": candidate_id, "status": "error", "name": cand_name,
-                                    "error": f"Talent profile missing fields: {', '.join(missing)}"})
-                    continue
             if not talent_data:
+                # No on-disk profile — use candidate data from Talent Market API
+                logger.debug("[batch-hire] No local profile for talent {}, using candidate data", talent_id)
                 talent_data = candidate
+
+            # Validate required fields
+            missing = _check_talent_required_fields(talent_data)
+            if missing:
+                source_repo = candidate.get("source_repo", "")
+                await _publish_talent_profile_error(talent_id or candidate_id, missing, source_repo)
+                results.append({"candidate_id": candidate_id, "status": "error", "name": cand_name,
+                                "error": f"Talent profile missing fields: {', '.join(missing)}"})
+                continue
 
             skill_names = [s["name"] if isinstance(s, dict) else s for s in candidate.get("skill_set", candidate.get("skills", []))]
 


### PR DESCRIPTION
## Summary
- **Root cause**: `_do_hire_single` and `_do_batch_hire` both call `load_talent_profile(talent_id)` — for AI-generated talents with no git repo, this returns `{}`. The code treated empty profile as a fatal error instead of falling back to the candidate data from the Talent Market API.
- **Fix**: When no on-disk profile exists, use the candidate dict (which already has all required fields from the market API) as `talent_data`. Validation still runs on the fallback data.
- Also removes duplicate `cv_hire` section in HR manifest (merge artifact from PR #56).

## Test plan
- [ ] Search talent market, select AI-generated candidate, batch hire → should succeed
- [ ] Single hire from interview modal → should succeed
- [ ] Hire talent WITH a real repo → should still clone and use on-disk profile
- [ ] HR manifest settings page renders correctly (no duplicate "Hire from CV")

🤖 Generated with [Claude Code](https://claude.com/claude-code)