### PR TITLE
feat: merge Q&A into task flow with simple mode

### DIFF
--- a/docs/superpowers/plans/2026-03-20-merge-qa-into-task.md
+++ b/docs/superpowers/plans/2026-03-20-merge-qa-into-task.md
@@ -1,0 +1,565 @@
+# Merge Q&A into Task Flow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the bare-LLM Q&A endpoint with EA agent dispatch, adding a `mode` field to TaskTree that controls dispatch restrictions and retrospective behavior.
+
+**Architecture:** Add `mode: "simple"|"standard"` to TaskTree. Q&A becomes `ceo_submit_task(mode="simple")`. In simple mode, EA dispatch skips O-level restriction and cleanup skips retrospective.
+
+**Tech Stack:** Python (FastAPI, LangChain), vanilla JS frontend, YAML persistence
+
+**Spec:** `docs/superpowers/specs/2026-03-20-merge-qa-into-task-design.md`
+
+**Note:** Spec says mode should flow through `project.yaml` metadata. This plan simplifies: `mode` goes directly from request body to `TaskTree(mode=mode)` in `ceo_submit_task`. No project.yaml indirection needed since the tree is created in the same function.
+
+---
+
+### Task 1: Add `mode` field to TaskTree
+
+**Files:**
+- Modify: `src/onemancompany/core/task_tree.py:214-227` (TaskTree.__init__)
+- Modify: `src/onemancompany/core/task_tree.py:395-427` (save/load)
+- Test: `tests/unit/core/test_task_tree.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/unit/core/test_task_tree.py`:
+
+```python
+class TestTaskTreeMode:
+    def test_default_mode_is_standard(self):
+        tree = TaskTree(project_id="p1")
+        assert tree.mode == "standard"
+
+    def test_mode_set_on_init(self):
+        tree = TaskTree(project_id="p1", mode="simple")
+        assert tree.mode == "simple"
+
+    def test_mode_persisted_in_save(self, tmp_path):
+        tree = TaskTree(project_id="p1", mode="simple")
+        root = tree.create_root(employee_id="00001", description="test")
+        root.set_status(TaskPhase.PROCESSING)
+        tree.save(tmp_path / "tree.yaml")
+        loaded = TaskTree.load(tmp_path / "tree.yaml")
+        assert loaded.mode == "simple"
+
+    def test_load_without_mode_defaults_to_standard(self, tmp_path):
+        """Backward compat: old trees without mode field default to standard."""
+        tree = TaskTree(project_id="p1")
+        root = tree.create_root(employee_id="00001", description="test")
+        root.set_status(TaskPhase.PROCESSING)
+        tree.save(tmp_path / "tree.yaml")
+        # Manually strip mode from YAML to simulate old file
+        import yaml
+        data = yaml.safe_load((tmp_path / "tree.yaml").read_text())
+        data.pop("mode", None)
+        (tmp_path / "tree.yaml").write_text(yaml.dump(data, allow_unicode=True))
+        loaded = TaskTree.load(tmp_path / "tree.yaml")
+        assert loaded.mode == "standard"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/unit/core/test_task_tree.py::TestTaskTreeMode -v`
+Expected: FAIL — `__init__() got an unexpected keyword argument 'mode'`
+
+- [ ] **Step 3: Implement mode field**
+
+In `task_tree.py`, modify `TaskTree.__init__`:
+```python
+def __init__(self, project_id: str, mode: str = "standard") -> None:
+    self.project_id = project_id
+    self.mode = mode
+    self.root_id: str = ""
+    self._nodes: dict[str, TaskNode] = {}
+    self.current_branch: int = 0
+```
+
+In `save()`, add `mode` to the data dict:
+```python
+data = {
+    "project_id": self.project_id,
+    "root_id": self.root_id,
+    "current_branch": self.current_branch,
+    "mode": self.mode,
+    "nodes": [n.to_dict() for n in nodes_snapshot],
+}
+```
+
+In `load()`, read `mode` with default:
+```python
+tree.current_branch = data.get("current_branch", 0)
+tree.mode = data.get("mode", "standard")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/core/test_task_tree.py::TestTaskTreeMode -v`
+Expected: 4 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/onemancompany/core/task_tree.py tests/unit/core/test_task_tree.py
+git commit -m "feat: add mode field to TaskTree (simple/standard)"
+```
+
+---
+
+### Task 2: Conditional EA dispatch restriction
+
+**Files:**
+- Modify: `src/onemancompany/agents/tree_tools.py:172-187` (dispatch_child EA check)
+- Test: `tests/unit/agents/test_tree_tools.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/unit/agents/test_tree_tools.py`, in `TestEADispatchConstraint`:
+
+```python
+def test_ea_can_dispatch_to_regular_employee_in_simple_mode(self):
+    """EA can dispatch to non-O-level when tree mode is simple."""
+    from onemancompany.agents.tree_tools import dispatch_child
+
+    tree = _make_tree_with_root(employee_id="00004")
+    tree.mode = "simple"
+    root_id = tree.root_id
+
+    vessel = _make_vessel_and_task()
+    tok_v, tok_t = _set_context(vessel, root_id)
+
+    mock_em = _make_mock_em(root_id)
+
+    try:
+        with (
+            patch("onemancompany.agents.tree_tools._load_tree", return_value=tree),
+            patch("onemancompany.agents.tree_tools._save_tree"),
+            patch("onemancompany.core.store.load_employee", return_value={"id": "00006", "name": "Test"}),
+            patch("onemancompany.core.vessel.employee_manager", mock_em),
+        ):
+            result = dispatch_child.invoke({
+                "employee_id": "00006",
+                "description": "do coding",
+                "acceptance_criteria": ["done"],
+            })
+
+        assert result["status"] == "dispatched"
+    finally:
+        _reset_context(tok_v, tok_t)
+
+def test_ea_still_restricted_in_standard_mode(self):
+    """EA cannot dispatch to non-O-level when tree mode is standard (default)."""
+    from onemancompany.agents.tree_tools import dispatch_child
+
+    tree = _make_tree_with_root(employee_id="00004")
+    tree.mode = "standard"
+    root_id = tree.root_id
+
+    vessel = _make_vessel_and_task()
+    tok_v, tok_t = _set_context(vessel, root_id)
+
+    mock_em = _make_mock_em(root_id)
+
+    try:
+        with (
+            patch("onemancompany.agents.tree_tools._load_tree", return_value=tree),
+            patch("onemancompany.agents.tree_tools._save_tree"),
+            patch("onemancompany.core.store.load_employee", return_value={"id": "00006", "name": "Test"}),
+            patch("onemancompany.core.vessel.employee_manager", mock_em),
+        ):
+            result = dispatch_child.invoke({
+                "employee_id": "00006",
+                "description": "do coding",
+                "acceptance_criteria": ["done"],
+            })
+
+        assert result["status"] == "error"
+    finally:
+        _reset_context(tok_v, tok_t)
+
+def test_ea_cannot_dispatch_to_self(self):
+    """EA cannot dispatch to itself regardless of mode."""
+    from onemancompany.agents.tree_tools import dispatch_child
+
+    tree = _make_tree_with_root(employee_id="00004")
+    tree.mode = "simple"
+    root_id = tree.root_id
+
+    vessel = _make_vessel_and_task()
+    tok_v, tok_t = _set_context(vessel, root_id)
+
+    mock_em = _make_mock_em(root_id)
+
+    try:
+        with (
+            patch("onemancompany.agents.tree_tools._load_tree", return_value=tree),
+            patch("onemancompany.agents.tree_tools._save_tree"),
+            patch("onemancompany.core.store.load_employee", return_value={"id": "00004", "name": "EA"}),
+            patch("onemancompany.core.vessel.employee_manager", mock_em),
+        ):
+            result = dispatch_child.invoke({
+                "employee_id": "00004",
+                "description": "self task",
+                "acceptance_criteria": ["done"],
+            })
+
+        assert result["status"] == "error"
+        assert "self" in result["message"].lower() or "cannot" in result["message"].lower()
+    finally:
+        _reset_context(tok_v, tok_t)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/unit/agents/test_tree_tools.py::TestEADispatchConstraint::test_ea_can_dispatch_to_regular_employee_in_simple_mode tests/unit/agents/test_tree_tools.py::TestEADispatchConstraint::test_ea_still_restricted_in_standard_mode tests/unit/agents/test_tree_tools.py::TestEADispatchConstraint::test_ea_cannot_dispatch_to_self -v`
+Expected: first test FAIL (dispatch blocked), second PASS (already works), third FAIL (no self-dispatch guard)
+
+- [ ] **Step 3: Implement conditional restriction**
+
+In `tree_tools.py`, replace lines 172-187:
+```python
+# EA can only dispatch to O-level executives (unless tree mode is "simple")
+from onemancompany.core.config import EA_ID, HR_ID, COO_ID, CSO_ID
+if current_node.employee_id == EA_ID:
+    # Self-dispatch guard — always blocked
+    if employee_id == EA_ID:
+        return {
+            "status": "error",
+            "message": "EA cannot dispatch tasks to itself. Please dispatch to an appropriate team member.",
+        }
+    # O-level restriction — only in standard mode
+    if tree.mode != "simple":
+        allowed_targets = {HR_ID, COO_ID, CSO_ID}
+        if employee_id not in allowed_targets:
+            suggestion = f"COO({COO_ID})"
+            return {
+                "status": "error",
+                "message": (
+                    f"EA cannot directly dispatch tasks to {employee_id}. "
+                    f"Please dispatch_child to the corresponding O-level executive instead: HR({HR_ID}), COO({COO_ID}), CSO({CSO_ID}). "
+                    f"Hint: for development/design/operations tasks, dispatch to {suggestion} to organize team execution. "
+                    f"Please immediately re-call dispatch_child with the correct employee_id."
+                ),
+            }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/agents/test_tree_tools.py::TestEADispatchConstraint -v`
+Expected: ALL PASS (existing + new tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/onemancompany/agents/tree_tools.py tests/unit/agents/test_tree_tools.py
+git commit -m "feat: EA dispatch unrestricted in simple mode, add self-dispatch guard"
+```
+
+---
+
+### Task 3: Skip retrospective in simple mode
+
+**Files:**
+- Modify: `src/onemancompany/core/vessel.py:2120-2126` (_request_ceo_confirmation)
+- Test: `tests/unit/core/test_agent_loop.py`
+
+- [ ] **Step 1: Write failing test**
+
+Follow the existing pattern in `TestRootNodeCompletion` (line 1896). Add to `test_agent_loop.py`:
+
+```python
+class TestSimpleModeSkipsRetrospective:
+    @pytest.mark.asyncio
+    @patch("onemancompany.core.vessel.company_state")
+    @patch("onemancompany.core.vessel.event_bus")
+    async def test_simple_mode_skips_retrospective(self, mock_bus, mock_state):
+        """When tree.mode == 'simple', _request_ceo_confirmation passes run_retrospective=False."""
+        mock_bus.publish = AsyncMock()
+        mock_state.employees = {}
+
+        mgr = EmployeeManager()
+
+        tree = TaskTree(project_id="p1", mode="simple")
+        node = MagicMock()
+        node.node_type = NodeType.TASK
+        node.description_preview = "test task"
+        node.id = "n1"
+        node.project_dir = "/tmp/proj"
+        node.is_ceo_node = False
+
+        entry = ScheduleEntry(node_id="n1", tree_path="/tmp/proj/task_tree.yaml")
+
+        with (
+            patch.object(mgr, "_full_cleanup", new_callable=AsyncMock) as mock_cleanup,
+            patch("onemancompany.core.vessel._store") as mock_store,
+        ):
+            mock_store.load_employee.return_value = {"name": "Test"}
+            tree._nodes = {"n1": node}
+            tree.get_children = MagicMock(return_value=[])
+
+            await mgr._request_ceo_confirmation("00006", node, tree, entry, "p1")
+
+            mock_cleanup.assert_called_once()
+            _, kwargs = mock_cleanup.call_args
+            assert kwargs["run_retrospective"] is False
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.core.vessel.company_state")
+    @patch("onemancompany.core.vessel.event_bus")
+    async def test_standard_mode_runs_retrospective(self, mock_bus, mock_state):
+        """When tree.mode == 'standard' and not system node, retrospective runs."""
+        mock_bus.publish = AsyncMock()
+        mock_state.employees = {}
+
+        mgr = EmployeeManager()
+
+        tree = TaskTree(project_id="p1", mode="standard")
+        node = MagicMock()
+        node.node_type = NodeType.TASK
+        node.description_preview = "test task"
+        node.id = "n1"
+        node.project_dir = "/tmp/proj"
+        node.is_ceo_node = False
+
+        entry = ScheduleEntry(node_id="n1", tree_path="/tmp/proj/task_tree.yaml")
+
+        with (
+            patch.object(mgr, "_full_cleanup", new_callable=AsyncMock) as mock_cleanup,
+            patch("onemancompany.core.vessel._store") as mock_store,
+        ):
+            mock_store.load_employee.return_value = {"name": "Test"}
+            tree._nodes = {"n1": node}
+            tree.get_children = MagicMock(return_value=[])
+
+            await mgr._request_ceo_confirmation("00006", node, tree, entry, "p1")
+
+            mock_cleanup.assert_called_once()
+            _, kwargs = mock_cleanup.call_args
+            assert kwargs["run_retrospective"] is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/unit/core/test_agent_loop.py::TestSimpleModeSkipsRetrospective -v`
+Expected: FAIL — simple mode still passes `run_retrospective=True`
+
+- [ ] **Step 3: Implement**
+
+In `vessel.py`, modify lines 2120-2126:
+```python
+# Auto-approve: proceed directly with cleanup
+is_system_node = node.node_type in SYSTEM_NODE_TYPES
+run_retro = not is_system_node and tree.mode != "simple"
+await self._full_cleanup(
+    employee_id, node, agent_error=False,
+    project_id=project_id,
+    run_retrospective=run_retro,
+)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/core/test_agent_loop.py::TestSimpleModeSkipsRetrospective -v`
+Expected: 2 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/onemancompany/core/vessel.py tests/unit/core/test_agent_loop.py
+git commit -m "feat: skip retrospective in simple mode"
+```
+
+---
+
+### Task 4: Modify `ceo_submit_task` to accept mode, remove `ceo_qa`
+
+**Files:**
+- Modify: `src/onemancompany/api/routes.py:476-537` (delete ceo_qa)
+- Modify: `src/onemancompany/api/routes.py:540-655` (ceo_submit_task add mode)
+- Modify: `src/onemancompany/core/models.py` (remove CEO_QA)
+- Test: `tests/unit/api/test_routes.py`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/unit/api/test_routes.py`:
+
+Follow the existing `TestCeoSubmitTask.test_routes_to_ea_initializes_task_tree` pattern (line 324) which uses `_store_patches(state)` and patches at source module level for deferred imports:
+
+```python
+class TestCeoTaskMode:
+    async def test_submit_task_default_mode_standard(self):
+        """When no mode specified, tree should have mode='standard'."""
+        state = _make_state()
+        bus = EventBus()
+        mock_save_tree = MagicMock()
+
+        with patch("onemancompany.api.routes.company_state", state), \
+             _store_patches(state), \
+             patch("onemancompany.api.routes.event_bus", bus), \
+             patch("onemancompany.core.agent_loop.get_agent_loop", return_value=MagicMock()), \
+             patch("onemancompany.core.project_archive.async_create_project_from_task", new_callable=AsyncMock, return_value=("proj1", "iter_001")), \
+             patch("onemancompany.core.project_archive.get_project_dir", return_value="/tmp/proj"), \
+             patch("onemancompany.core.vessel._save_project_tree", mock_save_tree), \
+             patch("onemancompany.core.vessel.employee_manager", MagicMock()):
+            app = _make_test_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/ceo/task", json={"task": "hello"})
+
+        assert resp.status_code == 200
+        mock_save_tree.assert_called_once()
+        _, saved_tree = mock_save_tree.call_args[0]
+        assert saved_tree.mode == "standard"
+
+    async def test_submit_task_simple_mode(self):
+        """When mode='simple', tree should have mode='simple'."""
+        state = _make_state()
+        bus = EventBus()
+        mock_save_tree = MagicMock()
+
+        with patch("onemancompany.api.routes.company_state", state), \
+             _store_patches(state), \
+             patch("onemancompany.api.routes.event_bus", bus), \
+             patch("onemancompany.core.agent_loop.get_agent_loop", return_value=MagicMock()), \
+             patch("onemancompany.core.project_archive.async_create_project_from_task", new_callable=AsyncMock, return_value=("proj1", "iter_001")), \
+             patch("onemancompany.core.project_archive.get_project_dir", return_value="/tmp/proj"), \
+             patch("onemancompany.core.vessel._save_project_tree", mock_save_tree), \
+             patch("onemancompany.core.vessel.employee_manager", MagicMock()):
+            app = _make_test_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/ceo/task", json={"task": "hello", "mode": "simple"})
+
+        assert resp.status_code == 200
+        mock_save_tree.assert_called_once()
+        _, saved_tree = mock_save_tree.call_args[0]
+        assert saved_tree.mode == "simple"
+
+    async def test_qa_endpoint_removed(self):
+        """The /api/ceo/qa endpoint should no longer exist."""
+        with patch("onemancompany.api.routes.company_state", _make_state()), \
+             patch("onemancompany.api.routes.event_bus", EventBus()):
+            app = _make_test_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/ceo/qa", json={"question": "hello"})
+        # 404 or 405 — endpoint gone
+        assert resp.status_code in (404, 405)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/unit/api/test_routes.py::TestCeoTaskMode -v`
+Expected: first two FAIL (no mode handling), third FAIL (endpoint still exists)
+
+- [ ] **Step 3: Implement**
+
+In `routes.py`:
+
+1. **Delete** the entire `ceo_qa` function (lines 476-537)
+
+2. **Modify** `ceo_submit_task` — read mode from body and pass to TaskTree:
+```python
+mode = body.get("mode", "standard")
+if mode not in ("simple", "standard"):
+    mode = "standard"
+```
+
+Then when creating TaskTree (line 628):
+```python
+tree = TaskTree(project_id=ctx_id, mode=mode)
+```
+
+3. **In `models.py`**, remove `CEO_QA = "ceo_qa"` from EventType enum.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/api/test_routes.py::TestCeoTaskMode -v`
+Expected: 3 PASS
+
+- [ ] **Step 5: Run full test suite to check nothing broke**
+
+Run: `.venv/bin/python -m pytest tests/ -x -q --tb=short`
+Expected: All pass (any test referencing `ceo_qa` or `CEO_QA` will need updating)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/onemancompany/api/routes.py src/onemancompany/core/models.py tests/unit/api/test_routes.py
+git commit -m "feat: ceo_submit_task accepts mode param, remove ceo_qa endpoint"
+```
+
+---
+
+### Task 5: Frontend — remove Q&A, add mode toggle
+
+**Files:**
+- Modify: `frontend/index.html:88-91` (remove Q&A option, add mode toggle)
+- Modify: `frontend/app.js:5944-5967` (remove Q&A branch, add mode to request)
+- Modify: `frontend/app.js:4917` (remove qa cost label)
+
+- [ ] **Step 1: Remove Q&A option from project selector**
+
+In `frontend/index.html`, replace the `__qa__` option (line 90) with a simple mode checkbox or toggle. Add after the project selector:
+```html
+<label class="mode-toggle" title="Simple mode: EA dispatches directly to employees, no retrospective">
+  <input type="checkbox" id="simple-mode-toggle" /> Simple
+</label>
+```
+
+- [ ] **Step 2: Remove Q&A branch in app.js**
+
+In `frontend/app.js`, delete the `if (projectId === '__qa__')` block (lines 5944-5967).
+
+Add mode to the request body (around line 5969):
+```javascript
+const reqBody = { task, attachments };
+if (projectId) reqBody.project_id = projectId;
+const simpleToggle = document.getElementById('simple-mode-toggle');
+if (simpleToggle && simpleToggle.checked) reqBody.mode = 'simple';
+```
+
+- [ ] **Step 3: Remove qa cost label**
+
+In `frontend/app.js` line 4917, remove `qa:'CEO Q&A',` from `catLabels`.
+
+- [ ] **Step 4: Manual test in browser**
+
+1. Open frontend, verify no Q&A option in project selector
+2. Check "Simple" toggle → submit task → verify request body has `mode: "simple"`
+3. Uncheck → submit → verify no mode field (defaults to standard)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/index.html frontend/app.js
+git commit -m "feat: replace Q&A mode with simple mode toggle in frontend"
+```
+
+---
+
+### Task 6: Full test suite verification and cleanup
+
+**Files:**
+- Any test files referencing `ceo_qa` or `CEO_QA`
+
+- [ ] **Step 1: Find and fix broken references**
+
+Run: `grep -rn "ceo_qa\|CEO_QA\|__qa__" tests/ src/ frontend/`
+
+Update any tests, WebSocket handlers, or frontend code that reference the removed endpoint, event type, or Q&A option value.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `.venv/bin/python -m pytest tests/ -x -q --tb=short`
+Expected: All pass
+
+- [ ] **Step 3: Commit fixes if any**
+
+```bash
+git commit -am "fix: update tests for Q&A removal"
+```
+
+- [ ] **Step 4: Create PR**
+
+```bash
+git push origin investigate/shared-prompt -u
+gh pr create --title "feat: merge Q&A into task flow with simple mode" --body "..."
+```

--- a/docs/superpowers/specs/2026-03-20-merge-qa-into-task-design.md
+++ b/docs/superpowers/specs/2026-03-20-merge-qa-into-task-design.md
@@ -11,53 +11,66 @@ Q&A mode (`/api/ceo/qa`) is a bare LLM call — no EA agent, no tools, no task t
 
 ### TaskTree `mode` Field
 
-Add `mode: Literal["simple", "standard"]` to the TaskTree data model, defaulting to `"standard"`.
+Add `mode: Literal["simple", "standard"]` to the TaskTree data model (in `task_tree.py`), defaulting to `"standard"`.
 
 - **standard**: Current behavior — EA restricted to O-level dispatch, retrospective on completion
 - **simple**: EA can dispatch to any employee directly, no retrospective on completion
 
 The mode is set at project creation time and persisted to disk with the tree.
 
+**Serialization**: `TaskTree.save()` and `TaskTree.load()` must include `mode`. Existing persisted trees without `mode` default to `"standard"` for backward compatibility.
+
+### Mode Threading: HTTP Request → TaskTree
+
+The `mode` value flows through the system as follows:
+
+1. `POST /api/ceo/task` receives `mode` in request body
+2. `ceo_submit_task` writes `mode` into `project.yaml` metadata (alongside project_id, name, etc.)
+3. When TaskTree is initialized for the EA node, it reads `mode` from `project.yaml`
+4. TaskTree stores `mode` as instance field, persisted via `save()`
+
 ### Endpoint Changes
 
 **Delete** `POST /api/ceo/qa` — remove entirely.
 
+**Delete** `EventType.CEO_QA` from `models.py` — dead code after endpoint removal.
+
 **Modify** `POST /api/ceo/task`:
 - Accept optional `mode` field in request body (default: `"standard"`)
-- Pass mode through to `TaskTree` initialization
+- Pass mode through to project metadata and TaskTree initialization
 - All other logic unchanged — project creation, EA dispatch, etc.
 
 ### EA Dispatch Restriction
 
 **File**: `src/onemancompany/agents/tree_tools.py`
 
-Current logic in `dispatch_child`:
-```python
-if current_node.employee_id == EA_ID:
-    if target_id not in {HR_ID, COO_ID, CSO_ID}:
-        return {"status": "error", "message": "EA can only dispatch to O-level"}
-```
+Current logic in `dispatch_child` checks EA dispatches against an `allowed_targets` set of O-level IDs. Change to: skip this check when `tree.mode == "simple"`. The tree object is already loaded at this point.
 
-Change to:
-```python
-if current_node.employee_id == EA_ID and tree.mode == "standard":
-    if target_id not in {HR_ID, COO_ID, CSO_ID}:
-        return {"status": "error", "message": "EA can only dispatch to O-level"}
-```
-
-When `mode == "simple"`, the check is skipped entirely.
+Add a self-dispatch guard: EA cannot dispatch to itself regardless of mode.
 
 ### Skip Retrospective
 
 **File**: `src/onemancompany/core/vessel.py`
 
-In `_full_cleanup()`, read the tree's mode. If `mode == "simple"`, pass `run_retrospective=False`.
+The retrospective flag is set at the **call site** in `_request_ceo_confirmation` (not inside `_full_cleanup` itself). Change:
+
+```python
+# Before
+run_retrospective = not is_system_node
+# After
+run_retrospective = not is_system_node and tree.mode != "simple"
+```
 
 ### Frontend
 
-- Remove Q&A input/button — CEO console has only one input that submits tasks
+- Remove Q&A input/button and `<option value="__qa__">` — CEO console has only one input that submits tasks
 - Add a toggle or similar control for CEO to choose simple vs standard mode before submitting
+- Remove `qa` category label from cost dashboard `catLabels`
 - Task progress display unchanged — simple mode tasks appear in the same console feed
+
+### Performance Tradeoff
+
+Simple mode queries that were previously bare LLM calls (~1s) will now create full projects with disk persistence and EA agent invocation. This is intentionally accepted — the benefit of unified audit trail, tool access, and real task dispatch outweighs the latency increase.
 
 ### What Stays the Same
 
@@ -70,13 +83,14 @@ In `_full_cleanup()`, read the tree's mode. If `mode == "simple"`, pass `run_ret
 
 | File | Change |
 |------|--------|
