### PR TITLE
fix: incremental child review to prevent dep-chain deadlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.476",
+  "version": "0.2.477",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.477",
+  "version": "0.2.478",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.476"
+version = "0.2.477"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.477"
+version = "0.2.478"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1782,16 +1782,17 @@ class EmployeeManager:
             parent_node = None  # Skip propagation, fall through to project completion check
         if parent_node and TaskPhase(parent_node.status) not in RESOLVED:
             children = tree.get_active_children(parent_node.id)
-            _SKIP_REVIEW_TYPES = {NodeType.REVIEW, NodeType.WATCHDOG_NUDGE}
-            non_review_children = [c for c in children if c.node_type not in _SKIP_REVIEW_TYPES]
+            non_review_children = [c for c in children if c.node_type not in SYSTEM_NODE_TYPES]
 
-            # Gate 1: all substantive children RESOLVED → auto-complete parent upward
-            if non_review_children and all(c.is_resolved for c in non_review_children):
+            # Gate 1: all substantive children ACCEPTED/FINISHED → auto-complete parent upward
+            # Excludes FAILED/CANCELLED — those need parent review to decide how to handle.
+            _SUCCESS_RESOLVED = frozenset({TaskPhase.ACCEPTED, TaskPhase.FINISHED})
+            if non_review_children and all(TaskPhase(c.status) in _SUCCESS_RESOLVED for c in non_review_children):
                 if parent_node.status != TaskPhase.COMPLETED.value:
                     logger.info("All non-review children of {} are resolved — auto-completing parent", parent_node.id)
-                    if parent_node.status == TaskPhase.HOLDING.value:
+                    if parent_node.status in (TaskPhase.PENDING.value, TaskPhase.HOLDING.value):
                         parent_node.set_status(TaskPhase.PROCESSING)
-                        logger.debug("[TASK LIFECYCLE] parent={} → PROCESSING (resuming from HOLDING for auto-complete)", parent_node.id)
+                        logger.debug("[TASK LIFECYCLE] parent={} → PROCESSING (auto-complete prep)", parent_node.id)
                     parent_node.set_status(TaskPhase.COMPLETED)
                     logger.debug("[TASK LIFECYCLE] parent={} → COMPLETED (all children resolved)", parent_node.id)
                     parent_node.result = "All child tasks accepted."

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1782,50 +1782,60 @@ class EmployeeManager:
             parent_node = None  # Skip propagation, fall through to project completion check
         if parent_node and TaskPhase(parent_node.status) not in RESOLVED:
             children = tree.get_active_children(parent_node.id)
