### PR TITLE
fix: HR copy hire, CEO inbox, meeting room CEO participation

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -243,9 +243,11 @@ class AppController {
     }
     if (msg.type === 'ceo_conversation') {
       const p = msg.payload || msg;
-      if (this._currentConvNodeId === p.node_id) {
-        this._appendConvMessage({
+      if (this._chatPanel && this._currentConvNodeId === p.node_id) {
+        const empName = this._resolveEmployeeName(p.sender);
+        this._chatPanel.appendMessage({
           sender: p.sender,
+          role: p.sender === 'ceo' ? 'CEO' : empName,
           text: p.text,
           timestamp: p.timestamp,
         });
@@ -918,17 +920,6 @@ class AppController {
       const el = document.getElementById(id);
       if (el) el.addEventListener('change', () => this._onRosterFilterChange());
     });
-
-    // CEO conversation dialog: Enter key to send
-    const convInput = document.getElementById('ceo-conv-input');
-    if (convInput) {
-      convInput.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' && !e.shiftKey) {
-          e.preventDefault();
-          app._sendCeoMessage();
-        }
-      });
-    }
 
     // 1-on-1 meeting modal bindings
     const oneononeModal = document.getElementById('oneonone-modal');
@@ -2162,118 +2153,77 @@ class AppController {
     `).join('');
   }
 
-  // ===== CEO Conversation Dialog =====
+  // ===== CEO Conversation (reuses ChatPanel) =====
   async _openCeoConversation(nodeId) {
     try {
       const resp = await fetch(`/api/ceo/inbox/${nodeId}/open`, { method: 'POST' });
       const data = await resp.json();
       this._currentConvNodeId = nodeId;
 
-      const overlay = document.getElementById('ceo-conv-overlay');
-      const title = document.getElementById('ceo-conv-title');
-      const desc = document.getElementById('ceo-conv-desc');
+      const chatContainer = document.getElementById('right-panel-chat');
+      // Hide CEO Console + CEO Inbox sections
+      for (const target of ['ceo-body', 'ceo-inbox-body']) {
+        const body = document.getElementById(target);
+        if (body) body.style.display = 'none';
+        const header = body?.previousElementSibling;
+        if (header?.classList.contains('collapsible-header')) header.style.display = 'none';
+      }
+      chatContainer.classList.remove('hidden');
+
+      if (!this._chatPanel) {
+        this._chatPanel = new ChatPanel(chatContainer);
+      }
+      // Wire callbacks for CEO inbox APIs
+      this._chatPanel.onSend((id, text) => this._sendCeoInboxMessage(id, text));
+      this._chatPanel.onClear(null);
+      this._chatPanel.onClose((id) => this._completeCeoConversation(id));
 
       const nickname = data.employee_nickname || data.employee_id || 'Employee';
-      title.textContent = `📥 Task Request from ${nickname}`;
-      if (data.description) {
-        desc.textContent = data.description;
-        desc.classList.remove('hidden');
-      }
-      this._renderConvMessages(data.messages || []);
-      overlay.classList.remove('hidden');
-      document.getElementById('ceo-conv-input').focus();
+      this._chatPanel.setConversation(nodeId, 'ceo_inbox', nickname);
+      // Convert inbox messages to ChatPanel format (add role field)
+      const messages = (data.messages || []).map(m => ({
+        ...m,
+        role: m.sender === 'ceo' ? 'CEO' : nickname,
+      }));
+      this._chatPanel.renderMessages(messages);
+      this._chatPanel.setInputEnabled(true);
     } catch (e) {
       console.error('Failed to open conversation:', e);
     }
   }
 
-  _closeCeoConversation() {
-    document.getElementById('ceo-conv-overlay').classList.add('hidden');
-  }
-
-  _renderConvMessages(messages) {
-    const container = document.getElementById('ceo-conv-messages');
-    container.innerHTML = messages.map(m => {
-      const isCeo = m.sender === 'ceo';
-      const cls = isCeo ? 'conv-msg-ceo' : 'conv-msg-employee';
-      let attachHtml = '';
-      if (m.attachments && m.attachments.length) {
-        attachHtml = m.attachments.map(a => `<div class="conv-attachment">📎 ${this._escHtml(a.filename)}</div>`).join('');
-      }
-      return `<div class="conv-msg ${cls}">
-        <div class="conv-msg-sender">${isCeo ? 'CEO' : this._escHtml(m.sender)}</div>
-        <div class="conv-msg-text">${this._escHtml(m.text)}</div>
-        ${attachHtml}
-        <div class="conv-msg-time">${new Date(m.timestamp).toLocaleTimeString()}</div>
-      </div>`;
-    }).join('');
-    container.scrollTop = container.scrollHeight;
-  }
-
-  _appendConvMessage(msg) {
-    const container = document.getElementById('ceo-conv-messages');
-    const isCeo = msg.sender === 'ceo';
-    const cls = isCeo ? 'conv-msg-ceo' : 'conv-msg-employee';
-    let attachHtml = '';
-    if (msg.attachments && msg.attachments.length) {
-      attachHtml = msg.attachments.map(a => `<div class="conv-attachment">📎 ${this._escHtml(a.filename)}</div>`).join('');
-    }
-    container.insertAdjacentHTML('beforeend', `
-      <div class="conv-msg ${cls}">
-        <div class="conv-msg-sender">${isCeo ? 'CEO' : this._escHtml(msg.sender)}</div>
-        <div class="conv-msg-text">${this._escHtml(msg.text)}</div>
-        ${attachHtml}
-        <div class="conv-msg-time">${new Date(msg.timestamp).toLocaleTimeString()}</div>
-      </div>
-    `);
-    container.scrollTop = container.scrollHeight;
-  }
-
-  async _sendCeoMessage() {
-    const input = document.getElementById('ceo-conv-input');
-    const text = input.value.trim();
-    if (!text || !this._currentConvNodeId) return;
-    input.value = '';
-    this._appendConvMessage({ sender: 'ceo', text, timestamp: new Date().toISOString() });
+  async _sendCeoInboxMessage(nodeId, text) {
+    if (!this._chatPanel || !nodeId) return;
+    this._chatPanel.showTyping(true);
     try {
-      await fetch(`/api/ceo/inbox/${this._currentConvNodeId}/message`, {
+      await fetch(`/api/ceo/inbox/${nodeId}/message`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text }),
       });
     } catch (e) {
+      this._chatPanel.showTyping(false);
       console.error('Failed to send message:', e);
     }
+    // Reply arrives via WebSocket ceo_conversation event
   }
 
-  async _completeCeoConversation() {
-    if (!this._currentConvNodeId) return;
-    if (!confirm('Confirm completing this conversation?')) return;
+  async _completeCeoConversation(nodeId) {
+    if (!nodeId) nodeId = this._currentConvNodeId;
+    if (!nodeId) return;
+    if (!confirm('Complete this conversation and send your decision to the agent?')) return;
     try {
-      await fetch(`/api/ceo/inbox/${this._currentConvNodeId}/complete`, { method: 'POST' });
-      this._closeCeoConversation();
-      this._currentConvNodeId = null;
-      this._refreshCeoInbox();
+      await fetch(`/api/ceo/inbox/${nodeId}/complete`, { method: 'POST' });
     } catch (e) {
       console.error('Failed to complete conversation:', e);
     }
-  }
-
-  async _uploadCeoAttachment() {
-    const fileInput = document.getElementById('ceo-conv-file');
-    if (!fileInput.files.length || !this._currentConvNodeId) return;
-    const formData = new FormData();
-    formData.append('file', fileInput.files[0]);
-    try {
-      const resp = await fetch(`/api/ceo/inbox/${this._currentConvNodeId}/upload`, {
-        method: 'POST', body: formData,
-      });
-      const data = await resp.json();
-      this._appendConvMessage(data.message);
-    } catch (e) {
-      console.error('Failed to upload:', e);
-    }
-    fileInput.value = '';
+    // Restore right panel
+    const chatContainer = document.getElementById('right-panel-chat');
+    chatContainer.classList.add('hidden');
+    this._restoreConsoleSections();
+    this._chatPanel = null;
+    this._currentConvNodeId = null;
+    this._refreshCeoInbox();
   }
 
   async _loadModelOrApiKeySection(empId) {
@@ -5667,10 +5617,11 @@ class AppController {
 
     if (!this._chatPanel) {
       this._chatPanel = new ChatPanel(chatContainer);
-      this._chatPanel.onSend((id, text, attachments) => this._sendConversationMessage(id, text, attachments));
-      this._chatPanel.onClear((id) => this._clearConversationHistory(id));
-      this._chatPanel.onClose((id) => this._closeConversation(id));
     }
+    // Always re-wire callbacks (may switch between 1-on-1 and inbox)
+    this._chatPanel.onSend((id, text, attachments) => this._sendConversationMessage(id, text, attachments));
+    this._chatPanel.onClear((id) => this._clearConversationHistory(id));
+    this._chatPanel.onClose((id) => this._closeConversation(id));
 
     // Fetch conversation + messages
     let convResp, msgsResp;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -994,6 +994,14 @@ class AppController {
     document.getElementById('meeting-modal').addEventListener('click', (e) => {
       if (e.target.id === 'meeting-modal') this.closeMeetingRoom();
     });
+    // CEO chat in meeting room
+    document.getElementById('meeting-ceo-send-btn').addEventListener('click', () => this._sendMeetingRoomMessage());
+    document.getElementById('meeting-ceo-input').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        this._sendMeetingRoomMessage();
+      }
+    });
 
     // Inquiry chat bindings (inside meeting modal)
     document.getElementById('meeting-inquiry-send-btn').addEventListener('click', () => this._sendInquiryMessage());
@@ -4201,6 +4209,14 @@ class AppController {
       partEl.innerHTML = '<div style="color:var(--text-dim)">No participants</div>';
     }
 
+    // Show CEO input if room is booked (meeting in progress)
+    const ceoInputArea = document.getElementById('meeting-ceo-input-area');
+    if (room.is_booked) {
+      ceoInputArea.classList.remove('hidden');
+    } else {
+      ceoInputArea.classList.add('hidden');
+    }
+
     // Load chat history from API
     const chatEl = document.getElementById('meeting-chat-messages');
     chatEl.innerHTML = '<div class="chat-empty">Loading...</div>';
@@ -4225,12 +4241,15 @@ class AppController {
   _refreshMeetingModalStatus(room) {
     const led = document.getElementById('meeting-modal-status-led');
     const statusText = document.getElementById('meeting-modal-status-text');
+    const ceoInputArea = document.getElementById('meeting-ceo-input-area');
     if (room.is_booked) {
       led.className = 'status-led booked';
       statusText.textContent = 'In Meeting';
+      ceoInputArea.classList.remove('hidden');
     } else {
       led.className = 'status-led free';
       statusText.textContent = 'Available';
+      ceoInputArea.classList.add('hidden');
     }
     // Update participants
     const partEl = document.getElementById('meeting-participants');
@@ -4255,7 +4274,8 @@ class AppController {
     if (this._inquirySessionId && this._inquiryRoomId === this.viewingRoomId) {
       this._endInquirySession();
     }
-    // Hide inquiry UI elements
+    // Hide input UI elements
+    document.getElementById('meeting-ceo-input-area').classList.add('hidden');
     document.getElementById('meeting-inquiry-input-area').classList.add('hidden');
     document.getElementById('meeting-inquiry-typing').classList.add('hidden');
     document.getElementById('meeting-inquiry-actions').classList.add('hidden');
@@ -4279,6 +4299,23 @@ class AppController {
     chatEl.appendChild(div);
     // Auto-scroll to bottom
     chatEl.scrollTop = chatEl.scrollHeight;
+  }
+
+  async _sendMeetingRoomMessage() {
+    const input = document.getElementById('meeting-ceo-input');
+    const text = input.value.trim();
+    if (!text || !this.viewingRoomId) return;
+    input.value = '';
+    try {
+      await fetch(`/api/rooms/${encodeURIComponent(this.viewingRoomId)}/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text }),
+      });
+    } catch (e) {
+      console.error('Failed to send meeting room message:', e);
+    }
+    // Message appears via WebSocket meeting_chat event
   }
 
   // ===== Inquiry Session =====

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2261,7 +2261,7 @@ class AppController {
           notice.textContent = '⚠ Settings changes will trigger a server reload. Use when no tasks are running.';
           container.appendChild(notice);
         }