-| `src/onemancompany/core/task_lifecycle.py` | Add `mode` field to TaskTree |
-| `src/onemancompany/agents/tree_tools.py` | Conditional O-level restriction based on tree mode |
-| `src/onemancompany/core/vessel.py` | Skip retrospective when mode=simple |
-| `src/onemancompany/api/routes.py` | Remove `ceo_qa`, add `mode` param to `ceo_submit_task` |
-| `frontend/app.js` | Remove Q&A UI, add mode toggle to task submit |
+| `src/onemancompany/core/task_tree.py` | Add `mode` field to TaskTree, update `save()`/`load()` |
+| `src/onemancompany/agents/tree_tools.py` | Conditional O-level restriction based on tree mode; self-dispatch guard |
+| `src/onemancompany/core/vessel.py` | Skip retrospective when mode=simple (at `_request_ceo_confirmation` call site) |
+| `src/onemancompany/api/routes.py` | Remove `ceo_qa`, add `mode` param to `ceo_submit_task`, thread to project.yaml |
+| `src/onemancompany/core/models.py` | Remove `EventType.CEO_QA` |
+| `frontend/app.js` | Remove Q&A UI, add mode toggle, remove `qa` cost label |
 | `frontend/index.html` | Remove Q&A related DOM elements |
-| Tests | New tests for mode field, conditional dispatch, skip retro |
+| Tests | New tests for mode field, conditional dispatch, skip retro, self-dispatch guard |
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-03-20-merge-qa-into-task-design.md
+++ b/docs/superpowers/specs/2026-03-20-merge-qa-into-task-design.md
@@ -1,0 +1,85 @@
+# Merge Q&A into Task Flow with Simple Mode
+
+## Problem
+
+Q&A mode (`/api/ceo/qa`) is a bare LLM call — no EA agent, no tools, no task tree, no project. This means:
+- Q&A answers can't trigger real work (dispatch tasks, use tools)
+- No audit trail for Q&A interactions
+- Two separate code paths for CEO input
+
+## Design
+
+### TaskTree `mode` Field
+
+Add `mode: Literal["simple", "standard"]` to the TaskTree data model, defaulting to `"standard"`.
+
+- **standard**: Current behavior — EA restricted to O-level dispatch, retrospective on completion
+- **simple**: EA can dispatch to any employee directly, no retrospective on completion
+
+The mode is set at project creation time and persisted to disk with the tree.
+
+### Endpoint Changes
+
+**Delete** `POST /api/ceo/qa` — remove entirely.
+
+**Modify** `POST /api/ceo/task`:
+- Accept optional `mode` field in request body (default: `"standard"`)
+- Pass mode through to `TaskTree` initialization
+- All other logic unchanged — project creation, EA dispatch, etc.
+
+### EA Dispatch Restriction
+
+**File**: `src/onemancompany/agents/tree_tools.py`
+
+Current logic in `dispatch_child`:
+```python
+if current_node.employee_id == EA_ID:
+    if target_id not in {HR_ID, COO_ID, CSO_ID}:
+        return {"status": "error", "message": "EA can only dispatch to O-level"}
+```
+
+Change to:
+```python
+if current_node.employee_id == EA_ID and tree.mode == "standard":
+    if target_id not in {HR_ID, COO_ID, CSO_ID}:
+        return {"status": "error", "message": "EA can only dispatch to O-level"}
+```
+
+When `mode == "simple"`, the check is skipped entirely.
+
+### Skip Retrospective
+
+**File**: `src/onemancompany/core/vessel.py`
+
+In `_full_cleanup()`, read the tree's mode. If `mode == "simple"`, pass `run_retrospective=False`.
+
+### Frontend
+
+- Remove Q&A input/button — CEO console has only one input that submits tasks
+- Add a toggle or similar control for CEO to choose simple vs standard mode before submitting
+- Task progress display unchanged — simple mode tasks appear in the same console feed
+
+### What Stays the Same
+
+- EA system prompt unchanged (routing table remains as guidance, code enforces)
+- Task lifecycle state machine unchanged
+- Project creation, task tree persistence, all audit trails — same for both modes
+- Standard mode behavior is 100% unchanged
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/onemancompany/core/task_lifecycle.py` | Add `mode` field to TaskTree |
+| `src/onemancompany/agents/tree_tools.py` | Conditional O-level restriction based on tree mode |
+| `src/onemancompany/core/vessel.py` | Skip retrospective when mode=simple |
+| `src/onemancompany/api/routes.py` | Remove `ceo_qa`, add `mode` param to `ceo_submit_task` |
+| `frontend/app.js` | Remove Q&A UI, add mode toggle to task submit |
+| `frontend/index.html` | Remove Q&A related DOM elements |
+| Tests | New tests for mode field, conditional dispatch, skip retro |
+
+## Out of Scope
+
+- Changing EA system prompt
+- Changing task lifecycle states
+- Any changes to standard mode behavior

--- a/docs/superpowers/specs/2026-03-20-merge-qa-into-task-design.md
+++ b/docs/superpowers/specs/2026-03-20-merge-qa-into-task-design.md
@@ -25,9 +25,10 @@ The mode is set at project creation time and persisted to disk with the tree.
 The `mode` value flows through the system as follows:
 
 1. `POST /api/ceo/task` receives `mode` in request body
-2. `ceo_submit_task` writes `mode` into `project.yaml` metadata (alongside project_id, name, etc.)
-3. When TaskTree is initialized for the EA node, it reads `mode` from `project.yaml`
-4. TaskTree stores `mode` as instance field, persisted via `save()`
+2. `ceo_submit_task` passes `mode` directly to `TaskTree(project_id=ctx_id, mode=mode)`
+3. TaskTree stores `mode` as instance field, persisted to `task_tree.yaml` via `save()`
+
+Note: `mode` is NOT stored in `project.yaml` — the TaskTree is constructed in the same function that reads the request, so no intermediate metadata step is needed.
 
 ### Endpoint Changes
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4914,7 +4914,7 @@ class AppController {
       // Section 2: Overhead by category
       const cats = oh.by_category || {};
       if (Object.keys(cats).length) {
-        const catLabels = {qa:'CEO Q&A', inquiry:'Inquiry', oneonone:'1-on-1', meeting:'Meeting', routine:'Routine', interview:'Interview', agent_task:'Agent Task', history_compress:'History Compress', completion_check:'Completion Check', nickname_gen:'Nickname Gen', remote_worker:'Remote Worker'};
+        const catLabels = {inquiry:'Inquiry', oneonone:'1-on-1', meeting:'Meeting', routine:'Routine', interview:'Interview', agent_task:'Agent Task', history_compress:'History Compress', completion_check:'Completion Check', nickname_gen:'Nickname Gen', remote_worker:'Remote Worker'};
         costHtml += `
           <div class="dash-section">
             <div class="dash-title">\u{1F4B0} Overhead by Category</div>