-            if tree.all_children_done(parent_node.id):
-                # Check for active review node (prevent infinite loop)
+            _SKIP_REVIEW_TYPES = {NodeType.REVIEW, NodeType.WATCHDOG_NUDGE}
+            non_review_children = [c for c in children if c.node_type not in _SKIP_REVIEW_TYPES]
+
+            # Gate 1: all substantive children RESOLVED → auto-complete parent upward
+            if non_review_children and all(c.is_resolved for c in non_review_children):
+                if parent_node.status != TaskPhase.COMPLETED.value:
+                    logger.info("All non-review children of {} are resolved — auto-completing parent", parent_node.id)
+                    if parent_node.status == TaskPhase.HOLDING.value:
+                        parent_node.set_status(TaskPhase.PROCESSING)
+                        logger.debug("[TASK LIFECYCLE] parent={} → PROCESSING (resuming from HOLDING for auto-complete)", parent_node.id)
+                    parent_node.set_status(TaskPhase.COMPLETED)
+                    logger.debug("[TASK LIFECYCLE] parent={} → COMPLETED (all children resolved)", parent_node.id)
+                    parent_node.result = "All child tasks accepted."
+                    save_tree_async(entry.tree_path)
+                    self._publish_node_update(parent_node.employee_id, parent_node)
+                if parent_node.status == TaskPhase.COMPLETED.value:
+                    parent_node.set_status(TaskPhase.ACCEPTED)
+                    logger.info("[TASK LIFECYCLE] parent={} → ACCEPTED (all children resolved, auto-promoting)", parent_node.id)
+                    parent_node.set_status(TaskPhase.FINISHED)
+                    logger.debug("[TASK LIFECYCLE] parent={} → FINISHED", parent_node.id)
+                    save_tree_async(entry.tree_path)
+                    self._publish_node_update(parent_node.employee_id, parent_node)
+                    # Recursively propagate upward (includes project completion check)
+                    parent_entry = ScheduleEntry(node_id=parent_node.id, tree_path=entry.tree_path)
+                    await self._on_child_complete_inner(
+                        parent_node.employee_id, parent_entry, project_id
+                    )
+                    return  # recursive call handles project completion check
+
+            # Gate 2: incremental review — any child COMPLETED triggers immediate
+            # review so it can be accepted individually.  This prevents dep-chain
+            # deadlocks (A→B): B stays PENDING until A is ACCEPTED, so we cannot
+            # wait for all children to finish before reviewing.
+            else:
+                needs_review = any(
+                    c for c in non_review_children
+                    if c.status == TaskPhase.COMPLETED.value
+                )
                 has_active_review = any(
                     c for c in children
                     if c.node_type == NodeType.REVIEW
                     and c.status in (TaskPhase.PENDING.value, TaskPhase.PROCESSING.value)
                 )
-                if not has_active_review:
-                    _SKIP_REVIEW_TYPES = {NodeType.REVIEW, NodeType.WATCHDOG_NUDGE}
-                    non_review_children = [c for c in children if c.node_type not in _SKIP_REVIEW_TYPES]
-                    if non_review_children and all(c.status == TaskPhase.ACCEPTED.value for c in non_review_children):
-                        # All substantive children accepted → auto-complete parent
-                        if parent_node.status != TaskPhase.COMPLETED.value:
-                            logger.info("All non-review children of {} are accepted — auto-completing parent", parent_node.id)
-                            if parent_node.status == TaskPhase.HOLDING.value:
-                                parent_node.set_status(TaskPhase.PROCESSING)
-                                logger.debug("[TASK LIFECYCLE] parent={} → PROCESSING (resuming from HOLDING for auto-complete)", parent_node.id)
-                            parent_node.set_status(TaskPhase.COMPLETED)
-                            logger.debug("[TASK LIFECYCLE] parent={} → COMPLETED (all children accepted)", parent_node.id)
-                            parent_node.result = "All child tasks accepted."
-                            save_tree_async(entry.tree_path)
-                            self._publish_node_update(parent_node.employee_id, parent_node)
-                        # Parent already COMPLETED with all children accepted → auto-accept
-                        # This recovers stuck nodes where parent completed before children
-                        if parent_node.status == TaskPhase.COMPLETED.value:
-                            parent_node.set_status(TaskPhase.ACCEPTED)
-                            logger.info("[TASK LIFECYCLE] parent={} → ACCEPTED (all children accepted, auto-promoting)", parent_node.id)
-                            parent_node.set_status(TaskPhase.FINISHED)
-                            logger.debug("[TASK LIFECYCLE] parent={} → FINISHED", parent_node.id)
-                            save_tree_async(entry.tree_path)
-                            self._publish_node_update(parent_node.employee_id, parent_node)
-                            # Recursively propagate upward (includes project completion check)
-                            parent_entry = ScheduleEntry(node_id=parent_node.id, tree_path=entry.tree_path)
-                            await self._on_child_complete_inner(
-                                parent_node.employee_id, parent_entry, project_id
-                            )
-                            return  # recursive call handles project completion check
-                    else:
-                        # Not all accepted yet → spawn review or escalate
-                        await self._spawn_review_or_escalate(
-                            tree, node, parent_node, children, entry, project_id
-                        )
-            else:
-                logger.debug("[ON_CHILD_COMPLETE] not all children done for parent={} → waiting", parent_node.id)
+                if needs_review and not has_active_review:
+                    logger.info(
+                        "[ON_CHILD_COMPLETE] child {} completed — triggering incremental review for parent {}",
+                        node.id, parent_node.id,
+                    )
+                    await self._spawn_review_or_escalate(
+                        tree, node, parent_node, children, entry, project_id
+                    )
+                else:
+                    logger.debug("[ON_CHILD_COMPLETE] parent={} — waiting (needs_review={}, active_review={})",
+                                 parent_node.id, needs_review, has_active_review)
 
         # --- Bottom-up project completion check ---
         # After any status change, check if the entire project tree is resolved.

