### PR TITLE
fix: resolve project root path and seed team on creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.480",
+  "version": "0.2.481",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.480"
+version = "0.2.481"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -59,12 +59,32 @@ def _save_tree(project_dir: str, tree: TaskTree) -> None:
     save_tree_async(path)
 
 
+def _resolve_project_root(project_dir: str) -> Path | None:
+    """Resolve project root dir containing project.yaml from an iteration dir.
+
+    project_dir is typically projects/{slug}/iterations/iter_NNN/.
+    project.yaml lives at projects/{slug}/project.yaml.
+    """
+    d = Path(project_dir)
+    # Check project_dir itself first
+    if (d / PROJECT_YAML_FILENAME).exists():
+        return d
+    # Walk up (max 3 levels) looking for project.yaml
+    for _ in range(3):
+        d = d.parent
+        if (d / PROJECT_YAML_FILENAME).exists():
+            return d
+    return None
+
+
 def _add_to_project_team(project_dir: str, employee_id: str) -> None:
     """Add employee to project.yaml team list (idempotent)."""
     import yaml
-    project_yaml = Path(project_dir) / PROJECT_YAML_FILENAME
-    if not project_yaml.exists():
+    root = _resolve_project_root(project_dir)
+    if root is None:
+        logger.debug("No project.yaml found from {}", project_dir)
         return
+    project_yaml = root / PROJECT_YAML_FILENAME
     try:
         data = yaml.safe_load(project_yaml.read_text(encoding=ENCODING_UTF8)) or {}
         team = data.get("team", [])

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -421,6 +421,10 @@ async def ceo_submit_task(body: dict) -> dict:
                 acceptance_criteria=[],
             )
             _save_project_tree(pdir, tree)
+            # Register CEO and EA in project team for project history
+            from onemancompany.agents.tree_tools import _add_to_project_team
+            _add_to_project_team(pdir, CEO_ID)
+            _add_to_project_team(pdir, EA_ID)
             # Schedule EA node for execution
             employee_manager.schedule_node(EA_ID, ea_node.id, str(tree_path))
             employee_manager._schedule_next(EA_ID)

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -312,6 +312,7 @@ def create_named_project(name: str) -> str:
         "status": PROJECT_STATUS_ACTIVE,
         "created_at": datetime.now().isoformat(),
         "archived_at": None,
+        "team": [],
         ITERATIONS_DIR_NAME: [],
     }
     path = proj_dir / PROJECT_YAML_FILENAME

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -2521,6 +2521,10 @@ async def _create_project_from_action_points(
         acceptance_criteria=action_points,
     )
     _save_project_tree(pdir, tree)
+    # Register CEO and EA in project team for project history
+    from onemancompany.agents.tree_tools import _add_to_project_team
+    _add_to_project_team(pdir, CEO_ID)
+    _add_to_project_team(pdir, EA_ID)
 
     tree_path = str(Path(pdir) / TASK_TREE_FILENAME)
     employee_manager.schedule_node(EA_ID, ea_node.id, tree_path)

--- a/tests/unit/agents/test_tree_tools.py
+++ b/tests/unit/agents/test_tree_tools.py
@@ -103,9 +103,14 @@ class TestDispatchChild:
         import yaml
         from onemancompany.agents.tree_tools import dispatch_child
 
-        # Create project.yaml without team
-        project_dir = str(tmp_path)
-        project_yaml = tmp_path / "project.yaml"
+        # Simulate real directory structure: project root has project.yaml,
+        # iteration dir (where task_tree.yaml lives) is a subdirectory
+        project_root = tmp_path / "my-project"
+        project_root.mkdir()
+        iter_dir = project_root / "iterations" / "iter_001"
+        iter_dir.mkdir(parents=True)
+
+        project_yaml = project_root / "project.yaml"
         project_yaml.write_text(yaml.dump({"project_id": "proj1", "name": "Test"}))
 
         tree = _make_tree_with_root()
@@ -113,7 +118,8 @@ class TestDispatchChild:
         vessel = _make_vessel_and_task()
         tok_v, tok_t = _set_context(vessel, root_id)
 