@@ -5940,34 +5940,10 @@ class AppController {
       attachments = await this._uploadTaskFiles();
     }
 
-    // Q&A mode: lightweight ask, no project creation
-    if (projectId === '__qa__') {
-      this.logEntry('CEO', task, 'ceo');
-      fetch('/api/ceo/qa', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ question: task, attachments }),
-      })
-        .then(r => r.json())
-        .then(data => {
-          if (data.error) {
-            this.logEntry('SYSTEM', `Q&A error: ${data.error}`, 'system');
-          } else {
-            this.logEntry('AI', data.answer, 'agent');
-          }
-        })
-        .catch(err => {
-          this.logEntry('SYSTEM', `Q&A failed: ${err.message}`, 'system');
-        })
-        .finally(() => {
-          setTimeout(() => { submitBtn.disabled = false; }, 2000);
-        });
-      input.value = '';
-      return;
-    }
-
     const reqBody = { task, attachments };
     if (projectId) reqBody.project_id = projectId;
+    const simpleToggle = document.getElementById('simple-mode-toggle');
+    if (simpleToggle && simpleToggle.checked) reqBody.mode = 'simple';
 
     fetch('/api/ceo/task', {
       method: 'POST',

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -87,9 +87,11 @@
           <div class="ceo-project-selector">
             <select id="project-select">
               <option value="">&#128203; New Task</option>
-              <option value="__qa__">&#128172; Q&amp;A Mode</option>
             </select>
           </div>
+          <label class="mode-toggle" title="Simple mode: EA dispatches directly to employees, no retrospective">
+            <input type="checkbox" id="simple-mode-toggle" /> Simple
+          </label>
           <div class="ceo-input-area">
             <textarea id="task-input"
                       placeholder="Enter a task or objective...&#10;e.g. 'Hire a Python engineer'&#10;     'Add a code review tool'&#10;     'Review all employee performance'"

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5099,3 +5099,14 @@ body {
     opacity: 1;
   }
 }
+
+.mode-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  color: #aaa;
+  cursor: pointer;
+  padding: 0 8px;
+}
+.mode-toggle input { cursor: pointer; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.475",
+  "version": "0.2.476",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.469",
+  "version": "0.2.470",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.466",
+  "version": "0.2.467",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.468",
+  "version": "0.2.469",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.473",
+  "version": "0.2.474",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.472",
+  "version": "0.2.473",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.474",
+  "version": "0.2.475",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.467",
+  "version": "0.2.468",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.470",
+  "version": "0.2.471",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.471",
+  "version": "0.2.472",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.468"
+version = "0.2.469"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.472"
+version = "0.2.473"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.467"
+version = "0.2.468"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.473"
+version = "0.2.474"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.469"
+version = "0.2.470"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.470"
+version = "0.2.471"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.475"
+version = "0.2.476"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.471"
+version = "0.2.472"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.474"
+version = "0.2.475"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.466"
+version = "0.2.467"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -169,22 +169,29 @@ def dispatch_child(
         if not current_node:
             return {"status": "error", "message": "Current task not found in task tree."}
 
-        # EA can only dispatch to O-level executives
+        # EA dispatch restrictions
         from onemancompany.core.config import EA_ID, HR_ID, COO_ID, CSO_ID
         if current_node.employee_id == EA_ID:
-            allowed_targets = {HR_ID, COO_ID, CSO_ID}
-            if employee_id not in allowed_targets:
-                # Suggest the correct O-level target based on common patterns
-                suggestion = f"COO({COO_ID})"  # default: most tasks are execution
+            # Self-dispatch guard — always blocked
+            if employee_id == EA_ID:
                 return {
                     "status": "error",
-                    "message": (
-                        f"EA cannot directly dispatch tasks to {employee_id}. "
-                        f"Please dispatch_child to the corresponding O-level executive instead: HR({HR_ID}), COO({COO_ID}), CSO({CSO_ID}). "
-                        f"Hint: for development/design/operations tasks, dispatch to {suggestion} to organize team execution. "
-                        f"Please immediately re-call dispatch_child with the correct employee_id."
-                    ),
+                    "message": "EA cannot dispatch tasks to itself. Please dispatch to an appropriate team member.",
                 }
+            # O-level restriction — only in standard mode
+            if tree.mode != "simple":
+                allowed_targets = {HR_ID, COO_ID, CSO_ID}
+                if employee_id not in allowed_targets:
+                    suggestion = f"COO({COO_ID})"
+                    return {
+                        "status": "error",
+                        "message": (
+                            f"EA cannot directly dispatch tasks to {employee_id}. "
+                            f"Please dispatch_child to the corresponding O-level executive instead: HR({HR_ID}), COO({COO_ID}), CSO({CSO_ID}). "
+                            f"Hint: for development/design/operations tasks, dispatch to {suggestion} to organize team execution. "
+                            f"Please immediately re-call dispatch_child with the correct employee_id."
+                        ),
+                    }
 
         # --- Circuit breaker: children count limit ---
         from onemancompany.core.config import MAX_CHILDREN_PER_NODE, MAX_TREE_DEPTH

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -473,70 +473,6 @@ async def _start_inquiry(task: str) -> dict:
     }
 
 
-@router.post("/api/ceo/qa")
-async def ceo_qa(body: dict) -> dict:
-    """CEO Q&A mode: direct LLM answer, no project creation."""
-    import base64
-    from pathlib import Path
-
-    from langchain_core.messages import HumanMessage, SystemMessage
-    from onemancompany.agents.base import make_llm
-
-    question = body.get("question", "")
-    attachments = body.get("attachments", [])
-    if not question:
-        return {"error": "Empty question"}
-
-    # Build multimodal content blocks for images, text descriptions for others
-    content_blocks: list = [{"type": "text", "text": question}]
-    for att in attachments:
-        att_path = att.get("path", "")
-        att_type = att.get("type", "file")
-        content_type = att.get("content_type", "")
-        if att_type == "image" and att_path:
-            try:
-                img_data = Path(att_path).read_bytes()
-                img_b64 = base64.b64encode(img_data).decode()
-                mime = content_type or "image/png"
-                content_blocks.append({
-                    "type": "image_url",
-                    "image_url": {"url": f"data:{mime};base64,{img_b64}"},
-                })
-            except Exception:
-                content_blocks.append({
-                    "type": "text",
-                    "text": f"\n[Attachment: {att.get('filename', 'file')} (path: {att_path})]",
-                })
-        elif att_path:
-            content_blocks.append({
-                "type": "text",
-                "text": f"\n[Attachment: {att.get('filename', 'file')} (saved at {att_path})]",
-            })
-
-    # Use multimodal content if there are image attachments, plain text otherwise
-    if len(content_blocks) > 1:
-        human_msg = HumanMessage(content=content_blocks)
-    else:
-        human_msg = HumanMessage(content=question)
-
-    llm = make_llm()
-    result = await tracked_ainvoke(llm, [
-        SystemMessage(content="You are the CEO's AI assistant. Answer questions concisely."),
-        human_msg,
-    ], category="qa")
-    answer = result.content
-
-    await event_bus.publish(
-        CompanyEvent(
-            type=EventType.CEO_QA,
-            payload={"question": question, "answer": answer},
-            agent="CEO",
-        )
-    )
-
-    return {"answer": answer}
-
-
 @router.post("/api/ceo/task")
 async def ceo_submit_task(body: dict) -> dict:
     """CEO submits a task, routed to the appropriate agent via persistent loop."""
@@ -556,6 +492,9 @@ async def ceo_submit_task(body: dict) -> dict:
     attachments = body.get("attachments", [])
     project_id = body.get("project_id", "")
     project_name = body.get("project_name", "")
+    mode = body.get("mode", "standard")
+    if mode not in ("simple", "standard"):
+        mode = "standard"
 
     company_state.ceo_tasks.append(task)
     await _store.append_activity({"type": "ceo_task", "task": task})
@@ -625,7 +564,7 @@ async def ceo_submit_task(body: dict) -> dict:
                 # Evict old tree from memory cache
                 evict_tree(tree_path)
 
-            tree = TaskTree(project_id=ctx_id)
+            tree = TaskTree(project_id=ctx_id, mode=mode)
             # CEO root node — records original prompt
             ceo_root = tree.create_root(employee_id=CEO_ID, description=task)
             ceo_root.node_type = NodeType.CEO_PROMPT

--- a/src/onemancompany/core/models.py
+++ b/src/onemancompany/core/models.py
@@ -91,7 +91,6 @@ class EventType(str, Enum):
     BACKEND_RESTART_SCHEDULED = "backend_restart_scheduled"
     CEO_TASK_SUBMITTED = "ceo_task_submitted"
     CEO_INBOX_UPDATED = "ceo_inbox_updated"
-    CEO_QA = "ceo_qa"
     CEO_REPORT = "ceo_report"
     AGENT_DONE = "agent_done"
     AGENT_LOG = "agent_log"

--- a/src/onemancompany/core/task_tree.py
+++ b/src/onemancompany/core/task_tree.py
@@ -19,6 +19,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+from typing import Literal
 
 import yaml
 from loguru import logger
@@ -214,7 +215,7 @@ class TaskNode:
 class TaskTree:
     """In-memory task tree with YAML persistence."""
 
-    def __init__(self, project_id: str, mode: str = "standard") -> None:
+    def __init__(self, project_id: str, mode: Literal["simple", "standard"] = "standard") -> None:
         self.project_id = project_id
         self.mode = mode
         self.root_id: str = ""

--- a/src/onemancompany/core/task_tree.py
+++ b/src/onemancompany/core/task_tree.py
@@ -214,8 +214,9 @@ class TaskNode:
 class TaskTree:
     """In-memory task tree with YAML persistence."""
 
-    def __init__(self, project_id: str) -> None:
+    def __init__(self, project_id: str, mode: str = "standard") -> None:
         self.project_id = project_id
+        self.mode = mode
         self.root_id: str = ""
         self._nodes: dict[str, TaskNode] = {}
         self.current_branch: int = 0
@@ -404,6 +405,7 @@ class TaskTree:
             "project_id": self.project_id,
             "root_id": self.root_id,
             "current_branch": self.current_branch,
+            "mode": self.mode,
             "nodes": [n.to_dict() for n in nodes_snapshot],
         }
         path.write_text(
@@ -417,6 +419,7 @@ class TaskTree:
         tree = cls(project_id=project_id or data.get("project_id", ""))
         tree.root_id = data.get("root_id", "")
         tree.current_branch = data.get("current_branch", 0)
+        tree.mode = data.get("mode", "standard")
         tree._source_dir = path.parent
         for nd in data.get("nodes", []):
             node = TaskNode.from_dict(nd)

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2119,10 +2119,11 @@ class EmployeeManager:
 
         # Auto-approve: proceed directly with cleanup
         is_system_node = node.node_type in SYSTEM_NODE_TYPES
+        run_retro = not is_system_node and tree.mode != "simple"
         await self._full_cleanup(
             employee_id, node, agent_error=False,
             project_id=project_id,
-            run_retrospective=not is_system_node,
+            run_retrospective=run_retro,
         )
 
     async def _full_cleanup(

--- a/tests/unit/agents/test_tree_tools.py
+++ b/tests/unit/agents/test_tree_tools.py
@@ -394,6 +394,96 @@ class TestEADispatchConstraint:
         finally:
             _reset_context(tok_v, tok_t)
 
+    def test_ea_can_dispatch_to_regular_employee_in_simple_mode(self):
+        """EA can dispatch to non-O-level when tree mode is simple."""
+        from onemancompany.agents.tree_tools import dispatch_child
+
+        tree = _make_tree_with_root(employee_id="00004")
+        tree.mode = "simple"
+        root_id = tree.root_id
+
+        vessel = _make_vessel_and_task()
+        tok_v, tok_t = _set_context(vessel, root_id)
+
+        mock_em = _make_mock_em(root_id)
+
+        try:
+            with (
+                patch("onemancompany.agents.tree_tools._load_tree", return_value=tree),
+                patch("onemancompany.agents.tree_tools._save_tree"),
+                patch("onemancompany.core.store.load_employee", return_value={"id": "00006", "name": "Test"}),
+                patch("onemancompany.core.vessel.employee_manager", mock_em),
+            ):
+                result = dispatch_child.invoke({
+                    "employee_id": "00006",
+                    "description": "do coding",
+                    "acceptance_criteria": ["done"],
+                })
+
+            assert result["status"] == "dispatched"
+        finally:
+            _reset_context(tok_v, tok_t)
+
+    def test_ea_still_restricted_in_standard_mode(self):
+        """EA cannot dispatch to non-O-level when tree mode is standard (default)."""
+        from onemancompany.agents.tree_tools import dispatch_child
+
+        tree = _make_tree_with_root(employee_id="00004")
+        tree.mode = "standard"
+        root_id = tree.root_id
+
+        vessel = _make_vessel_and_task()
+        tok_v, tok_t = _set_context(vessel, root_id)
+
+        mock_em = _make_mock_em(root_id)
+
+        try:
+            with (
+                patch("onemancompany.agents.tree_tools._load_tree", return_value=tree),
+                patch("onemancompany.agents.tree_tools._save_tree"),
+                patch("onemancompany.core.store.load_employee", return_value={"id": "00006", "name": "Test"}),
+                patch("onemancompany.core.vessel.employee_manager", mock_em),
+            ):
+                result = dispatch_child.invoke({
+                    "employee_id": "00006",
+                    "description": "do coding",
+                    "acceptance_criteria": ["done"],
+                })
+
+            assert result["status"] == "error"
+        finally:
+            _reset_context(tok_v, tok_t)
+
+    def test_ea_cannot_dispatch_to_self(self):
+        """EA cannot dispatch to itself regardless of mode."""
+        from onemancompany.agents.tree_tools import dispatch_child
+
+        tree = _make_tree_with_root(employee_id="00004")
+        tree.mode = "simple"
+        root_id = tree.root_id
+
+        vessel = _make_vessel_and_task()
+        tok_v, tok_t = _set_context(vessel, root_id)
+
+        mock_em = _make_mock_em(root_id)
+
+        try:
+            with (
+                patch("onemancompany.agents.tree_tools._load_tree", return_value=tree),
+                patch("onemancompany.agents.tree_tools._save_tree"),
+                patch("onemancompany.core.store.load_employee", return_value={"id": "00004", "name": "EA"}),
+                patch("onemancompany.core.vessel.employee_manager", mock_em),
+            ):
+                result = dispatch_child.invoke({
+                    "employee_id": "00004",
+                    "description": "self task",
+                    "acceptance_criteria": ["done"],
+                })
+
+            assert result["status"] == "error"
+        finally:
+            _reset_context(tok_v, tok_t)
+
     def test_non_ea_can_dispatch_to_anyone(self):
         """Non-EA employees (e.g. COO 00003) can dispatch to any employee."""
         from onemancompany.agents.tree_tools import dispatch_child

--- a/tests/unit/api/test_routes.py
+++ b/tests/unit/api/test_routes.py
@@ -3865,8 +3865,8 @@ class TestSalesSettleNotFound:
 
 
 class TestStartInquiry:
-    async def test_start_inquiry_via_ceo_qa(self):
-        """CEO QA that triggers inquiry — covers _start_inquiry."""
+    async def test_start_inquiry_via_ceo_task(self):
+        """CEO task that triggers inquiry — covers _start_inquiry."""
         emp_coo = _make_employee(id="00003", name="COO Agent", nickname="SomeNick")
         emp_hr = _make_employee(id="00002", name="HR Agent", nickname="HRNick")
         emp_cso = _make_employee(id="00005", name="CSO Agent", nickname="CSONick")

--- a/tests/unit/api/test_routes.py
+++ b/tests/unit/api/test_routes.py
@@ -1144,25 +1144,6 @@ class TestInquiryChat:
 
 
 # ---------------------------------------------------------------------------
-# POST /api/ceo/qa
-# ---------------------------------------------------------------------------
-
-
-class TestCeoQA:
-    async def test_empty_question(self):
-        state = _make_state()
-
-        with patch("onemancompany.api.routes.company_state", state), \
-             _store_patches(state), \
-             patch("onemancompany.api.routes.event_bus", EventBus()):
-            app = _make_test_app()
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                resp = await c.post("/api/ceo/qa", json={"question": ""})
-
-        assert resp.json()["error"] == "Empty question"
-
-
-# ---------------------------------------------------------------------------
 # 1-on-1 endpoints
 # ---------------------------------------------------------------------------
 
@@ -1288,32 +1269,6 @@ class TestEmployeeManifest:
 
         assert resp.status_code == 200
         assert resp.json()["id"] == "test"
-
-
-# ---------------------------------------------------------------------------
-# POST /api/ceo/qa — happy path
-# ---------------------------------------------------------------------------
-
-
-class TestCeoQAHappyPath:
-    async def test_qa_success(self):
-        state = _make_state()
-        bus = EventBus()
-
-        mock_result = MagicMock()
-        mock_result.content = "The answer is 42"
-
-        with patch("onemancompany.api.routes.company_state", state), \
-             _store_patches(state), \
-             patch("onemancompany.api.routes.event_bus", bus), \
-             patch("onemancompany.api.routes.tracked_ainvoke", new_callable=AsyncMock, return_value=mock_result), \
-             patch("onemancompany.agents.base.make_llm", return_value=MagicMock()):
-            app = _make_test_app()
-            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-                resp = await c.post("/api/ceo/qa", json={"question": "What is the meaning of life?"})
-
-        assert resp.status_code == 200
-        assert resp.json()["answer"] == "The answer is 42"
 
 
 # ---------------------------------------------------------------------------
@@ -7051,3 +7006,68 @@ class TestPostRoomChat:
                 resp = await client.post("/api/rooms/room-1/chat", json={"message": "Test"})
 
         assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# CEO task mode parameter & QA endpoint removal
+# ---------------------------------------------------------------------------
+
+
+class TestCeoTaskMode:
+    @pytest.mark.asyncio
+    async def test_submit_task_default_mode_standard(self):
+        """When no mode specified, tree should have mode='standard'."""
+        state = _make_state()
+        bus = EventBus()
+        mock_save_tree = MagicMock()
+
+        with patch("onemancompany.api.routes.company_state", state), \
+             _store_patches(state), \
+             patch("onemancompany.api.routes.event_bus", bus), \
+             patch("onemancompany.core.agent_loop.get_agent_loop", return_value=MagicMock()), \
+             patch("onemancompany.core.project_archive.async_create_project_from_task", new_callable=AsyncMock, return_value=("proj1", "iter_001")), \
+             patch("onemancompany.core.project_archive.get_project_dir", return_value="/tmp/proj"), \
+             patch("onemancompany.core.vessel._save_project_tree", mock_save_tree), \
+             patch("onemancompany.core.vessel.employee_manager", MagicMock()):
+            app = _make_test_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/ceo/task", json={"task": "hello"})
+
+        assert resp.status_code == 200
+        mock_save_tree.assert_called_once()
+        _, saved_tree = mock_save_tree.call_args[0]
+        assert saved_tree.mode == "standard"
+
+    @pytest.mark.asyncio
+    async def test_submit_task_simple_mode(self):
+        """When mode='simple', tree should have mode='simple'."""
+        state = _make_state()
+        bus = EventBus()
+        mock_save_tree = MagicMock()
+
+        with patch("onemancompany.api.routes.company_state", state), \
+             _store_patches(state), \
+             patch("onemancompany.api.routes.event_bus", bus), \
+             patch("onemancompany.core.agent_loop.get_agent_loop", return_value=MagicMock()), \
+             patch("onemancompany.core.project_archive.async_create_project_from_task", new_callable=AsyncMock, return_value=("proj1", "iter_001")), \
+             patch("onemancompany.core.project_archive.get_project_dir", return_value="/tmp/proj"), \
+             patch("onemancompany.core.vessel._save_project_tree", mock_save_tree), \
+             patch("onemancompany.core.vessel.employee_manager", MagicMock()):
+            app = _make_test_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/ceo/task", json={"task": "hello", "mode": "simple"})
+
+        assert resp.status_code == 200
+        mock_save_tree.assert_called_once()
+        _, saved_tree = mock_save_tree.call_args[0]
+        assert saved_tree.mode == "simple"
+
+    @pytest.mark.asyncio
+    async def test_qa_endpoint_removed(self):
+        """The /api/ceo/qa endpoint should no longer exist."""
+        with patch("onemancompany.api.routes.company_state", _make_state()), \
+             patch("onemancompany.api.routes.event_bus", EventBus()):
+            app = _make_test_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/ceo/qa", json={"question": "hello"})
+        assert resp.status_code in (404, 405)

--- a/tests/unit/core/test_agent_loop.py
+++ b/tests/unit/core/test_agent_loop.py
@@ -33,7 +33,7 @@ from onemancompany.core.agent_loop import (
     RETRY_DELAYS,
 )
 from onemancompany.core.task_tree import TaskNode, TaskTree
-from onemancompany.core.task_lifecycle import TaskPhase
+from onemancompany.core.task_lifecycle import NodeType, TaskPhase
 
 
 def _make_tree_entry(tmp_path, employee_id="emp01", description="Build widget",
@@ -2477,3 +2477,73 @@ class TestFindHoldingTask:
         """Returns None when employee has no scheduled tasks."""
         mgr = EmployeeManager()
         assert mgr.find_holding_task("emp01", "batch_id=b1") is None
+
+
+class TestSimpleModeSkipsRetrospective:
+    @pytest.mark.asyncio
+    @patch("onemancompany.core.vessel.company_state")
+    @patch("onemancompany.core.vessel.event_bus")
+    async def test_simple_mode_skips_retrospective(self, mock_bus, mock_state):
+        """When tree.mode == 'simple', _request_ceo_confirmation passes run_retrospective=False."""
+        mock_bus.publish = AsyncMock()
+        mock_state.employees = {}
+
+        mgr = EmployeeManager()
+
+        tree = TaskTree(project_id="p1", mode="simple")
+        node = MagicMock()
+        node.node_type = NodeType.TASK
+        node.description_preview = "test task"
+        node.id = "n1"
+        node.project_dir = "/tmp/proj"
+        node.is_ceo_node = False
+
+        entry = ScheduleEntry(node_id="n1", tree_path="/tmp/proj/task_tree.yaml")
+
+        with (
+            patch.object(mgr, "_full_cleanup", new_callable=AsyncMock) as mock_cleanup,
+            patch("onemancompany.core.vessel._store") as mock_store,
+        ):
+            mock_store.load_employee.return_value = {"name": "Test"}
+            tree._nodes = {"n1": node}
+            tree.get_children = MagicMock(return_value=[])
+
+            await mgr._request_ceo_confirmation("00006", node, tree, entry, "p1")
+
+            mock_cleanup.assert_called_once()
+            _, kwargs = mock_cleanup.call_args
+            assert kwargs["run_retrospective"] is False
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.core.vessel.company_state")
+    @patch("onemancompany.core.vessel.event_bus")
+    async def test_standard_mode_runs_retrospective(self, mock_bus, mock_state):
+        """When tree.mode == 'standard' and not system node, retrospective runs."""
+        mock_bus.publish = AsyncMock()
+        mock_state.employees = {}
+
+        mgr = EmployeeManager()
+
+        tree = TaskTree(project_id="p1", mode="standard")
+        node = MagicMock()
+        node.node_type = NodeType.TASK
+        node.description_preview = "test task"
+        node.id = "n1"
+        node.project_dir = "/tmp/proj"
+        node.is_ceo_node = False
+
+        entry = ScheduleEntry(node_id="n1", tree_path="/tmp/proj/task_tree.yaml")
+
+        with (
+            patch.object(mgr, "_full_cleanup", new_callable=AsyncMock) as mock_cleanup,
+            patch("onemancompany.core.vessel._store") as mock_store,
+        ):
+            mock_store.load_employee.return_value = {"name": "Test"}
+            tree._nodes = {"n1": node}
+            tree.get_children = MagicMock(return_value=[])
+
+            await mgr._request_ceo_confirmation("00006", node, tree, entry, "p1")
+
+            mock_cleanup.assert_called_once()
+            _, kwargs = mock_cleanup.call_args
+            assert kwargs["run_retrospective"] is True

--- a/tests/unit/core/test_task_tree.py
+++ b/tests/unit/core/test_task_tree.py
@@ -761,3 +761,33 @@ class TestTaskTreeContentExternalization:
             assert "description" not in nd
             assert "result" not in nd
         assert (tmp_path / "nodes" / "old_root.yaml").exists()
+
+
+class TestTaskTreeMode:
+    def test_default_mode_is_standard(self):
+        tree = TaskTree(project_id="p1")
+        assert tree.mode == "standard"
+
+    def test_mode_set_on_init(self):
+        tree = TaskTree(project_id="p1", mode="simple")
+        assert tree.mode == "simple"
+
+    def test_mode_persisted_in_save(self, tmp_path):
+        tree = TaskTree(project_id="p1", mode="simple")
+        root = tree.create_root(employee_id="00001", description="test")
+        tree.save(tmp_path / "tree.yaml")
+        loaded = TaskTree.load(tmp_path / "tree.yaml")
+        assert loaded.mode == "simple"
+
+    def test_load_without_mode_defaults_to_standard(self, tmp_path):
+        """Backward compat: old trees without mode field default to standard."""
+        import yaml
+        tree = TaskTree(project_id="p1")
+        root = tree.create_root(employee_id="00001", description="test")
+        tree.save(tmp_path / "tree.yaml")
+        # Strip mode from YAML to simulate old file
+        data = yaml.safe_load((tmp_path / "tree.yaml").read_text())
+        data.pop("mode", None)
+        (tmp_path / "tree.yaml").write_text(yaml.dump(data, allow_unicode=True))
+        loaded = TaskTree.load(tmp_path / "tree.yaml")
+        assert loaded.mode == "standard"


### PR DESCRIPTION
## Summary

Replaces the bare-LLM Q&A endpoint with EA agent dispatch, unifying all CEO input into a single task flow.

### TaskTree `mode` field
- Added `mode: Literal["simple", "standard"]` to TaskTree (default: `"standard"`)
- Persisted in tree YAML with backward-compatible default for existing trees

### EA dispatch unrestricted in simple mode
- Standard mode: EA can only dispatch to O-level (HR/COO/CSO) — unchanged
- Simple mode: EA can dispatch to any employee directly
- Added self-dispatch guard: EA cannot dispatch to itself regardless of mode

### Skip retrospective in simple mode
- `_request_ceo_confirmation` passes `run_retrospective=False` when `tree.mode == "simple"`

### Endpoint changes
- **Removed** `POST /api/ceo/qa` endpoint and `EventType.CEO_QA`
- **Modified** `POST /api/ceo/task` to accept optional `mode` param

### Frontend
- Removed Q&A option from project selector
- Added "Simple" toggle checkbox for CEO to choose mode before submitting

### Code review fixes
- Added `Literal["simple", "standard"]` type annotation to `TaskTree.mode`
- Updated spec to reflect actual mode threading path (direct to TaskTree, not via project.yaml)

## Test plan
- [x] All 1998 tests pass (+12 new)
- [ ] Submit task with Simple toggle OFF → EA dispatches to O-level only
- [ ] Submit task with Simple toggle ON → EA can dispatch to any employee
- [ ] Simple mode task completes → no retrospective
- [ ] Standard mode task completes → retrospective runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)