--- a/tests/unit/core/test_agent_loop.py
+++ b/tests/unit/core/test_agent_loop.py
@@ -1907,6 +1907,104 @@ class TestTaskTreeCallback:
     @pytest.mark.asyncio
     @patch("onemancompany.core.vessel.company_state")
     @patch("onemancompany.core.vessel.event_bus")
+    async def test_all_children_accepted_auto_completes_parent(self, mock_bus, mock_state, tmp_path):
+        """Gate 1: when all substantive children are ACCEPTED, parent auto-completes
+        through COMPLETED → ACCEPTED → FINISHED."""
+        mock_bus.publish = AsyncMock()
+        mock_state.employees = {}
+        mock_state.active_tasks = []
+
+        mgr = EmployeeManager()
+
+        tree = TaskTree(project_id="proj1")
+        root = tree.create_root("00001", "Root")
+        parent_node = tree.add_child(root.id, "00003", "Manage", [])
+        child1 = tree.add_child(parent_node.id, "00010", "Backend", [])
+        child2 = tree.add_child(parent_node.id, "00011", "Frontend", [])
+        child1.status = "accepted"
+        child2.status = "accepted"  # Last child just accepted
+
+        tree_path = tmp_path / "tree.yaml"
+        tree.save(tree_path)
+        entry = ScheduleEntry(node_id=child2.id, tree_path=str(tree_path))
+
+        await mgr._on_child_complete("00011", entry, project_id="proj1")
+
+        reloaded = TaskTree.load(tree_path, skeleton_only=False)
+        parent = reloaded.get_node(parent_node.id)
+        assert parent.status == "finished"
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.core.vessel.company_state")
+    @patch("onemancompany.core.vessel.event_bus")
+    async def test_failed_child_does_not_auto_complete_parent(self, mock_bus, mock_state, tmp_path):
+        """Gate 1 excludes FAILED — parent should NOT auto-complete, should
+        trigger review instead so parent can decide how to handle failure."""
+        mock_bus.publish = AsyncMock()
+        mock_state.employees = {}
+        mock_state.active_tasks = []
+
+        mgr = EmployeeManager()
+        parent_launcher = MagicMock(spec=Launcher)
+        mgr.register("00003", parent_launcher)
+
+        tree = TaskTree(project_id="proj1")
+        root = tree.create_root("00001", "Root")
+        parent_node = tree.add_child(root.id, "00003", "Manage", [])
+        child1 = tree.add_child(parent_node.id, "00010", "Backend", [])
+        child2 = tree.add_child(parent_node.id, "00011", "Frontend", [])
+        child1.status = "accepted"
+        child2.status = "failed"  # This child failed
+        child2.result = "Error occurred"
+
+        tree_path = tmp_path / "tree.yaml"
+        tree.save(tree_path)
+        entry = ScheduleEntry(node_id=child2.id, tree_path=str(tree_path))
+
+        await mgr._on_child_complete("00011", entry, project_id="proj1")
+
+        # Parent should NOT auto-complete — needs review to handle failure
+        reloaded = TaskTree.load(tree_path, skeleton_only=False)
+        parent = reloaded.get_node(parent_node.id)
+        assert parent.status != "finished"
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.core.vessel.company_state")
+    @patch("onemancompany.core.vessel.event_bus")
+    async def test_no_duplicate_review_when_review_active(self, mock_bus, mock_state, tmp_path):
+        """When a review node is already PROCESSING, no second review is spawned
+        even if another child completes."""
+        mock_bus.publish = AsyncMock()
+        mock_state.employees = {}
+        mock_state.active_tasks = []
+
+        mgr = EmployeeManager()
+
+        tree = TaskTree(project_id="proj1")
+        root = tree.create_root("00001", "Root")
+        parent_node = tree.add_child(root.id, "00003", "Manage", [])
+        child1 = tree.add_child(parent_node.id, "00010", "Backend", [])
+        child2 = tree.add_child(parent_node.id, "00011", "Frontend", [])
+        child1.status = "completed"
+        child2.status = "completed"
+        # Existing active review node
+        from onemancompany.core.task_lifecycle import NodeType
+        review = tree.add_child(parent_node.id, "00003", "Review children", [])
+        review.node_type = NodeType.REVIEW.value
+        review.status = "processing"
+
+        tree_path = tmp_path / "tree.yaml"
+        tree.save(tree_path)
+        entry = ScheduleEntry(node_id=child2.id, tree_path=str(tree_path))
+
+        await mgr._on_child_complete("00011", entry, project_id="proj1")
+
+        # No new review scheduled — one is already active
+        assert len(mgr._schedule.get("00003", [])) == 0
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.core.vessel.company_state")
+    @patch("onemancompany.core.vessel.event_bus")
     async def test_child_complete_updates_node(self, mock_bus, mock_state, tmp_path):
         """Child completion updates node status and result in tree."""
         mock_bus.publish = AsyncMock()

