### PR TITLE
fix: allow meetings with founding employees only

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.485",
+  "version": "0.2.486",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.483",
+  "version": "0.2.484",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.486",
+  "version": "0.2.487",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.482",
+  "version": "0.2.483",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.487",
+  "version": "0.2.488",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.481",
+  "version": "0.2.482",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.488",
+  "version": "0.2.489",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.484",
+  "version": "0.2.485",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.485"
+version = "0.2.486"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.484"
+version = "0.2.485"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.481"
+version = "0.2.482"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.486"
+version = "0.2.487"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.487"
+version = "0.2.488"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.482"
+version = "0.2.483"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.483"
+version = "0.2.484"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.488"
+version = "0.2.489"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -299,20 +299,20 @@ async def tracked_ainvoke(
     if project_id:
         from datetime import datetime
         from onemancompany.core.claude_session import write_llm_trace
-        prompt_text = messages if isinstance(messages, str) else str(messages)[:2000]
+        prompt_text = messages if isinstance(messages, str) else str(messages)
         response_text = getattr(result, "content", "") or ""
         write_llm_trace(project_id, {
             "ts": datetime.now().isoformat(),
             "employee_id": employee_id,
             "role": "user", "type": "llm_input",
-            "content": prompt_text[:2000],
+            "content": prompt_text,
             "category": category,
         })
         write_llm_trace(project_id, {
             "ts": datetime.now().isoformat(),
             "employee_id": employee_id,
             "role": "assistant", "type": "llm_output",
-            "content": response_text[:5000] if isinstance(response_text, str) else str(response_text)[:5000],
+            "content": response_text if isinstance(response_text, str) else str(response_text),
             "model": model_name,
             "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
         })

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -295,6 +295,28 @@ async def tracked_ainvoke(
     # Always record overhead
     _record_overhead(category, model_name, input_tokens, output_tokens, cost_usd)
 
+    # Write to project-level LLM trace JSONL
+    if project_id:
+        from datetime import datetime
+        from onemancompany.core.claude_session import write_llm_trace
+        prompt_text = messages if isinstance(messages, str) else str(messages)[:2000]
+        response_text = getattr(result, "content", "") or ""
+        write_llm_trace(project_id, {
+            "ts": datetime.now().isoformat(),
+            "employee_id": employee_id,
+            "role": "user", "type": "llm_input",
+            "content": prompt_text[:2000],
+            "category": category,
+        })
+        write_llm_trace(project_id, {
+            "ts": datetime.now().isoformat(),
+            "employee_id": employee_id,
+            "role": "assistant", "type": "llm_output",
+            "content": response_text[:5000] if isinstance(response_text, str) else str(response_text)[:5000],
+            "model": model_name,
+            "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
+        })
+
     return result
 
 

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -297,21 +297,23 @@ async def tracked_ainvoke(
 
     # Write to project-level LLM trace JSONL
     if project_id:
-        from datetime import datetime
+        from datetime import datetime, timezone
         from onemancompany.core.claude_session import write_llm_trace
         prompt_text = messages if isinstance(messages, str) else str(messages)
         response_text = getattr(result, "content", "") or ""
         write_llm_trace(project_id, {
-            "ts": datetime.now().isoformat(),
+            "ts": datetime.now(timezone.utc).isoformat(),
             "employee_id": employee_id,
-            "role": "user", "type": "llm_input",
+            "source": "langchain",
+            "role": "user", "type": "prompt",
             "content": prompt_text,
             "category": category,
         })
         write_llm_trace(project_id, {
-            "ts": datetime.now().isoformat(),
+            "ts": datetime.now(timezone.utc).isoformat(),
             "employee_id": employee_id,
-            "role": "assistant", "type": "llm_output",
+            "source": "langchain",
+            "role": "assistant", "type": "text",
             "content": response_text if isinstance(response_text, str) else str(response_text),
             "model": model_name,
             "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -1379,13 +1379,20 @@ def update_project_team(members: list[dict]) -> dict:
     data = yaml.safe_load(project_yaml.read_text(encoding=ENCODING_UTF8)) or {}
     team = data.get("team", [])
 
+    existing_ids = {t.get("employee_id") for t in team}
+    added = 0
     now = datetime.now().isoformat()
     for m in members:
+        eid = m["employee_id"]
+        if eid in existing_ids:
+            continue
         team.append({
-            "employee_id": m["employee_id"],
+            "employee_id": eid,
             "role": m.get("role", ""),
             "joined_at": now,
         })
+        existing_ids.add(eid)
+        added += 1
 
     data["team"] = team
     project_yaml.write_text(
@@ -1393,7 +1400,7 @@ def update_project_team(members: list[dict]) -> dict:
         encoding=ENCODING_UTF8,
     )
 
-    return {"status": "ok", "added": len(members), "total": len(team)}
+    return {"status": "ok", "added": added, "total": len(team)}
 
 
 # ---------------------------------------------------------------------------

--- a/src/onemancompany/core/claude_session.py
+++ b/src/onemancompany/core/claude_session.py
@@ -28,7 +28,29 @@ from pathlib import Path
 
 from loguru import logger
 
-from onemancompany.core.config import BLOCK_KEY_TEXT, BLOCK_KEY_TYPE, BLOCK_TYPE_TEXT, EMPLOYEES_DIR, ENCODING_UTF8
+from onemancompany.core.config import BLOCK_KEY_TEXT, BLOCK_KEY_TYPE, BLOCK_TYPE_TEXT, EMPLOYEES_DIR, ENCODING_UTF8, PROJECTS_DIR
+
+LLM_TRACES_FILENAME = "llm_traces.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Shared LLM trace writer — project-level JSONL log
+# ---------------------------------------------------------------------------
+
+def write_llm_trace(project_id: str, entry: dict) -> None:
+    """Append a single trace entry to the project's llm_traces.jsonl.
+
+    Called by both ClaudeDaemon (self-hosted) and vessel _on_log (company-hosted).
+    """
+    if not project_id or project_id == "default":
+        return
+    path = PROJECTS_DIR / project_id / LLM_TRACES_FILENAME
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding=ENCODING_UTF8) as f:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+    except OSError as e:
+        logger.debug("[llm-trace] write failed for project={}: {}", project_id, e)
 
 # Single-file constants
 SESSIONS_FILENAME = "sessions.json"
@@ -259,6 +281,55 @@ class ClaudeDaemon:
                 f"for employee={self.employee_id} (stale --resume output)"
             )
 
+    # ------------------------------------------------------------------
+    # LLM trace logging — delegate to shared write_llm_trace
+    # ------------------------------------------------------------------
+
+    def _write_trace(self, entry: dict) -> None:
+        write_llm_trace(self.project_id, entry)
+
+    def _trace_assistant_message(self, message: dict) -> None:
+        """Parse an assistant message's content blocks into trace entries."""
+        ts = datetime.now(timezone.utc).isoformat()
+        model = message.get("model", "")
+        usage = message.get("usage", {})
+        content = message.get("content", [])
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get(BLOCK_KEY_TYPE, "")
+            if btype == BLOCK_TYPE_TEXT:
+                self._write_trace({
+                    "ts": ts, "employee_id": self.employee_id,
+                    "role": "assistant", "type": "text",
+                    "content": block.get(BLOCK_KEY_TEXT, ""),
+                    "model": model, "usage": usage,
+                })
+            elif btype == "tool_use":
+                self._write_trace({
+                    "ts": ts, "employee_id": self.employee_id,
+                    "role": "assistant", "type": "tool_use",
+                    "tool_name": block.get("name", ""),
+                    "tool_id": block.get("id", ""),
+                    "input": block.get("input", {}),
+                    "model": model,
+                })
+            elif btype == "tool_result":
+                self._write_trace({
+                    "ts": ts, "employee_id": self.employee_id,
+                    "role": "tool", "type": "tool_result",
+                    "tool_id": block.get("tool_use_id", ""),
+                    "content": block.get("content", ""),
+                    "is_error": block.get("is_error", False),
+                })
+            elif btype == "thinking":
+                self._write_trace({
+                    "ts": ts, "employee_id": self.employee_id,
+                    "role": "assistant", "type": "thinking",
+                    "content": block.get(BLOCK_KEY_TEXT, ""),
+                    "model": model,
+                })
+
     async def send_prompt(self, prompt: str, timeout: int = 600) -> dict:
         """Send a prompt and collect the full response.
 
@@ -267,6 +338,14 @@ class ClaudeDaemon:
         """
         if not self.alive:
             raise RuntimeError("Daemon process is not running")
+
+        # Log user prompt
+        self._write_trace({
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "employee_id": self.employee_id,
+            "role": "user", "type": "prompt",
+            "content": prompt,
+        })
 
         # Send user message via stdin
         msg = json.dumps({
@@ -317,6 +396,8 @@ class ClaudeDaemon:
                     elif msg_type == "assistant":
                         # Complete assistant message — extract text and usage
                         message = msg_data.get("message", {})
+                        # Trace full assistant message (text, tool_use, thinking)
+                        self._trace_assistant_message(message)
                         content = message.get("content", [])
                         for block in content:
                             if isinstance(block, dict) and block.get(BLOCK_KEY_TYPE) == BLOCK_TYPE_TEXT:
@@ -340,6 +421,18 @@ class ClaudeDaemon:
                             total_output_tokens = max(total_output_tokens, msg_data["output_tokens"])
                         if msg_data.get("model"):
                             model_used = msg_data["model"]
+                        # Trace result summary
+                        self._write_trace({
+                            "ts": datetime.now(timezone.utc).isoformat(),
+                            "employee_id": self.employee_id,
+                            "role": "system", "type": "result",
+                            "content": result_text[:500] if result_text else "",
+                            "model": model_used,
+                            "usage": {
+                                "input_tokens": total_input_tokens,
+                                "output_tokens": total_output_tokens,
+                            },
+                        })
                         _mark_session_used(self.employee_id, self.project_id)
                         break
 

--- a/src/onemancompany/core/claude_session.py
+++ b/src/onemancompany/core/claude_session.py
@@ -430,7 +430,7 @@ class ClaudeDaemon:
                             "ts": datetime.now(timezone.utc).isoformat(),
                             "employee_id": self.employee_id,
                             "role": "system", "type": "result",
-                            "content": result_text[:500] if result_text else "",
+                            "content": result_text or "",
                             "model": model_used,
                             "usage": {
                                 "input_tokens": total_input_tokens,

--- a/src/onemancompany/core/claude_session.py
+++ b/src/onemancompany/core/claude_session.py
@@ -40,8 +40,12 @@ LLM_TRACES_FILENAME = "llm_traces.jsonl"
 def write_llm_trace(project_id: str, entry: dict) -> None:
     """Append a single trace entry to the project's llm_traces.jsonl.
 
+    Only active when OMC_DEBUG=1.
     Called by both ClaudeDaemon (self-hosted) and vessel _on_log (company-hosted).
     """
+    from onemancompany.core.config import IS_DEBUG
+    if not IS_DEBUG:
+        return
     if not project_id or project_id == "default":
         return
     path = PROJECTS_DIR / project_id / LLM_TRACES_FILENAME

--- a/src/onemancompany/core/claude_session.py
+++ b/src/onemancompany/core/claude_session.py
@@ -305,6 +305,7 @@ class ClaudeDaemon:
             if btype == BLOCK_TYPE_TEXT:
                 self._write_trace({
                     "ts": ts, "employee_id": self.employee_id,
+                    "source": "daemon",
                     "role": "assistant", "type": "text",
                     "content": block.get(BLOCK_KEY_TEXT, ""),
                     "model": model, "usage": usage,
@@ -312,6 +313,7 @@ class ClaudeDaemon:
             elif btype == "tool_use":
                 self._write_trace({
                     "ts": ts, "employee_id": self.employee_id,
+                    "source": "daemon",
                     "role": "assistant", "type": "tool_use",
                     "tool_name": block.get("name", ""),
                     "tool_id": block.get("id", ""),
@@ -321,6 +323,7 @@ class ClaudeDaemon:
             elif btype == "tool_result":
                 self._write_trace({
                     "ts": ts, "employee_id": self.employee_id,
+                    "source": "daemon",
                     "role": "tool", "type": "tool_result",
                     "tool_id": block.get("tool_use_id", ""),
                     "content": block.get("content", ""),
@@ -329,6 +332,7 @@ class ClaudeDaemon:
             elif btype == "thinking":
                 self._write_trace({
                     "ts": ts, "employee_id": self.employee_id,
+                    "source": "daemon",
                     "role": "assistant", "type": "thinking",
                     "content": block.get(BLOCK_KEY_TEXT, ""),
                     "model": model,
@@ -347,6 +351,7 @@ class ClaudeDaemon:
         self._write_trace({
             "ts": datetime.now(timezone.utc).isoformat(),
             "employee_id": self.employee_id,
+            "source": "daemon",
             "role": "user", "type": "prompt",
             "content": prompt,
         })
@@ -429,6 +434,7 @@ class ClaudeDaemon:
                         self._write_trace({
                             "ts": datetime.now(timezone.utc).isoformat(),
                             "employee_id": self.employee_id,
+                            "source": "daemon",
                             "role": "system", "type": "result",
                             "content": result_text or "",
                             "model": model_used,

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import yaml
@@ -114,6 +115,7 @@ BLOCK_TYPE_TEXT = "text"  # value of type field for text blocks
 from enum import Enum
 
 ENV_OMC_DEBUG = "OMC_DEBUG"
+IS_DEBUG = os.environ.get(ENV_OMC_DEBUG, "0") == "1"
 ENV_OMC_EMPLOYEE_ID = "OMC_EMPLOYEE_ID"
 ENV_OMC_TASK_ID = "OMC_TASK_ID"
 ENV_OMC_PROJECT_ID = "OMC_PROJECT_ID"

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -2113,11 +2113,14 @@ async def start_ceo_meeting(meeting_type: str) -> dict:
     if not all_emps:
         return {"error": "No employees available"}
 
-    # Exclude founding members (CEO, HR, COO, EA, CSO) — only regular employees attend
+    # Prefer regular employees; fall back to founding members (excluding CEO) if none hired yet
     from onemancompany.core.config import FOUNDING_IDS
     all_emp_ids = [eid for eid in all_emps if eid not in FOUNDING_IDS]
     if not all_emp_ids:
-        return {"error": "No non-founding employees available"}
+        # No regular employees yet — include founding members (HR, COO, EA, CSO)
+        all_emp_ids = [eid for eid in all_emps if eid != CEO_ID]
+    if not all_emp_ids:
+        return {"error": "No employees available for meeting"}
     room_participants = [CEO_ID] + all_emp_ids
 
     # Book largest available room

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -1041,13 +1041,15 @@ async def run_post_task_routine(
         from onemancompany.core.project_archive import load_project
         project_record = load_project(project_id) or {}
 
-        # Filter participants to project team members (excluding CEO)
+        # Filter participants to project team members (excluding CEO);
+        # EA always attends (dispatched the task, needs full context).
         team_members = {
             m["employee_id"]
             for m in project_record.get("team", [])
             if m.get("employee_id") and m["employee_id"] != CEO_ID
         }
         if team_members:
+            team_members.add(EA_ID)
             participants = [pid for pid in participants if pid in team_members]
 
     # Increment current_quarter_tasks for participating normal employees

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -2113,12 +2113,8 @@ async def start_ceo_meeting(meeting_type: str) -> dict:
     if not all_emps:
         return {"error": "No employees available"}
 
-    # Prefer regular employees; fall back to founding members (excluding CEO) if none hired yet
-    from onemancompany.core.config import FOUNDING_IDS
-    all_emp_ids = [eid for eid in all_emps if eid not in FOUNDING_IDS]
-    if not all_emp_ids:
-        # No regular employees yet — include founding members (HR, COO, EA, CSO)
-        all_emp_ids = [eid for eid in all_emps if eid != CEO_ID]
+    # All employees except CEO participate (founding and regular alike)
+    all_emp_ids = [eid for eid in all_emps if eid != CEO_ID]
     if not all_emp_ids:
         return {"error": "No employees available for meeting"}
     room_participants = [CEO_ID] + all_emp_ids

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -1041,17 +1041,14 @@ async def run_post_task_routine(
         from onemancompany.core.project_archive import load_project
         project_record = load_project(project_id) or {}
 
-        # Filter participants to only actual contributors (those with timeline entries)
-        actual_contributors = {
-            entry["employee_id"]
-            for entry in project_record.get("timeline", [])
-            if entry.get("employee_id")
+        # Filter participants to project team members (excluding CEO)
+        team_members = {
+            m["employee_id"]
+            for m in project_record.get("team", [])
+            if m.get("employee_id") and m["employee_id"] != CEO_ID
         }
-        if actual_contributors:
-            # EA always attends (dispatched the task, needs full context).
-            # Everyone else only joins if they actually contributed.
-            actual_contributors.add(EA_ID)
-            participants = [pid for pid in participants if pid in actual_contributors]
+        if team_members:
+            participants = [pid for pid in participants if pid in team_members]
 
     # Increment current_quarter_tasks for participating normal employees
     for pid in participants:

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1099,12 +1099,19 @@ class EmployeeManager:
                 self._log_node(employee_id, entry.node_id, log_type, content)
                 # Also write to project-level LLM trace JSONL
                 if project_id:
+                    from datetime import timezone as _tz
                     from onemancompany.core.claude_session import write_llm_trace
+                    # Normalize on_log types to trace schema
+                    _role_map = {"llm_input": "user", "llm_output": "assistant",
+                                 "tool_call": "assistant", "tool_result": "tool", "result": "system"}
+                    _type_map = {"llm_input": "prompt", "llm_output": "text",
+                                 "tool_call": "tool_use", "tool_result": "tool_result", "result": "result"}
                     write_llm_trace(project_id, {
-                        "ts": datetime.now().isoformat(),
+                        "ts": datetime.now(_tz.utc).isoformat(),
                         "employee_id": employee_id,
-                        "role": "assistant" if log_type in ("llm_output", "llm_input") else "tool",
-                        "type": log_type,
+                        "source": "vessel",
+                        "role": _role_map.get(log_type, "system"),
+                        "type": _type_map.get(log_type, log_type),
                         "content": content,
                     })
 

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1097,6 +1097,16 @@ class EmployeeManager:
 
             def _on_log(log_type: str, content: str) -> None:
                 self._log_node(employee_id, entry.node_id, log_type, content)
+                # Also write to project-level LLM trace JSONL
+                if project_id:
+                    from onemancompany.core.claude_session import write_llm_trace
+                    write_llm_trace(project_id, {
+                        "ts": datetime.now().isoformat(),
+                        "employee_id": employee_id,
+                        "role": "assistant" if log_type in ("llm_output", "llm_input") else "tool",
+                        "type": log_type,
+                        "content": content,
+                    })
 
             # 5. Execute via launcher with retry
             executor = self.executors.get(employee_id)

--- a/tests/unit/core/test_routine.py
+++ b/tests/unit/core/test_routine.py
@@ -130,6 +130,37 @@ class TestCeoMeetingStart:
         routine_mod._active_ceo_meeting = None
 
     @pytest.mark.asyncio
+    async def test_start_with_founding_only(self):
+        """start_ceo_meeting should work with only founding employees (no regular hires)."""
+        from onemancompany.core import routine as routine_mod
+        from onemancompany.core.config import HR_ID, COO_ID, EA_ID, CSO_ID
+
+        # Only founding employees — no regular hires
+        emp_data = {
+            HR_ID: {"name": "HR", "level": 1, "nickname": "HR"},
+            COO_ID: {"name": "COO", "level": 1, "nickname": "COO"},
+            EA_ID: {"name": "EA", "level": 1, "nickname": "EA"},
+            CSO_ID: {"name": "CSO", "level": 1, "nickname": "CSO"},
+        }
+        mock_room = MagicMock(
+            id="room1", name="Main Room", capacity=10,
+            is_booked=False, booked_by="", participants=[],
+        )
+
+        with (
+            patch.object(routine_mod, "load_all_employees", return_value=emp_data),
+            patch.object(routine_mod, "company_state", MagicMock(meeting_rooms={"room1": mock_room})),
+            patch.object(routine_mod, "_store", MagicMock(save_room=AsyncMock())),
+            patch.object(routine_mod, "_publish", new_callable=AsyncMock),
+            patch.object(routine_mod, "_set_participants_status", new_callable=AsyncMock),
+        ):
+            result = await routine_mod.start_ceo_meeting("discussion")
+
+        assert result["status"] == "started"
+        assert len(result["participants"]) == 4  # HR, COO, EA, CSO
+        routine_mod._active_ceo_meeting = None
+
+    @pytest.mark.asyncio
     async def test_start_returns_error_when_meeting_active(self):
         """Should return error dict if a CEO meeting is already in progress."""
         from onemancompany.core import routine as routine_mod


### PR DESCRIPTION
## Summary
- All-hands and discussion meetings now include all non-CEO employees (founding and regular alike), no longer filtering out founding members
- Retrospective meeting participants based on project team field (excluding CEO), EA always attends
- New debug-only feature: project-level LLM trace logging (`llm_traces.jsonl`) — records all LLM calls, tool uses, reasoning, and results when `OMC_DEBUG=1`

## LLM Trace Schema
```jsonl
{"ts": "UTC", "employee_id": "...", "source": "daemon|langchain|vessel", "role": "user|assistant|tool|system", "type": "prompt|text|tool_use|tool_result|thinking|result", ...}
```

## Test plan
- [x] `test_start_with_founding_only` — meetings work with founding employees only
- [x] All 1996 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)