-        // Deduplicate sections by id (last occurrence wins)
+        // Deduplicate sections by id (first occurrence wins)
         const seenIds = new Set();
         const dedupSections = [];
         for (const s of manifest.settings.sections) {
@@ -4180,6 +4180,10 @@ class AppController {
     this.viewingRoomId = room.id;
     const modal = document.getElementById('meeting-modal');
     modal.classList.remove('hidden');
+
+    // Remove stale agenda from previous meeting
+    const oldAgenda = document.getElementById('meeting-agenda-list');
+    if (oldAgenda) oldAgenda.parentElement.remove();
 
     // Title
     document.getElementById('meeting-modal-title').textContent = `🏢 ${room.name}`;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -344,6 +344,12 @@ class AppController {
         }
         return { text: `💬 [${p.speaker}] ${(p.message || '').substring(0, 50)}`, cls: 'system', agent: 'MEETING' };
       },
+      'meeting_agenda_update': (p) => {
+        if (this.viewingRoomId === p.room_id) {
+          this._renderMeetingAgenda(p);
+        }
+        return null; // no activity log entry
+      },
       'workflow_updated':    (p) => ({ text: `📋 Workflow updated: ${p.name}`, cls: 'ceo', agent: 'CEO' }),
       'candidates_ready':   (p) => {
         this.showCandidateSelection(p);
@@ -4299,6 +4305,30 @@ class AppController {
     chatEl.appendChild(div);
     // Auto-scroll to bottom
     chatEl.scrollTop = chatEl.scrollHeight;
+  }
+
+  _renderMeetingAgenda(data) {
+    let agendaEl = document.getElementById('meeting-agenda-list');
+    if (!agendaEl) {
+      // Create agenda container in the info panel
+      const infoPanel = document.getElementById('meeting-info-panel');
+      if (!infoPanel) return;
+      const block = document.createElement('div');
+      block.className = 'meeting-info-block';
+      block.innerHTML = '<div class="meeting-info-label">Agenda</div><div id="meeting-agenda-list" class="meeting-agenda-list"></div>';
+      infoPanel.appendChild(block);
+      agendaEl = document.getElementById('meeting-agenda-list');
+    }
+    const items = data.items || [];
+    const current = data.current_index;
+    const completed = new Set(data.completed || []);
+    agendaEl.innerHTML = items.map((item, i) => {
+      const done = completed.has(i);
+      const active = i === current;
+      const cls = done ? 'agenda-done' : active ? 'agenda-active' : 'agenda-pending';
+      const icon = done ? '✅' : active ? '▶' : '⬜';
+      return `<div class="agenda-item ${cls}">${icon} ${this._escHtml(item)}</div>`;
+    }).join('');
   }
 
   async _sendMeetingRoomMessage() {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -242,11 +242,12 @@ class AppController {
       return;
     }
     if (msg.type === 'ceo_conversation') {
-      if (this._currentConvNodeId === (msg.payload && msg.payload.node_id)) {
+      const p = msg.payload || msg;
+      if (this._currentConvNodeId === p.node_id) {
         this._appendConvMessage({
-          sender: msg.payload.sender,
-          text: msg.payload.text,
-          timestamp: msg.payload.timestamp,
+          sender: p.sender,
+          text: p.text,
+          timestamp: p.timestamp,
         });
       }
       return;

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2296,7 +2296,15 @@ class AppController {
           notice.textContent = '⚠ Settings changes will trigger a server reload. Use when no tasks are running.';
           container.appendChild(notice);
         }
-        for (const section of manifest.settings.sections) {
+        // Deduplicate sections by id (last occurrence wins)
+        const seenIds = new Set();
+        const dedupSections = [];
+        for (const s of manifest.settings.sections) {
+          if (s.id && seenIds.has(s.id)) continue;
+          if (s.id) seenIds.add(s.id);
+          dedupSections.push(s);
+        }
+        for (const section of dedupSections) {
           const sectionEl = document.createElement('div');
           sectionEl.className = 'emp-settings-section';
           if (section.title) {
@@ -2406,6 +2414,7 @@ class AppController {
       ta.dataset.fieldKey = field.key;
       ta.dataset.fieldType = 'textarea';
       ta.value = currentValue;
+      if (field.placeholder) ta.placeholder = field.placeholder;
       row.appendChild(ta);
     } else if (field.type === 'readonly') {
       const span = document.createElement('span');
@@ -2438,7 +2447,10 @@ class AppController {
       btn.dataset.fieldType = 'action_button';
       btn.dataset.action = field.action || '';
       btn.dataset.cvField = field.cv_field || '';
-      btn.addEventListener('click', () => this._handleManifestAction(field, empId));
+      btn.addEventListener('click', (e) => {
+        const sectionEl = e.target.closest('.emp-settings-section');
+        this._handleManifestAction(field, empId, sectionEl);
+      });
       row.appendChild(btn);
     } else {
       // Default: text input
@@ -2554,9 +2566,9 @@ class AppController {
 
   /** Registry of manifest action handlers keyed by action name. */
   _manifestActions = {
-    hire_from_cv: async (field, empId) => {
-      const container = document.getElementById('emp-settings-container');
-      const cvEl = container.querySelector(`[data-field-key="${field.cv_field}"]`);
+    hire_from_cv: async (field, empId, sectionEl) => {
+      const scope = sectionEl || document.getElementById('emp-settings-container');
+      const cvEl = scope.querySelector(`[data-field-key="${field.cv_field}"]`);
       if (!cvEl || !cvEl.value.trim()) {
         this.logEntry('SYSTEM', 'Please paste a CV JSON before clicking Hire.', 'system');
         return;
@@ -2568,7 +2580,7 @@ class AppController {
         this.logEntry('SYSTEM', 'Invalid JSON in CV field.', 'system');
         return;
       }
-      const btn = container.querySelector(`[data-field-key="${field.key}"]`);
+      const btn = scope.querySelector(`[data-field-key="${field.key}"]`);
       btn.disabled = true;
       btn.textContent = 'Hiring...';
       try {
@@ -2592,13 +2604,13 @@ class AppController {
     },
   };
 
-  async _handleManifestAction(field, empId) {
+  async _handleManifestAction(field, empId, sectionEl) {
     const handler = this._manifestActions[field.action];
     if (!handler) {
       console.error(`[manifest] Unknown action: ${field.action}`);
       return;
     }
-    await handler(field, empId);
+    await handler(field, empId, sectionEl);
   }
 
   _renderSelfHostedSection(empId, empData, container) {

--- a/frontend/conversation.js
+++ b/frontend/conversation.js
@@ -101,6 +101,7 @@ class ChatPanel {
             convType === 'oneonone' ? '1-on-1' : 'Inbox';
         this._container.querySelector('.chat-panel-employee').textContent = employeeName;
         this._clearBtn.style.display = convType === 'oneonone' ? '' : 'none';
+        this._closeBtn.textContent = convType === 'ceo_inbox' ? 'Complete' : 'End';
     }
 
     renderMessages(messages) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -385,6 +385,10 @@
           <div class="meeting-chat-header">Live Meeting Log</div>
           <div id="meeting-chat-messages" class="meeting-chat-messages"></div>
         </div>
+        <div id="meeting-ceo-input-area" class="chat-input-area hidden">
+          <textarea id="meeting-ceo-input" class="chat-textarea" placeholder="Send a message to this meeting..." rows="1"></textarea>
+          <button id="meeting-ceo-send-btn" class="chat-send-btn">&#9654;</button>
+        </div>
         <div id="meeting-inquiry-input-area" class="chat-input-area hidden">
           <textarea id="meeting-inquiry-input" class="chat-textarea" placeholder="Ask a follow-up..." rows="1"></textarea>
           <button id="meeting-inquiry-send-btn" class="chat-send-btn">&#9654;</button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -620,31 +620,6 @@
     <span class="reconnecting-text">&#128260; Reconnecting...</span>
   </div>
 
-  <!-- CEO Conversation Dialog -->
-  <div id="ceo-conv-overlay" class="ceo-conv-overlay hidden">
-    <div class="ceo-conv-dialog">
-      <div class="ceo-conv-header">
-        <span id="ceo-conv-title">&#128229; Conversation</span>
-        <button class="ceo-conv-close" onclick="app._closeCeoConversation()">&#10005;</button>
-      </div>
-      <div id="ceo-conv-desc" class="ceo-conv-desc"></div>
-      <div id="ceo-conv-messages" class="ceo-conv-messages"></div>
-      <div class="ceo-conv-input-area">
-        <div class="ceo-conv-attach-row">
-          <label class="ceo-conv-attach-btn" title="Attach file">
-            &#128206;
-            <input type="file" id="ceo-conv-file" style="display:none" onchange="app._uploadCeoAttachment()">
-          </label>
-        </div>
-        <textarea id="ceo-conv-input" rows="2" placeholder="Type a message..."></textarea>
-        <div class="ceo-conv-btn-row">
-          <button class="pixel-btn ceo-conv-send" onclick="app._sendCeoMessage()">&#9654; Send</button>
-          <button class="pixel-btn ceo-conv-complete" onclick="app._completeCeoConversation()">&#10003; Complete</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
   <script src="https://d3js.org/d3.v7.min.js"></script>
   <script src="conversation.js"></script>
   <script src="office-tileatlas.js?v=17"></script>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1105,6 +1105,16 @@ body {
   color: var(--pixel-white);
 }
 
+.meeting-agenda-list {
+  font-size: 7px;
+  line-height: 1.8;
+  color: var(--text-dim);
+}
+.agenda-item { padding: 1px 0; }
+.agenda-done { color: var(--pixel-green); text-decoration: line-through; opacity: 0.7; }
+.agenda-active { color: var(--pixel-yellow); font-weight: bold; }
+.agenda-pending { color: var(--text-dim); }
+
 .meeting-participant {
   display: flex;
   align-items: center;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.463",
+  "version": "0.2.464",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.462",
+  "version": "0.2.463",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.461",
+  "version": "0.2.462",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.460",
+  "version": "0.2.461",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.465",
+  "version": "0.2.466",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.458",
+  "version": "0.2.459",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.457",
+  "version": "0.2.458",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.456",
+  "version": "0.2.457",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.464",
+  "version": "0.2.465",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.459",
+  "version": "0.2.460",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.459"
+version = "0.2.460"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.460"
+version = "0.2.461"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.462"
+version = "0.2.463"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.458"
+version = "0.2.459"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.457"
+version = "0.2.458"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.464"
+version = "0.2.465"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.456"
+version = "0.2.457"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.461"
+version = "0.2.462"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.465"
+version = "0.2.466"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.463"
+version = "0.2.464"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -576,6 +576,126 @@ def _build_speech_prompt(emp_data: dict, emp_id: str, topic: str, agenda: str, c
     return prompt
 
 
+def _parse_agenda_items(agenda: str) -> list[str]:
+    """Parse an agenda string into discrete items.
+
+    Handles numbered lists (1. xxx), bullet lists (- xxx, * xxx),
+    and plain newline-separated items. Returns empty list if no
+    structured items are found.
+    """
+    if not agenda or not agenda.strip():
+        return []
+
+    items: list[str] = []
+    for line in agenda.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        # Strip numbered prefix: "1. ", "1) ", "1: "
+        cleaned = re.sub(r'^\d+[\.\)\:]\s*', '', line)
+        # Strip bullet prefix: "- ", "* ", "• "
+        cleaned = re.sub(r'^[-\*•]\s*', '', cleaned)
+        if cleaned:
+            items.append(cleaned)
+
+    # Only treat as structured if there are 2+ items
+    return items if len(items) >= 2 else []
+
+
+async def _run_discussion_round(
+    *,
+    room,
+    speakers: list[tuple[str, dict]],
+    topic: str,
+    agenda: str,
+    chat_history: list[dict],
+    discussion_entries: list[dict],
+    ceo_queue: asyncio.Queue,
+    max_rounds: int = 15,
+) -> tuple[int, list[dict]]:
+    """Run a token-grab discussion round. Returns (rounds_used, new_entries)."""
+    loop = asyncio.get_running_loop()
+    last_speaker_id = ""
+    new_entries: list[dict] = []
+    rounds_used = 0
+
+    for round_num in range(max_rounds):
+        rounds_used = round_num + 1
+        # Drain any CEO messages queued since last round
+        while not ceo_queue.empty():
+            try:
+                ceo_msg = ceo_queue.get_nowait()
+                chat_history.append({"speaker": "CEO", "message": ceo_msg})
+                last_speaker_id = ""
+            except asyncio.QueueEmpty:
+                break
+
+        # Concurrent evaluation
+        async def _evaluate(eid_and_data: tuple[str, dict]):
+            eid, edata = eid_and_data
+            prompt = _build_evaluate_prompt(edata, eid, topic, agenda, chat_history)
+            llm = make_llm(eid)
+            resp = await tracked_ainvoke(llm, prompt, category="meeting", employee_id=eid)
+            t1 = loop.time()
+            first_line = resp.content.strip().split("\n")[0].upper()[:20]
+            wants = "YES" in first_line
+            return (eid, edata, wants, t1)
+
+        results = await asyncio.gather(
+            *[_evaluate(e) for e in speakers],
+            return_exceptions=True,
+        )
+
+        willing: list[tuple[str, dict, float]] = [
+            (eid, edata, ts)
+            for r in results
+            if not isinstance(r, Exception)
+            for eid, edata, wants, ts in [r]
+            if wants
+        ]
+
+        if not willing:
+            # Check if CEO sent messages during evaluation
+            ceo_interjected = False
+            while not ceo_queue.empty():
+                try:
+                    ceo_msg = ceo_queue.get_nowait()
+                    await _chat(room.id, "CEO", "CEO", ceo_msg)
+                    chat_history.append({"speaker": "CEO", "message": ceo_msg})
+                    ceo_interjected = True
+                except asyncio.QueueEmpty:
+                    break
+            if ceo_interjected:
+                last_speaker_id = ""
+                continue
+            break
+
+        # Token grab — fastest wins
+        willing.sort(key=lambda x: x[2])
+        winner_id, winner_data, _ = willing[0]
+        if winner_id == last_speaker_id and len(willing) > 1:
+            winner_id, winner_data, _ = willing[1]
+
+        speech_prompt = _build_speech_prompt(winner_data, winner_id, topic, agenda, chat_history)
+        resp = await tracked_ainvoke(make_llm(winner_id), speech_prompt, category="meeting", employee_id=winner_id)
+        last_speaker_id = winner_id
+
+        display = winner_data.get("nickname", "") or winner_data.get("name", "")
+        await _chat(room.id, display, winner_data.get("role", ""), resp.content)
+        chat_history.append({"speaker": display, "message": resp.content})
+        new_entries.append({
+            "id": winner_id,
+            "name": winner_data.get("name", ""),
+            "nickname": winner_data.get("nickname", ""),
+            "comment": resp.content,
+        })
+    else:
+        await _chat(room.id, MEETING_SYSTEM_SENDER, SYSTEM_SENDER,
+                     "Discussion round has reached the maximum number of rounds.")
+
+    return rounds_used, new_entries
+
+
 @tool
 async def pull_meeting(
     topic: str,
@@ -666,7 +786,9 @@ async def pull_meeting(
         await _chat(room.id, initiator_name, "employee", f"Agenda: {agenda}")
 
     try:
-        # --- Token-grabbing discussion loop ---
+        # --- Parse agenda into discrete items ---
+        agenda_items = _parse_agenda_items(agenda)
+
         discussion_entries: list[dict] = []
         chat_history: list[dict] = [
             {"speaker": initiator_name, "message": f"Topic: {topic}"},
@@ -675,102 +797,79 @@ async def pull_meeting(
             chat_history.append({"speaker": initiator_name, "message": f"Agenda: {agenda}"})
 
         # All participants (including initiator if present) can compete to speak
-        # speakers is a list of (emp_id, emp_data) tuples
         speakers: list[tuple[str, dict]] = list(valid_participants)
         if initiator_id:
             ini_data = load_employee(initiator_id)
             if ini_data and initiator_id not in {pid for pid, _ in speakers}:
                 speakers.append((initiator_id, ini_data))
 
-        max_rounds = 15
-        loop = asyncio.get_running_loop()
-        rounds_used = 0
-        last_speaker_id: str = ""  # track last speaker for no-consecutive rule
-
         # Register CEO message queue for this room
         ceo_queue: asyncio.Queue = asyncio.Queue()
         _ceo_meeting_queues[room.id] = ceo_queue
 
-        for round_num in range(max_rounds):
-            rounds_used = round_num + 1
+        # Broadcast initial agenda to frontend
+        await _publish("meeting_agenda_update", {
+            "room_id": room.id,
+            "items": agenda_items,
+            "current_index": 0,
+            "completed": [],
+        })
 
-            # Drain any CEO messages queued since last round
-            while not ceo_queue.empty():
-                try:
-                    ceo_msg = ceo_queue.get_nowait()
-                    chat_history.append({"speaker": "CEO", "message": ceo_msg})
-                    last_speaker_id = ""  # reset so agents respond naturally
-                except asyncio.QueueEmpty:
-                    break
+        rounds_used = 0
 
-            # Concurrent evaluation — all participants judge whether they need to speak
-            async def _evaluate(eid_and_data: tuple[str, dict]):
-                eid, edata = eid_and_data
-                prompt = _build_evaluate_prompt(edata, eid, topic, agenda, chat_history)
-                llm = make_llm(eid)
-                t0 = loop.time()
-                resp = await tracked_ainvoke(llm, prompt, category="meeting", employee_id=eid)
-                t1 = loop.time()
-                first_line = resp.content.strip().split("\n")[0].upper()[:20]
-                wants = "YES" in first_line
-                return (eid, edata, wants, t1)
+        if agenda_items:
+            # --- Structured agenda: discuss each item in sequence ---
+            completed_indices: list[int] = []
+            for item_idx, item_text in enumerate(agenda_items):
+                # Broadcast current agenda item
+                await _publish("meeting_agenda_update", {
+                    "room_id": room.id,
+                    "items": agenda_items,
+                    "current_index": item_idx,
+                    "completed": completed_indices,
+                })
+                await _chat(room.id, MEETING_SYSTEM_SENDER, SYSTEM_SENDER,
+                            f"📋 Agenda item {item_idx + 1}/{len(agenda_items)}: {item_text}")
+                chat_history.append({"speaker": MEETING_SYSTEM_SENDER, "message": f"Now discussing: {item_text}"})
 
-            results = await asyncio.gather(
-                *[_evaluate(e) for e in speakers],
-                return_exceptions=True,
-            )
+                item_rounds, item_entries = await _run_discussion_round(
+                    room=room,
+                    speakers=speakers,
+                    topic=topic,
+                    agenda=f"Current agenda item: {item_text}",
+                    chat_history=chat_history,
+                    discussion_entries=discussion_entries,
+                    ceo_queue=ceo_queue,
+                    max_rounds=10,
+                )
+                rounds_used += item_rounds
+                discussion_entries.extend(item_entries)
 
-            # Filter out exceptions and those who don't want to speak
-            willing: list[tuple[str, dict, float]] = [
-                (eid, edata, ts)
-                for r in results
-                if not isinstance(r, Exception)
-                for eid, edata, wants, ts in [r]
-                if wants
-            ]
+                completed_indices.append(item_idx)
 
-            if not willing:
-                # Before concluding, check if CEO sent messages during evaluation
-                ceo_interjected = False
-                while not ceo_queue.empty():
-                    try:
-                        ceo_msg = ceo_queue.get_nowait()
-                        await _chat(room.id, "CEO", "CEO", f"[CEO interjection] {ceo_msg}")
-                        chat_history.append({"speaker": "CEO", "message": ceo_msg})
-                        ceo_interjected = True
-                    except asyncio.QueueEmpty:
-                        break
-                if ceo_interjected:
-                    last_speaker_id = ""  # let agents respond to CEO
-                    continue  # re-evaluate — agents may want to respond
-                await _chat(room.id, MEETING_SYSTEM_SENDER, SYSTEM_SENDER, "All participants have finished speaking. Meeting concluded.")
-                break
-
-            # Token grab — sort by timestamp, fastest wins
-            willing.sort(key=lambda x: x[2])
-
-            # No-consecutive rule: same person cannot get the token twice in a row
-            winner_id, winner_data, _ = willing[0]
-            if winner_id == last_speaker_id and len(willing) > 1:
-                winner_id, winner_data, _ = willing[1]
-
-            # Winner delivers their speech
-            speech_prompt = _build_speech_prompt(winner_data, winner_id, topic, agenda, chat_history)
-            resp = await tracked_ainvoke(make_llm(winner_id), speech_prompt, category="meeting", employee_id=winner_id)
-            last_speaker_id = winner_id
-
-            display = winner_data.get("nickname", "") or winner_data.get("name", "")
-            await _chat(room.id, display, winner_data.get("role", ""), resp.content)
-            chat_history.append({"speaker": display, "message": resp.content})
-            discussion_entries.append({
-                "id": winner_id,
-                "name": winner_data.get("name", ""),
-                "nickname": winner_data.get("nickname", ""),
-                "comment": resp.content,
+            # Broadcast all items completed
+            await _publish("meeting_agenda_update", {
+                "room_id": room.id,
+                "items": agenda_items,
+                "current_index": -1,
+                "completed": completed_indices,
             })
+            await _chat(room.id, MEETING_SYSTEM_SENDER, SYSTEM_SENDER, "All agenda items have been discussed. Meeting concluded.")
+
         else:
-            # max_rounds reached
-            await _chat(room.id, MEETING_SYSTEM_SENDER, SYSTEM_SENDER, "Meeting has reached the maximum number of rounds. Auto-concluded.")
+            # --- No structured agenda: single discussion round (original behavior) ---
+            item_rounds, item_entries = await _run_discussion_round(
+                room=room,
+                speakers=speakers,
+                topic=topic,
+                agenda=agenda,
+                chat_history=chat_history,
+                discussion_entries=discussion_entries,
+                ceo_queue=ceo_queue,
+                max_rounds=15,
+            )
+            rounds_used = item_rounds
+            discussion_entries.extend(item_entries)
 
         # --- Synthesize meeting conclusion ---
         all_comments = "\n".join(

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -30,6 +30,15 @@ async def _publish(event_type: str, payload: dict, agent: str = "MEETING") -> No
     await event_bus.publish(CompanyEvent(type=event_type, payload=payload, agent=agent))
 
 
+# Per-room CEO message queues — CEO messages injected into active meetings
+_ceo_meeting_queues: dict[str, asyncio.Queue] = {}
+
+
+def get_ceo_meeting_queue(room_id: str) -> asyncio.Queue | None:
+    """Get the CEO message queue for an active meeting, or None."""
+    return _ceo_meeting_queues.get(room_id)
+
+
 async def _chat(room_id: str, speaker: str, role: str, message: str) -> None:
     from datetime import datetime
     entry = {
@@ -678,8 +687,21 @@ async def pull_meeting(
         rounds_used = 0
         last_speaker_id: str = ""  # track last speaker for no-consecutive rule
 
+        # Register CEO message queue for this room
+        ceo_queue: asyncio.Queue = asyncio.Queue()
+        _ceo_meeting_queues[room.id] = ceo_queue
+
         for round_num in range(max_rounds):
             rounds_used = round_num + 1
+
+            # Drain any CEO messages queued since last round
+            while not ceo_queue.empty():
+                try:
+                    ceo_msg = ceo_queue.get_nowait()
+                    chat_history.append({"speaker": "CEO", "message": ceo_msg})
+                    last_speaker_id = ""  # reset so agents respond naturally
+                except asyncio.QueueEmpty:
+                    break
 
             # Concurrent evaluation — all participants judge whether they need to speak
             async def _evaluate(eid_and_data: tuple[str, dict]):
@@ -796,6 +818,8 @@ async def pull_meeting(
         }
 
     finally:
+        # Unregister CEO message queue
+        _ceo_meeting_queues.pop(room.id, None)
         # Release meeting room
         room.is_booked = False
         room.booked_by = ""

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -609,7 +609,6 @@ async def _run_discussion_round(
     topic: str,
     agenda: str,
     chat_history: list[dict],
-    discussion_entries: list[dict],
     ceo_queue: asyncio.Queue,
     max_rounds: int = 15,
 ) -> tuple[int, list[dict]]:
@@ -621,7 +620,9 @@ async def _run_discussion_round(
 
     for round_num in range(max_rounds):
         rounds_used = round_num + 1
-        # Drain any CEO messages queued since last round
+        # Drain any CEO messages queued since last round.
+        # We only append to chat_history here (no _chat() call) because the
+        # API route that enqueued the message already persisted and broadcast it.
         while not ceo_queue.empty():
             try:
                 ceo_msg = ceo_queue.get_nowait()
@@ -838,7 +839,6 @@ async def pull_meeting(
                     topic=topic,
                     agenda=f"Current agenda item: {item_text}",
                     chat_history=chat_history,
-                    discussion_entries=discussion_entries,
                     ceo_queue=ceo_queue,
                     max_rounds=10,
                 )
@@ -864,7 +864,6 @@ async def pull_meeting(
                 topic=topic,
                 agenda=agenda,
                 chat_history=chat_history,
-                discussion_entries=discussion_entries,
                 ceo_queue=ceo_queue,
                 max_rounds=15,
             )

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -730,6 +730,19 @@ async def pull_meeting(
             ]
 
             if not willing:
+                # Before concluding, check if CEO sent messages during evaluation
+                ceo_interjected = False
+                while not ceo_queue.empty():
+                    try:
+                        ceo_msg = ceo_queue.get_nowait()
+                        await _chat(room.id, "CEO", "CEO", f"[CEO interjection] {ceo_msg}")
+                        chat_history.append({"speaker": "CEO", "message": ceo_msg})
+                        ceo_interjected = True
+                    except asyncio.QueueEmpty:
+                        break
+                if ceo_interjected:
+                    last_speaker_id = ""  # let agents respond to CEO
+                    continue  # re-evaluate — agents may want to respond
                 await _chat(room.id, MEETING_SYSTEM_SENDER, SYSTEM_SENDER, "All participants have finished speaking. Meeting concluded.")
                 break
 

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -5763,6 +5763,16 @@ async def open_ceo_conversation(node_id: str):
     }
 
 
+def _parse_hold_reason(hold_reason: str | None) -> dict[str, str]:
+    """Parse a hold_reason string like 'ceo_request=node_id,no_watchdog=1' into a dict."""
+    result: dict[str, str] = {}
+    for pair in (hold_reason or "").split(","):
+        if "=" in pair:
+            k, v = pair.split("=", 1)
+            result[k.strip()] = v.strip()
+    return result
+
+
 async def _run_conversation_loop(session, node, tree, project_dir):
     """Run conversation loop and handle completion."""
     from onemancompany.core.task_lifecycle import transition
@@ -5786,13 +5796,7 @@ async def _run_conversation_loop(session, node, tree, project_dir):
         # Auto-resume parent if it's HOLDING specifically for THIS ceo_request
         parent = tree.get_node(node.parent_id) if node.parent_id else None
         if parent and parent.status == TaskPhase.HOLDING.value:
-            # hold_reason format: "ceo_request={node_id},no_watchdog=1"
-            hr = parent.hold_reason or ""
-            hr_meta = {}
-            for pair in hr.split(","):
-                if "=" in pair:
-                    k, v = pair.split("=", 1)
-                    hr_meta[k.strip()] = v.strip()
+            hr_meta = _parse_hold_reason(parent.hold_reason)
             if hr_meta.get("ceo_request") == node.id:
                 resumed = await employee_manager.resume_held_task(
                     parent.employee_id,

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -5728,12 +5728,12 @@ async def _run_conversation_loop(session, node, tree, project_dir):
     from onemancompany.core.task_lifecycle import transition
     from onemancompany.core.vessel import (
         _trigger_dep_resolution,
-        _parse_holding_metadata,
         employee_manager,
     )
 
     try:
         summary = await session.run()
+        logger.info("[ceo_inbox] conversation completed: node={}, summary_len={}", node.id, len(summary))
         node.result = summary
         transition(node.id, TaskPhase(node.status), TaskPhase.COMPLETED)
         node.status = TaskPhase.COMPLETED.value
@@ -5746,8 +5746,14 @@ async def _run_conversation_loop(session, node, tree, project_dir):
         # Auto-resume parent if it's HOLDING specifically for THIS ceo_request
         parent = tree.get_node(node.parent_id) if node.parent_id else None
         if parent and parent.status == TaskPhase.HOLDING.value:
-            holding_meta = _parse_holding_metadata(parent.result or "")
-            if holding_meta and holding_meta.get("ceo_request") == node.id:
+            # hold_reason format: "ceo_request={node_id},no_watchdog=1"
+            hr = parent.hold_reason or ""
+            hr_meta = {}
+            for pair in hr.split(","):
+                if "=" in pair:
+                    k, v = pair.split("=", 1)
+                    hr_meta[k.strip()] = v.strip()
+            if hr_meta.get("ceo_request") == node.id:
                 resumed = await employee_manager.resume_held_task(
                     parent.employee_id,
                     parent.id,

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -5587,9 +5587,15 @@ async def get_room_chat(room_id: str):
 
 @router.post("/api/rooms/{room_id}/chat")
 async def post_room_chat(room_id: str, body: dict):
-    """CEO sends a message to a meeting room chat."""
+    """CEO sends a message to a meeting room chat.
+
+    The message is persisted to disk, broadcast via WebSocket, and
+    injected into the active pull_meeting token-grab loop (if any)
+    so agents see it in their next evaluation round.
+    """
     from datetime import datetime
     from onemancompany.core.store import append_room_chat
+    from onemancompany.agents.common_tools import get_ceo_meeting_queue
 
     message = body.get("message", "").strip()
     if not message:
@@ -5610,6 +5616,12 @@ async def post_room_chat(room_id: str, body: dict):
             agent="CEO",
         )
     )
+
+    # Inject into active meeting's token-grab loop
+    q = get_ceo_meeting_queue(room_id)
+    if q is not None:
+        await q.put(message)
+
     return {"status": "sent"}
 
 

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -5585,6 +5585,34 @@ async def get_room_chat(room_id: str):
     return load_room_chat(room_id)
 
 
+@router.post("/api/rooms/{room_id}/chat")
+async def post_room_chat(room_id: str, body: dict):
+    """CEO sends a message to a meeting room chat."""
+    from datetime import datetime
+    from onemancompany.core.store import append_room_chat
+
+    message = body.get("message", "").strip()
+    if not message:
+        raise HTTPException(status_code=400, detail="Message text required")
+
+    entry = {
+        "room_id": room_id,
+        "speaker": "CEO",
+        "role": "CEO",
+        "message": message,
+        "time": datetime.now().strftime("%H:%M:%S"),
+    }
+    await append_room_chat(room_id, entry)
+    await event_bus.publish(
+        CompanyEvent(
+            type=EventType.MEETING_CHAT,
+            payload=entry,
+            agent="CEO",
+        )
+    )
+    return {"status": "sent"}
+
+
 @router.get("/api/tools")
 async def list_tools():
     """List tools — reads from disk."""

--- a/src/onemancompany/core/models.py
+++ b/src/onemancompany/core/models.py
@@ -99,6 +99,7 @@ class EventType(str, Enum):
     TREE_UPDATE = "tree_update"
     MEETING_BOOKED = "meeting_booked"
     MEETING_CHAT = "meeting_chat"
+    MEETING_AGENDA_UPDATE = "meeting_agenda_update"
     MEETING_RELEASED = "meeting_released"
     INQUIRY_STARTED = "inquiry_started"
     INQUIRY_ENDED = "inquiry_ended"

--- a/tests/unit/agents/test_common_tools.py
+++ b/tests/unit/agents/test_common_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1857,3 +1858,338 @@ class TestReadNodeDetail:
         finally:
             _current_vessel.reset(tok_v)
             _current_task_id.reset(tok_t)
+
+
+# ---------------------------------------------------------------------------
+# _parse_agenda_items
+# ---------------------------------------------------------------------------
+
+
+class TestParseAgendaItems:
+    def test_numbered_list(self):
+        from onemancompany.agents.common_tools import _parse_agenda_items
+
+        result = _parse_agenda_items("1. First item\n2. Second item\n3. Third item")
+        assert result == ["First item", "Second item", "Third item"]
+
+    def test_bullet_dash(self):
+        from onemancompany.agents.common_tools import _parse_agenda_items
+
+        result = _parse_agenda_items("- Alpha\n- Beta")
+        assert result == ["Alpha", "Beta"]
+
+    def test_bullet_star(self):
+        from onemancompany.agents.common_tools import _parse_agenda_items
+
+        result = _parse_agenda_items("* One\n* Two")
+        assert result == ["One", "Two"]
+
+    def test_plain_newlines(self):
+        from onemancompany.agents.common_tools import _parse_agenda_items
+
+        result = _parse_agenda_items("Discuss design\nReview code")
+        assert result == ["Discuss design", "Review code"]
+
+    def test_returns_empty_for_none(self):
+        from onemancompany.agents.common_tools import _parse_agenda_items
+
+        assert _parse_agenda_items(None) == []
+
+    def test_returns_empty_for_empty_string(self):
+        from onemancompany.agents.common_tools import _parse_agenda_items
+
+        assert _parse_agenda_items("") == []
+
+    def test_returns_empty_for_whitespace(self):
+        from onemancompany.agents.common_tools import _parse_agenda_items
+
+        assert _parse_agenda_items("   \n  \n  ") == []
+
+    def test_returns_empty_for_single_item(self):
+        from onemancompany.agents.common_tools import _parse_agenda_items
+
+        assert _parse_agenda_items("Just one thing") == []
+
+    def test_returns_empty_for_single_bullet(self):
+        from onemancompany.agents.common_tools import _parse_agenda_items
+
+        assert _parse_agenda_items("- Only one") == []
+
+    def test_mixed_formats(self):
+        from onemancompany.agents.common_tools import _parse_agenda_items
+
+        result = _parse_agenda_items("1. First\n- Second\nThird")
+        assert result == ["First", "Second", "Third"]
+
+    def test_blank_lines_filtered(self):
+        from onemancompany.agents.common_tools import _parse_agenda_items
+
+        result = _parse_agenda_items("1. A\n\n2. B\n\n")
+        assert result == ["A", "B"]
+
+    def test_numbered_with_paren(self):
+        from onemancompany.agents.common_tools import _parse_agenda_items
+
+        result = _parse_agenda_items("1) First\n2) Second")
+        assert result == ["First", "Second"]
+
+    def test_numbered_with_colon(self):
+        from onemancompany.agents.common_tools import _parse_agenda_items
+
+        result = _parse_agenda_items("1: First\n2: Second")
+        assert result == ["First", "Second"]
+
+
+# ---------------------------------------------------------------------------
+# get_ceo_meeting_queue
+# ---------------------------------------------------------------------------
+
+
+class TestGetCeoMeetingQueue:
+    def test_returns_none_for_missing_room(self):
+        from onemancompany.agents.common_tools import get_ceo_meeting_queue
+
+        assert get_ceo_meeting_queue("nonexistent-room") is None
+
+    def test_returns_queue_when_present(self):
+        import onemancompany.agents.common_tools as ct_mod
+
+        q = asyncio.Queue()
+        ct_mod._ceo_meeting_queues["test-room-123"] = q
+        try:
+            result = ct_mod.get_ceo_meeting_queue("test-room-123")
+            assert result is q
+        finally:
+            ct_mod._ceo_meeting_queues.pop("test-room-123", None)
+
+
+# ---------------------------------------------------------------------------
+# _run_discussion_round
+# ---------------------------------------------------------------------------
+
+
+class TestRunDiscussionRound:
+    @pytest.mark.asyncio
+    async def test_no_willing_speakers_stops_immediately(self):
+        """When no speaker is willing, the loop should stop after 1 round."""
+        from onemancompany.agents.common_tools import _run_discussion_round
+
+        room = MagicMock()
+        room.id = "room-1"
+        ceo_queue = asyncio.Queue()
+
+        speakers = [
+            ("00010", {"name": "Alice", "nickname": "A", "role": "Engineer"}),
+            ("00011", {"name": "Bob", "nickname": "B", "role": "Designer"}),
+        ]
+
+        # LLM returns "NO" — nobody wants to speak
+        mock_resp = MagicMock()
+        mock_resp.content = "NO, I have nothing to add"
+
+        with patch("onemancompany.agents.common_tools.make_llm", return_value=MagicMock()), \
+             patch("onemancompany.agents.common_tools.tracked_ainvoke", return_value=mock_resp), \
+             patch("onemancompany.agents.common_tools.get_employee_skills_prompt", return_value=""), \
+             patch("onemancompany.agents.common_tools.get_employee_tools_prompt", return_value=""), \
+             patch("onemancompany.agents.common_tools._chat", new_callable=AsyncMock):
+            rounds, entries = await _run_discussion_round(
+                room=room,
+                speakers=speakers,
+                topic="Test topic",
+                agenda="",
+                chat_history=[],
+                ceo_queue=ceo_queue,
+                max_rounds=5,
+            )
+
+        assert rounds == 1
+        assert entries == []
+
+    @pytest.mark.asyncio
+    async def test_willing_speaker_wins_and_speaks(self):
+        """A willing speaker should produce a new_entry."""
+        from onemancompany.agents.common_tools import _run_discussion_round
+
+        room = MagicMock()
+        room.id = "room-2"
+        ceo_queue = asyncio.Queue()
+
+        speakers = [
+            ("00010", {"name": "Alice", "nickname": "A", "role": "Engineer"}),
+        ]
+
+        call_count = 0
+
+        async def fake_invoke(llm, prompt, **kw):
+            nonlocal call_count
+            call_count += 1
+            resp = MagicMock()
+            if call_count == 1:
+                # Evaluation — willing
+                resp.content = "YES, I want to discuss this"
+            elif call_count == 2:
+                # Speech
+                resp.content = "Here is my contribution"
+            else:
+                # Second round evaluation — not willing
+                resp.content = "NO"
+            return resp
+
+        with patch("onemancompany.agents.common_tools.make_llm", return_value=MagicMock()), \
+             patch("onemancompany.agents.common_tools.tracked_ainvoke", side_effect=fake_invoke), \
+             patch("onemancompany.agents.common_tools.get_employee_skills_prompt", return_value=""), \
+             patch("onemancompany.agents.common_tools.get_employee_tools_prompt", return_value=""), \
+             patch("onemancompany.agents.common_tools._chat", new_callable=AsyncMock):
+            rounds, entries = await _run_discussion_round(
+                room=room,
+                speakers=speakers,
+                topic="Test topic",
+                agenda="",
+                chat_history=[],
+                ceo_queue=ceo_queue,
+                max_rounds=5,
+            )
+
+        assert rounds == 2  # round 1 = speak, round 2 = no willing → break
+        assert len(entries) == 1
+        assert entries[0]["id"] == "00010"
+        assert entries[0]["comment"] == "Here is my contribution"
+
+    @pytest.mark.asyncio
+    async def test_no_consecutive_same_speaker(self):
+        """If the fastest willing speaker spoke last round, the second fastest wins."""
+        from onemancompany.agents.common_tools import _run_discussion_round
+
+        room = MagicMock()
+        room.id = "room-3"
+        ceo_queue = asyncio.Queue()
+
+        speakers = [
+            ("00010", {"name": "Alice", "nickname": "A", "role": "Engineer"}),
+            ("00011", {"name": "Bob", "nickname": "B", "role": "Designer"}),
+        ]
+
+        round_counter = [0]  # track which round we're in
+
+        async def fake_invoke(llm, prompt, **kw):
+            resp = MagicMock()
+            if "want to speak" in prompt.lower() or "YES or NO" in prompt:
+                # Evaluation phase — everyone willing
+                resp.content = "YES"
+            else:
+                # Speech phase
+                round_counter[0] += 1
+                resp.content = f"Speech round {round_counter[0]}"
+            return resp
+
+        with patch("onemancompany.agents.common_tools.make_llm", return_value=MagicMock()), \
+             patch("onemancompany.agents.common_tools.tracked_ainvoke", side_effect=fake_invoke), \
+             patch("onemancompany.agents.common_tools.get_employee_skills_prompt", return_value=""), \
+             patch("onemancompany.agents.common_tools.get_employee_tools_prompt", return_value=""), \
+             patch("onemancompany.agents.common_tools._chat", new_callable=AsyncMock):
+            rounds, entries = await _run_discussion_round(
+                room=room,
+                speakers=speakers,
+                topic="Test topic",
+                agenda="",
+                chat_history=[],
+                ceo_queue=ceo_queue,
+                max_rounds=3,
+            )
+
+        # With max 3 rounds and all willing, should use all 3 rounds
+        assert rounds == 3
+        assert len(entries) == 3
+        # No two consecutive entries should have the same speaker
+        for i in range(1, len(entries)):
+            assert entries[i]["id"] != entries[i - 1]["id"]
+
+    @pytest.mark.asyncio
+    async def test_ceo_queue_drained_between_rounds(self):
+        """CEO messages should be added to chat_history between rounds."""
+        from onemancompany.agents.common_tools import _run_discussion_round
+
+        room = MagicMock()
+        room.id = "room-4"
+        ceo_queue = asyncio.Queue()
+        # Enqueue a CEO message before the round starts
+        await ceo_queue.put("CEO says hello")
+
+        speakers = [
+            ("00010", {"name": "Alice", "nickname": "A", "role": "Engineer"}),
+        ]
+        chat_history: list[dict] = []
+
+        async def fake_invoke(llm, prompt, **kw):
+            resp = MagicMock()
+            # Always NO so we stop after 1 round
+            resp.content = "NO"
+            return resp
+
+        with patch("onemancompany.agents.common_tools.make_llm", return_value=MagicMock()), \
+             patch("onemancompany.agents.common_tools.tracked_ainvoke", side_effect=fake_invoke), \
+             patch("onemancompany.agents.common_tools.get_employee_skills_prompt", return_value=""), \
+             patch("onemancompany.agents.common_tools.get_employee_tools_prompt", return_value=""), \
+             patch("onemancompany.agents.common_tools._chat", new_callable=AsyncMock):
+            rounds, entries = await _run_discussion_round(
+                room=room,
+                speakers=speakers,
+                topic="Test topic",
+                agenda="",
+                chat_history=chat_history,
+                ceo_queue=ceo_queue,
+                max_rounds=5,
+            )
+
+        # CEO message should have been drained into chat_history
+        assert any(e["speaker"] == "CEO" and e["message"] == "CEO says hello" for e in chat_history)
+
+    @pytest.mark.asyncio
+    async def test_ceo_interjection_during_no_willing_triggers_continue(self):
+        """If nobody is willing but CEO has interjected, loop should continue."""
+        from onemancompany.agents.common_tools import _run_discussion_round
+
+        room = MagicMock()
+        room.id = "room-5"
+        ceo_queue = asyncio.Queue()
+
+        speakers = [
+            ("00010", {"name": "Alice", "nickname": "A", "role": "Engineer"}),
+        ]
+
+        eval_count = [0]
+
+        async def fake_invoke(llm, prompt, **kw):
+            resp = MagicMock()
+            eval_count[0] += 1
+            if eval_count[0] == 1:
+                # First eval — nobody willing, but CEO will interject
+                resp.content = "NO"
+                # Simulate CEO sending a message while eval was running
+                await ceo_queue.put("CEO: What about approach X?")
+            elif eval_count[0] == 2:
+                # Second eval after CEO interjection — still no
+                resp.content = "NO"
+            else:
+                resp.content = "NO"
+            return resp
+
+        with patch("onemancompany.agents.common_tools.make_llm", return_value=MagicMock()), \
+             patch("onemancompany.agents.common_tools.tracked_ainvoke", side_effect=fake_invoke), \
+             patch("onemancompany.agents.common_tools.get_employee_skills_prompt", return_value=""), \
+             patch("onemancompany.agents.common_tools.get_employee_tools_prompt", return_value=""), \
+             patch("onemancompany.agents.common_tools._chat", new_callable=AsyncMock):
+            rounds, entries = await _run_discussion_round(
+                room=room,
+                speakers=speakers,
+                topic="Test topic",
+                agenda="",
+                chat_history=[],
+                ceo_queue=ceo_queue,
+                max_rounds=5,
+            )
+
+        # Should have run 2 rounds: round 1 no willing + CEO interjection → continue,
+        # round 2 no willing + no CEO → break
+        assert rounds == 2
+        assert entries == []

--- a/tests/unit/api/test_routes.py
+++ b/tests/unit/api/test_routes.py
@@ -6909,3 +6909,145 @@ class TestHireFromCV:
                     "cv": {"name": "Bob", "role": "PM", "temperature": "hot"}
                 })
                 assert resp.json()["status"] == "onboarding"
+
+
+# ---------------------------------------------------------------------------
+# _parse_hold_reason
+# ---------------------------------------------------------------------------
+
+
+class TestParseHoldReason:
+    def test_none_returns_empty(self):
+        from onemancompany.api.routes import _parse_hold_reason
+
+        assert _parse_hold_reason(None) == {}
+
+    def test_empty_string_returns_empty(self):
+        from onemancompany.api.routes import _parse_hold_reason
+
+        assert _parse_hold_reason("") == {}
+
+    def test_single_pair(self):
+        from onemancompany.api.routes import _parse_hold_reason
+
+        result = _parse_hold_reason("ceo_request=node_123")
+        assert result == {"ceo_request": "node_123"}
+
+    def test_multiple_pairs(self):
+        from onemancompany.api.routes import _parse_hold_reason
+
+        result = _parse_hold_reason("ceo_request=node_id,no_watchdog=1")
+        assert result == {"ceo_request": "node_id", "no_watchdog": "1"}
+
+    def test_whitespace_trimmed(self):
+        from onemancompany.api.routes import _parse_hold_reason
+
+        result = _parse_hold_reason(" key1 = val1 , key2 = val2 ")
+        assert result == {"key1": "val1", "key2": "val2"}
+
+    def test_no_equals_sign_ignored(self):
+        from onemancompany.api.routes import _parse_hold_reason
+
+        result = _parse_hold_reason("ceo_request=val,garbage,other=ok")
+        assert result == {"ceo_request": "val", "other": "ok"}
+
+    def test_value_with_equals(self):
+        from onemancompany.api.routes import _parse_hold_reason
+
+        result = _parse_hold_reason("key=val=extra")
+        assert result == {"key": "val=extra"}
+
+
+# ---------------------------------------------------------------------------
+# POST /api/rooms/{room_id}/chat
+# ---------------------------------------------------------------------------
+
+
+class TestPostRoomChat:
+    @pytest.mark.asyncio
+    async def test_empty_message_returns_400(self):
+        app = _make_test_app()
+        transport = ASGITransport(app=app)
+
+        with patch("onemancompany.api.routes.event_bus", MagicMock(publish=AsyncMock())):
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post("/api/rooms/room-1/chat", json={"message": ""})
+                assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_message_returns_400(self):
+        app = _make_test_app()
+        transport = ASGITransport(app=app)
+
+        with patch("onemancompany.api.routes.event_bus", MagicMock(publish=AsyncMock())):
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post("/api/rooms/room-1/chat", json={"message": "   "})
+                assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_missing_message_key_returns_400(self):
+        app = _make_test_app()
+        transport = ASGITransport(app=app)
+
+        with patch("onemancompany.api.routes.event_bus", MagicMock(publish=AsyncMock())):
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post("/api/rooms/room-1/chat", json={})
+                assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_valid_message_persists_and_broadcasts(self):
+        app = _make_test_app()
+        transport = ASGITransport(app=app)
+
+        mock_append = AsyncMock()
+        mock_event_bus = MagicMock(publish=AsyncMock())
+
+        with patch("onemancompany.api.routes.event_bus", mock_event_bus), \
+             patch("onemancompany.core.store.append_room_chat", mock_append), \
+             patch("onemancompany.agents.common_tools.get_ceo_meeting_queue", return_value=None):
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post("/api/rooms/room-1/chat", json={"message": "Hello team"})
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "sent"
+        mock_append.assert_awaited_once()
+        call_args = mock_append.call_args
+        assert call_args[0][0] == "room-1"
+        assert call_args[0][1]["message"] == "Hello team"
+        assert call_args[0][1]["speaker"] == "CEO"
+        mock_event_bus.publish.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_injects_into_ceo_meeting_queue(self):
+        app = _make_test_app()
+        transport = ASGITransport(app=app)
+
+        q = asyncio.Queue()
+        mock_append = AsyncMock()
+        mock_event_bus = MagicMock(publish=AsyncMock())
+
+        with patch("onemancompany.api.routes.event_bus", mock_event_bus), \
+             patch("onemancompany.core.store.append_room_chat", mock_append), \
+             patch("onemancompany.agents.common_tools.get_ceo_meeting_queue", return_value=q):
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post("/api/rooms/room-1/chat", json={"message": "Chime in"})
+
+        assert resp.status_code == 200
+        assert not q.empty()
+        assert q.get_nowait() == "Chime in"
+
+    @pytest.mark.asyncio
+    async def test_no_queue_injection_when_no_active_meeting(self):
+        app = _make_test_app()
+        transport = ASGITransport(app=app)
+
+        mock_append = AsyncMock()
+        mock_event_bus = MagicMock(publish=AsyncMock())
+
+        with patch("onemancompany.api.routes.event_bus", mock_event_bus), \
+             patch("onemancompany.core.store.append_room_chat", mock_append), \
+             patch("onemancompany.agents.common_tools.get_ceo_meeting_queue", return_value=None):
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post("/api/rooms/room-1/chat", json={"message": "Test"})
+
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

### HR Copy Hire Fix
- Scoped field lookup to parent section element to avoid matching wrong textarea when duplicate section IDs exist
- Added manifest section deduplication (first occurrence wins)

### CEO Inbox Fixes
- **Auto-resume bug**: Was parsing `parent.result` (wrong field, wrong format), now correctly parses `parent.hold_reason` for `ceo_request={node_id}` via extracted `_parse_hold_reason()` utility
- **WebSocket format mismatch**: Backend broadcast fields at top level, frontend read from `msg.payload` — agent replies were never displayed
- **UI consolidation**: Replaced separate overlay dialog with shared ChatPanel component (same UI as 1-on-1, with "Complete" button)

### Meeting Room CEO Participation
- CEO can now send messages to active meeting rooms via input area in meeting modal
- CEO messages are injected into `pull_meeting` token-grab loop via per-room `asyncio.Queue`
- Agents see CEO's message in their next evaluation round and respond naturally
- If all agents finish speaking, CEO messages sent during evaluation trigger re-evaluation
- **Structured agenda**: `pull_meeting` now parses agenda into discrete items, runs separate discussion round per item
- Frontend shows live agenda checklist (current item highlighted, completed items checked off)
- CEO interjection during any agenda item triggers discussion, then auto-continues to next item

### Code Review Fixes
- Fixed section dedup comment (first wins, not last wins)
- Removed dead `discussion_entries` parameter from `_run_discussion_round`
- Added comment explaining why `_chat()` is skipped in CEO drain
- Extracted `_parse_hold_reason()` utility function in routes.py
- Added agenda DOM cleanup on `openMeetingRoom` re-entry

### Unit Tests (+33)
- `_parse_agenda_items`: 13 tests (numbered/bullet/plain lists, edge cases)
- `get_ceo_meeting_queue`: 2 tests (missing → None, present → Queue)
- `_run_discussion_round`: 5 tests (token-grab, no-consecutive, CEO interjection)
- `_parse_hold_reason`: 7 tests (None/empty, multi-pair, whitespace, edge cases)
- `POST /api/rooms/{id}/chat`: 6 tests (validation, persist+broadcast, queue injection)

## Test plan
- [x] All 1998 tests pass (was 1965, +33 new)
- [ ] HR copy hire: fill CV JSON → click Hire → should work
- [ ] CEO inbox: reply to CEO_REQUEST → agent responds in ChatPanel → Complete → parent task resumes
- [ ] Meeting room: click booked room → CEO input visible → send message → appears in chat + agents respond
- [ ] Structured agenda: pull_meeting with multi-item agenda → items discussed sequentially with checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)