--- a/tests/unit/core/test_agent_loop.py
+++ b/tests/unit/core/test_agent_loop.py
@@ -1814,13 +1814,16 @@ class TestTaskTreeCallback:
     @pytest.mark.asyncio
     @patch("onemancompany.core.vessel.company_state")
     @patch("onemancompany.core.vessel.event_bus")
-    async def test_child_complete_waits_when_siblings_pending(self, mock_bus, mock_state, tmp_path):
-        """When siblings still running, no wake-up."""
+    async def test_child_complete_triggers_incremental_review_while_siblings_running(self, mock_bus, mock_state, tmp_path):
+        """When one child completes while sibling still running, incremental
+        review is triggered so the completed child can be accepted individually."""
         mock_bus.publish = AsyncMock()
         mock_state.employees = {}
         mock_state.active_tasks = []
 
         mgr = EmployeeManager()
+        parent_launcher = MagicMock(spec=Launcher)
+        mgr.register("00003", parent_launcher)
 
         tree = TaskTree(project_id="proj1")
         root = tree.create_root("00001", "Root")
@@ -1836,7 +1839,69 @@ class TestTaskTreeCallback:
 
         await mgr._on_child_complete("00010", entry, project_id="proj1")
 
-        # Parent should NOT be woken
+        # Parent should be woken for incremental review of child1
+        assert len(mgr._schedule.get("00003", [])) > 0
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.core.vessel.company_state")
+    @patch("onemancompany.core.vessel.event_bus")
+    async def test_child_complete_with_dep_chain_triggers_review(self, mock_bus, mock_state, tmp_path):
+        """Dep chain A→B: when A completes, incremental review triggers so A
+        can be accepted and B can be unblocked."""
+        mock_bus.publish = AsyncMock()
+        mock_state.employees = {}
+        mock_state.active_tasks = []
+
+        mgr = EmployeeManager()
+        parent_launcher = MagicMock(spec=Launcher)
+        mgr.register("00003", parent_launcher)
+
+        tree = TaskTree(project_id="proj1")
+        root = tree.create_root("00001", "Root")
+        parent_node = tree.add_child(root.id, "00003", "Manage feature", ["Done"])
+        child_a = tree.add_child(parent_node.id, "00010", "Step A", ["A done"])
+        child_b = tree.add_child(parent_node.id, "00011", "Step B", ["B done"])
+        child_b.depends_on = [child_a.id]  # B depends on A
+        child_a.status = "completed"
+        child_a.result = "Step A result"
+        # B is still PENDING — can't start until A is accepted
+
+        tree_path = tmp_path / "tree.yaml"
+        tree.save(tree_path)
+        entry = ScheduleEntry(node_id=child_a.id, tree_path=str(tree_path))
+
+        await mgr._on_child_complete("00010", entry, project_id="proj1")
+
+        # Parent should receive a review task to accept A → unblock B
+        assert len(mgr._schedule.get("00003", [])) > 0
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.core.vessel.company_state")
+    @patch("onemancompany.core.vessel.event_bus")
+    async def test_no_review_when_no_completed_children(self, mock_bus, mock_state, tmp_path):
+        """When the completing child is already accepted (e.g. system node),
+        and siblings are still running, no redundant review is spawned."""
+        mock_bus.publish = AsyncMock()
+        mock_state.employees = {}
+        mock_state.active_tasks = []
+
+        mgr = EmployeeManager()
+
+        tree = TaskTree(project_id="proj1")
+        root = tree.create_root("00001", "Root")
+        parent_node = tree.add_child(root.id, "00003", "Manage", [])
+        child1 = tree.add_child(parent_node.id, "00010", "Backend", [])
+        child2 = tree.add_child(parent_node.id, "00011", "Frontend", [])
+        child1.status = "accepted"  # Already reviewed
+        child2.status = "processing"  # Still running
+
+        tree_path = tmp_path / "tree.yaml"
+        tree.save(tree_path)
+        entry = ScheduleEntry(node_id=child1.id, tree_path=str(tree_path))
+
+        await mgr._on_child_complete("00010", entry, project_id="proj1")
+
+        # No review needed — child1 already accepted, child2 still running
         assert len(mgr._schedule.get("00003", [])) == 0
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

