### PR TITLE
fix: cancel project only cancels target project

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2744,6 +2744,9 @@ body {
 }
 
 /* Follow-up input in detail view */
+.task-followup-section .hidden {
+  display: none;
+}
 .task-followup-section {
   margin: 8px 0;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.489",
+  "version": "0.2.490",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.490",
+  "version": "0.2.491",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.489"
+version = "0.2.490"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.490"
+version = "0.2.491"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -904,12 +904,19 @@ class EmployeeManager:
                 except Exception as e:
                     logger.error("Failed to cancel node {} for project {}: {}", entry.node_id, project_id, e)
 
-            # Cancel running asyncio.Task if it's working on this project
-            if emp_id in self._running_tasks:
-                running = self._running_tasks[emp_id]
-                if not running.done():
-                    running.cancel()
-                    logger.info("Cancelled running asyncio.Task for {} (project {})", emp_id, project_id)
+            # Cancel running asyncio.Task only if it's actually working on this project
+            current_entry = self._current_entries.get(emp_id)
+            if current_entry and emp_id in self._running_tasks:
+                try:
+                    cur_tree = get_tree(current_entry.tree_path)
+                    cur_node = cur_tree.get_node(current_entry.node_id)
+                    if cur_node and cur_node.project_id == project_id:
+                        running = self._running_tasks[emp_id]
+                        if not running.done():
+                            running.cancel()
+                            logger.info("Cancelled running asyncio.Task for {} (project {})", emp_id, project_id)
+                except Exception as exc:
+                    logger.debug("Could not check running task for {}: {}", emp_id, exc)
 
         return count
 

--- a/tests/unit/core/test_vessel.py
+++ b/tests/unit/core/test_vessel.py
@@ -573,3 +573,77 @@ class TestScheduleEntry:
         """ScheduleEntry should be importable from agent_loop.py."""
         from onemancompany.core.agent_loop import ScheduleEntry as SE
         assert SE is ScheduleEntry
+
+
+class TestAbortProject:
+    """Tests for EmployeeManager.abort_project — cancel only the target project."""
+
+    def test_abort_cancels_only_target_project_running_task(self, tmp_path):
+        """Running asyncio.Task should only be cancelled if it belongs to the target project."""
+        mgr = EmployeeManager()
+
+        # Employee has a scheduled task for proj-A (the target)
+        entry_a, _, _ = _make_tree_entry(tmp_path / "a", employee_id="emp01",
+                                          project_id="proj-A", status="pending")
+        mgr._schedule["emp01"] = [entry_a]
+
+        # But the *running* task is for proj-B (different project)
+        entry_b, _, _ = _make_tree_entry(tmp_path / "b", employee_id="emp01",
+                                          project_id="proj-B", status="processing")
+        mgr._current_entries["emp01"] = entry_b
+
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        mgr._running_tasks["emp01"] = mock_task
+
+        mgr.abort_project("proj-A")
+
+        # Running task for proj-B must NOT be cancelled
+        mock_task.cancel.assert_not_called()
+
+    def test_abort_cancels_running_task_for_matching_project(self, tmp_path):
+        """Running asyncio.Task IS cancelled when it belongs to the target project."""
+        mgr = EmployeeManager()
+
+        # Employee has a scheduled task for proj-A
+        entry_a, _, _ = _make_tree_entry(tmp_path / "a", employee_id="emp01",
+                                          project_id="proj-A", status="pending")
+        mgr._schedule["emp01"] = [entry_a]
+
+        # Running task is also proj-A
+        entry_run, _, _ = _make_tree_entry(tmp_path / "r", employee_id="emp01",
+                                            project_id="proj-A", status="processing")
+        mgr._current_entries["emp01"] = entry_run
+
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        mgr._running_tasks["emp01"] = mock_task
+
+        mgr.abort_project("proj-A")
+
+        # Running task for proj-A SHOULD be cancelled
+        mock_task.cancel.assert_called_once()
+
+    def test_abort_does_not_cancel_other_employees(self, tmp_path):
+        """Employees with no tasks for the target project are untouched."""
+        mgr = EmployeeManager()
+
+        # emp01 has tasks for proj-A (target)
+        entry_a, _, _ = _make_tree_entry(tmp_path / "a", employee_id="emp01",
+                                          project_id="proj-A", status="pending")
+        mgr._schedule["emp01"] = [entry_a]
+
+        # emp02 has tasks only for proj-B
+        entry_b, _, _ = _make_tree_entry(tmp_path / "b", employee_id="emp02",
+                                          project_id="proj-B", status="processing")
+        mgr._schedule["emp02"] = [entry_b]
+        mgr._current_entries["emp02"] = entry_b
+
+        mock_task_02 = MagicMock()
+        mock_task_02.done.return_value = False
+        mgr._running_tasks["emp02"] = mock_task_02
+
+        mgr.abort_project("proj-A")
+
+        # emp02's running task must NOT be cancelled
+        mock_task_02.cancel.assert_not_called()


### PR DESCRIPTION
## Summary
- Fixed `abort_project()` in `vessel.py` which cancelled running asyncio.Tasks for **all** employees regardless of whether their running task belonged to the target project
- Now checks `_current_entries` to verify the running task's `project_id` matches before cancelling
- Added 3 unit tests covering: non-matching project preserved, matching project cancelled, unrelated employees untouched

## Root Cause
`abort_project()` iterated all employees in `_schedule` and at lines 907-912 unconditionally cancelled `_running_tasks[emp_id]` without checking if the currently executing task actually belonged to the target project. This meant cancelling project A would also kill running tasks for project B if the employee had entries for both.

## Test plan
- [x] `TestAbortProject::test_abort_cancels_only_target_project_running_task` — running task for different project is NOT cancelled
- [x] `TestAbortProject::test_abort_cancels_running_task_for_matching_project` — running task for target project IS cancelled
- [x] `TestAbortProject::test_abort_does_not_cancel_other_employees` — employees with no tasks for target project are untouched
- [x] Full test suite (1999 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)