-        mock_em = _make_mock_em(root_id, tree_path=str(tmp_path / "task_tree.yaml"))
+        tree_path = str(iter_dir / "task_tree.yaml")
+        mock_em = _make_mock_em(root_id, tree_path=tree_path)
 
         try:
             with (
@@ -122,7 +128,7 @@ class TestDispatchChild:
                 patch("onemancompany.core.store.load_employee", return_value={"id": "00100", "name": "Test"}),
                 patch("onemancompany.core.vessel.employee_manager", mock_em),
                 patch("onemancompany.agents.tree_tools._find_entry_for_task",
-                       return_value=(project_dir, str(tmp_path / "task_tree.yaml"))),
+                       return_value=(str(iter_dir), tree_path)),
             ):
                 result = dispatch_child.invoke({
                     "employee_id": "00100",
@@ -132,7 +138,7 @@ class TestDispatchChild:
 
             assert result["status"] == "dispatched"
 
-            # Verify employee was added to project.yaml team
+            # Verify employee was added to project root's project.yaml team
             data = yaml.safe_load(project_yaml.read_text())
             team = data.get("team", [])
             assert len(team) == 1
@@ -145,8 +151,13 @@ class TestDispatchChild:
         import yaml
         from onemancompany.agents.tree_tools import dispatch_child
 
-        project_dir = str(tmp_path)
-        project_yaml = tmp_path / "project.yaml"
+        # Simulate real directory structure
+        project_root = tmp_path / "my-project"
+        project_root.mkdir()
+        iter_dir = project_root / "iterations" / "iter_001"
+        iter_dir.mkdir(parents=True)
+
+        project_yaml = project_root / "project.yaml"
         project_yaml.write_text(yaml.dump({
             "project_id": "proj1",
             "team": [{"employee_id": "00100", "role": "", "joined_at": "2026-01-01"}],
@@ -157,7 +168,8 @@ class TestDispatchChild:
         vessel = _make_vessel_and_task()
         tok_v, tok_t = _set_context(vessel, root_id)
 
-        mock_em = _make_mock_em(root_id, tree_path=str(tmp_path / "task_tree.yaml"))
+        tree_path = str(iter_dir / "task_tree.yaml")
+        mock_em = _make_mock_em(root_id, tree_path=tree_path)
 
         try:
             with (
@@ -166,7 +178,7 @@ class TestDispatchChild:
                 patch("onemancompany.core.store.load_employee", return_value={"id": "00100", "name": "Test"}),
                 patch("onemancompany.core.vessel.employee_manager", mock_em),
                 patch("onemancompany.agents.tree_tools._find_entry_for_task",
-                       return_value=(project_dir, str(tmp_path / "task_tree.yaml"))),
+                       return_value=(str(iter_dir), tree_path)),
             ):
                 result = dispatch_child.invoke({
                     "employee_id": "00100",
@@ -181,6 +193,20 @@ class TestDispatchChild:
             assert len(data.get("team", [])) == 1
         finally:
             _reset_context(tok_v, tok_t)
+
+    def test_resolve_project_root_from_iteration_dir(self, tmp_path):
+        """_resolve_project_root walks up from iteration dir to find project.yaml."""
+        import yaml
+        from onemancompany.agents.tree_tools import _resolve_project_root
+
+        project_root = tmp_path / "my-project"
+        project_root.mkdir()
+        iter_dir = project_root / "iterations" / "iter_001"
+        iter_dir.mkdir(parents=True)
+        (project_root / "project.yaml").write_text(yaml.dump({"project_id": "p1"}))
+
+        assert _resolve_project_root(str(iter_dir)) == project_root
+        assert _resolve_project_root(str(tmp_path / "nonexistent")) is None
 
     def test_unknown_employee_returns_error(self):
         """Returns error when employee_id not in company_state."""


### PR DESCRIPTION
## Summary
Follow-up to PR #64. Code review found three issues with the initial project team fix:

1. **Path mismatch**: `_add_to_project_team` looked for `project.yaml` in the iteration dir (`projects/{slug}/iterations/iter_NNN/`) but it only exists at the project root (`projects/{slug}/`). Added `_resolve_project_root()` to walk up from iteration dir.
2. **Founding employees bypass dispatch_child**: `ceo_submit_task` and routine meeting action points assign EA directly via `tree.add_child`. Now explicitly seeds CEO + EA in team at project creation.
3. **Missing team field**: `create_named_project` now initializes `team: []` so the field exists for subsequent writes.

## Test plan
- [x] Updated tests with realistic directory structure (project root + iteration subdir)
- [x] Added `_resolve_project_root` unit test
- [x] Full test suite passes (2005 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)