修复子任务完成后依赖任务无法自动启动的 bug，树卡住只能靠 watchdog 兜底。

### Root Cause

`_on_child_complete_inner` 用 `all_children_done(parent)` 作为触发 review 的门槛：只有当所有兄弟任务都完成执行后，parent 才会 review/accept 子任务。

当存在依赖链（A→B）时，这导致**循环死锁**：
- B 是 PENDING（等 A 被 ACCEPTED 才能开始）
- `all_children_done` 要求 B 也要 done_executing → 永远为 False
- A 永远停在 COMPLETED，B 永远停在 PENDING
- 只有 watchdog 最终兜底才能打破

### Fix

移除 `all_children_done` 门槛，改为**逐个验收**：

- **Gate 1**: 所有 substantive children 都 RESOLVED → parent 自动向上 complete
- **Gate 2**: 任何 child COMPLETED → 立刻触发 incremental review（除非已有 review 在进行）

流程变为：A 完成 → 立即 review/accept A → 触发 dep resolution → B 解锁开始 → B 完成 → review/accept B → 所有 children RESOLVED → parent 自动 complete 向上回报

### 改动逻辑

| 之前 | 之后 |
|------|------|
| 等所有兄弟 done → 批量 review | 每个子任务完成立即 review |
| `all(c.status == ACCEPTED)` → parent 完成 | `all(c.is_resolved)` → parent 完成 |
| 有 PENDING 兄弟 → 不触发 review | 有 COMPLETED child → 触发 incremental review |

### Changed files
| File | Change |
|------|--------|
| `src/onemancompany/core/vessel.py` | 重写 `_on_child_complete_inner` 的 review 触发逻辑 |
| `tests/unit/core/test_agent_loop.py` | 新增 3 个测试，修改 1 个旧测试 |

## Test plan
- [ ] 部署后创建包含依赖链的任务（A→B），验证 A 完成后立即被 review/accept，B 自动开始
- [ ] 验证无依赖的并行任务（A, B 同时执行）也能正常 review
- [ ] 验证所有 children resolved 后 parent 正确向上 complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)