### PR TITLE
fix: meeting room duplicate input boxes and missing agenda list

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -19,6 +19,8 @@ class AppController {
     // Inquiry session state
     this._inquirySessionId = null;
     this._inquiryRoomId = null;
+    // Meeting agenda cache per room (room_id → agenda data)
+    this._meetingAgendaCache = {};
     // Dashboard cost auto-refresh timer
     this._dashboardCostTimer = null;
     // Input history (up/down arrow)
@@ -345,6 +347,8 @@ class AppController {
         return { text: `💬 [${p.speaker}] ${(p.message || '').substring(0, 50)}`, cls: 'system', agent: 'MEETING' };
       },
       'meeting_agenda_update': (p) => {
+        // Cache agenda state so it survives modal close/reopen
+        if (p.room_id) this._meetingAgendaCache[p.room_id] = p;
         if (this.viewingRoomId === p.room_id) {
           this._renderMeetingAgenda(p);
         }
@@ -4227,6 +4231,12 @@ class AppController {
       ceoInputArea.classList.add('hidden');
     }
 
+    // Restore cached agenda for this room (survives modal close/reopen)
+    const cachedAgenda = this._meetingAgendaCache[room.id];
+    if (cachedAgenda && cachedAgenda.items && cachedAgenda.items.length > 0) {
+      this._renderMeetingAgenda(cachedAgenda);
+    }
+
     // Load chat history from API
     const chatEl = document.getElementById('meeting-chat-messages');
     chatEl.innerHTML = '<div class="chat-empty">Loading...</div>';
@@ -4368,7 +4378,8 @@ class AppController {
       console.error('Failed to fetch rooms for inquiry:', e);
     }
 
-    // Show inquiry input area and actions
+    // Hide CEO input, show inquiry input area and actions
+    document.getElementById('meeting-ceo-input-area').classList.add('hidden');
     document.getElementById('meeting-inquiry-input-area').classList.remove('hidden');
     document.getElementById('meeting-inquiry-actions').classList.remove('hidden');
     document.getElementById('meeting-inquiry-input').focus();
@@ -4439,6 +4450,10 @@ class AppController {
     document.getElementById('meeting-inquiry-input-area').classList.add('hidden');
     document.getElementById('meeting-inquiry-typing').classList.add('hidden');
     document.getElementById('meeting-inquiry-actions').classList.add('hidden');
+    // Restore CEO input if a booked room is still open
+    if (this.viewingRoomId) {
+      document.getElementById('meeting-ceo-input-area').classList.remove('hidden');
+    }
   }
 
   // ===== Ex-Employee Wall =====

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.476",
+  "version": "0.2.477",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.476"
+version = "0.2.477"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary

修复 PR #60 引入的会议室前端两个 bug。

### Bug 1: 点击会议室后出现两个输入框

**原因**: `_startInquiryMode()` 显示 inquiry 输入区时，没有隐藏已有的 CEO 输入区（`meeting-ceo-input-area`），导致两个输入框同时可见。

**修复**:
- `_startInquiryMode()`: 进入 inquiry 模式时，隐藏 `meeting-ceo-input-area`
- `_endInquiryMode()`: 退出 inquiry 模式时，如果当前仍在查看已预订的会议室，恢复 `meeting-ceo-input-area` 显示

```js
// _startInquiryMode — hide CEO input
document.getElementById('meeting-ceo-input-area').classList.add('hidden');

// _endInquiryMode — restore CEO input if room still open
if (this.viewingRoomId) {
  document.getElementById('meeting-ceo-input-area').classList.remove('hidden');
}
```

### Bug 2: 打开会议室后没有出现会议日程列表

**原因**: 会议日程数据通过 WebSocket `meeting_agenda_update` 事件推送，只在 modal 打开时实时渲染。关闭 modal 后数据丢失，重新打开时不会再次收到 WebSocket 推送，因此看不到日程。

**修复**:
- 新增 `_meetingAgendaCache` 字典（`room_id → agenda data`），在收到 `meeting_agenda_update` 事件时缓存
- `openMeetingRoom()` 打开 modal 时，从缓存恢复已有日程并调用 `_renderMeetingAgenda()` 渲染

```js
// WebSocket handler — cache agenda
if (p.room_id) this._meetingAgendaCache[p.room_id] = p;

// openMeetingRoom — restore from cache
const cachedAgenda = this._meetingAgendaCache[room.id];
if (cachedAgenda && cachedAgenda.items && cachedAgenda.items.length > 0) {
  this._renderMeetingAgenda(cachedAgenda);
}
```

## Changed files
| File | Change |
|------|--------|
| `frontend/app.js` | 添加 agenda 缓存、修复 inquiry 模式输入框切换 |
| `package.json` | 版本号 0.2.476 → 0.2.477 |
| `pyproject.toml` | 版本号 0.2.476 → 0.2.477 |

## Test plan
- [ ] 打开一个已预订的会议室 → 只出现一个输入框
- [ ] 关闭会议室 modal 后重新打开 → 日程列表仍然显示
- [ ] 进入 inquiry 模式 → CEO 输入框消失，inquiry 输入框出现
- [ ] 结束 inquiry → inquiry 输入框消失，CEO 输入框恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)