### PR TITLE
fix: project cost tracking for company-hosted employees

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3804,7 +3804,7 @@ class AppController {
         // Cost & Budget
         const cost = doc.cost || {};
         if (cost.actual_cost_usd > 0 || cost.budget_estimate_usd > 0) {
-          html += `<div style="font-size:7px;color:var(--pixel-cyan);margin:8px 0 4px;">Cost & Budget:</div>`;
+          html += `<div style="font-size:7px;color:var(--pixel-cyan);margin:8px 0 4px;">Cost & Budget: <span style="font-size:5px;color:var(--text-dim);">(estimated)</span></div>`;
           const actual = cost.actual_cost_usd || 0;
           const budget = cost.budget_estimate_usd || 0;
           const tokens = cost.token_usage || {};
@@ -4791,7 +4791,7 @@ class AppController {
       const overheadCost = oh.total_cost_usd || 0;
       costHtml += `
         <div class="dash-section">
-          <div class="dash-title">\u{1F4B0} Cost Overview</div>
+          <div class="dash-title">\u{1F4B0} Cost Overview <span style="font-size:5px;color:var(--text-dim);">(estimated, subject to actual billing)</span></div>
           <div class="dash-stats">
             <div class="dash-stat"><span class="dash-num" style="color:var(--pixel-yellow);">$${grandTotal.toFixed(3)}</span><span class="dash-label">Grand Total</span></div>
             <div class="dash-stat"><span class="dash-num">$${projectCost.toFixed(3)}</span><span class="dash-label">Projects</span></div>
@@ -6150,7 +6150,7 @@ class AppController {
         }
 
         const cost = doc.cost || {};
-        detailHtml += `<div style="font-size:7px;color:var(--pixel-cyan);margin:8px 0 3px;">Cost & Budget</div>`;
+        detailHtml += `<div style="font-size:7px;color:var(--pixel-cyan);margin:8px 0 3px;">Cost & Budget <span style="font-size:5px;color:var(--text-dim);">(estimated)</span></div>`;
         const actual = cost.actual_cost_usd || 0;
         const budget = cost.budget_estimate_usd || 0;
         const tokens = cost.token_usage || {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.492",
+  "version": "0.2.493",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.491",
+  "version": "0.2.492",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.492"
+version = "0.2.493"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.491"
+version = "0.2.492"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -200,6 +200,7 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
                 base_url=base_url,
                 temperature=effective_temp,
                 max_retries=3,
+                stream_usage=True,
             )
 
     # --- Fallback: unknown provider or no key → fall back to openrouter with default model ---
@@ -217,6 +218,7 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
         base_url=settings.openrouter_base_url,
         temperature=effective_temp,
         max_retries=3,
+        stream_usage=True,
     )
 
 
@@ -267,11 +269,16 @@ async def tracked_ainvoke(
 
     result = await llm.ainvoke(messages)
 
-    # Extract token usage from response_metadata
+    # Extract token usage from response_metadata, fallback to usage_metadata
     meta = getattr(result, "response_metadata", {}) or {}
     usage = meta.get("usage", {}) or meta.get("token_usage", {}) or {}
     input_tokens = usage.get("prompt_tokens", 0) or usage.get("input_tokens", 0)
     output_tokens = usage.get("completion_tokens", 0) or usage.get("output_tokens", 0)
+    if not input_tokens and not output_tokens:
+        usage_meta = getattr(result, "usage_metadata", None)
+        if usage_meta and isinstance(usage_meta, dict):
+            input_tokens = usage_meta.get("input_tokens", 0)
+            output_tokens = usage_meta.get("output_tokens", 0)
 
     # Determine model name
     model_name = meta.get("model_name", "") or meta.get("model", "")
@@ -523,12 +530,20 @@ class BaseAgentRunner:
             elif kind == "on_chat_model_end":
                 output = data.get("output", None)
                 if output:
-                    # Extract token usage from response_metadata
+                    # Extract token usage — try response_metadata first, then usage_metadata
                     meta = getattr(output, "response_metadata", {}) or {}
                     usage = meta.get("usage", {}) or meta.get("token_usage", {}) or {}
                     if usage:
                         total_input_tokens += usage.get("prompt_tokens", 0) or usage.get("input_tokens", 0)
                         total_output_tokens += usage.get("completion_tokens", 0) or usage.get("output_tokens", 0)
+                    else:
+                        # Streaming mode: usage lives in usage_metadata (requires stream_usage=True)
+                        usage_meta = getattr(output, "usage_metadata", None)
+                        if usage_meta and isinstance(usage_meta, dict):
+                            total_input_tokens += usage_meta.get("input_tokens", 0)
+                            total_output_tokens += usage_meta.get("output_tokens", 0)
+                        else:
+                            logger.debug("[COST] on_chat_model_end: no usage data for employee={}, meta_keys={}", self.employee_id, list(meta.keys()))
                     if not model_used:
                         model_used = meta.get("model_name", "") or meta.get("model", "")
 
@@ -599,8 +614,16 @@ class BaseAgentRunner:
                 continue
             meta = getattr(msg, "response_metadata", {}) or {}
             usage = meta.get("usage", {}) or meta.get("token_usage", {}) or {}
-            total_input += usage.get("prompt_tokens", 0) or usage.get("input_tokens", 0)
-            total_output += usage.get("completion_tokens", 0) or usage.get("output_tokens", 0)
+            msg_input = usage.get("prompt_tokens", 0) or usage.get("input_tokens", 0)
+            msg_output = usage.get("completion_tokens", 0) or usage.get("output_tokens", 0)
+            # Fallback: streaming mode puts usage in usage_metadata
+            if not msg_input and not msg_output:
+                usage_meta = getattr(msg, "usage_metadata", None)
+                if usage_meta and isinstance(usage_meta, dict):
+                    msg_input = usage_meta.get("input_tokens", 0)
+                    msg_output = usage_meta.get("output_tokens", 0)
+            total_input += msg_input
+            total_output += msg_output
             if not model:
                 model = meta.get("model_name", "") or meta.get("model", "")
 

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -287,8 +287,11 @@ async def tracked_ainvoke(
         cfg = employee_configs.get(employee_id)
         model_name = cfg.llm_model if cfg and cfg.llm_model else settings.default_llm_model
 
-    # Compute cost
-    if input_tokens or output_tokens:
+    # Compute cost: prefer provider-reported cost, fallback to catalog price
+    provider_cost = usage.get("cost") if usage else None
+    if provider_cost is not None and provider_cost:
+        cost_usd = float(provider_cost)
+    elif input_tokens or output_tokens:
         costs = get_model_cost(model_name)
         cost_usd = (input_tokens * costs["input"] + output_tokens * costs["output"]) / 1_000_000
     else:
@@ -510,6 +513,7 @@ class BaseAgentRunner:
         final_content = ""
         total_input_tokens = 0
         total_output_tokens = 0
+        provider_cost: float | None = None  # provider-reported cost (e.g. OpenRouter)
         model_used = ""
         last_tool_calls: list[str] = []  # track tool names for fallback
         last_tool_results: list[str] = []
@@ -536,6 +540,9 @@ class BaseAgentRunner:
                     if usage:
                         total_input_tokens += usage.get("prompt_tokens", 0) or usage.get("input_tokens", 0)
                         total_output_tokens += usage.get("completion_tokens", 0) or usage.get("output_tokens", 0)
+                        # Provider-reported cost (e.g. OpenRouter includes "cost" in token_usage)
+                        if "cost" in usage and usage["cost"]:
+                            provider_cost = (provider_cost or 0.0) + float(usage["cost"])
                     else:
                         # Streaming mode: usage lives in usage_metadata (requires stream_usage=True)
                         usage_meta = getattr(output, "usage_metadata", None)
@@ -574,20 +581,28 @@ class BaseAgentRunner:
             parts.extend(last_tool_results)
             final_content = "\n".join(parts)
 
+        # Compute cost: prefer provider-reported cost, fallback to catalog price
+        _model = model_used or self._get_model_name()
+        if provider_cost is not None:
+            _cost_usd = provider_cost
+        elif total_input_tokens or total_output_tokens:
+            from onemancompany.core.model_costs import get_model_cost
+            _costs = get_model_cost(_model)
+            _cost_usd = (total_input_tokens * _costs["input"] + total_output_tokens * _costs["output"]) / 1_000_000
+        else:
+            _cost_usd = 0.0
+
         # Store usage for caller to read
         self._last_usage = {
-            "model": model_used or self._get_model_name(),
+            "model": _model,
             "input_tokens": total_input_tokens,
             "output_tokens": total_output_tokens,
             "total_tokens": total_input_tokens + total_output_tokens,
+            "cost_usd": _cost_usd,
         }
 
         # Record streaming usage into overhead
-        if total_input_tokens or total_output_tokens:
-            from onemancompany.core.model_costs import get_model_cost
-            _model = model_used or self._get_model_name()
-            _costs = get_model_cost(_model)
-            _cost_usd = (total_input_tokens * _costs["input"] + total_output_tokens * _costs["output"]) / 1_000_000
+        if total_input_tokens or total_output_tokens or _cost_usd > 0:
             _record_overhead("agent_task", _model, total_input_tokens, total_output_tokens, _cost_usd)
 
         self._set_status(STATUS_IDLE)
@@ -608,6 +623,7 @@ class BaseAgentRunner:
 
         total_input = 0
         total_output = 0
+        provider_cost: float | None = None
         model = ""
         for msg in result.get(_LG_MESSAGES_KEY, []):
             if not isinstance(msg, AIMessage):
@@ -616,6 +632,9 @@ class BaseAgentRunner:
             usage = meta.get("usage", {}) or meta.get("token_usage", {}) or {}
             msg_input = usage.get("prompt_tokens", 0) or usage.get("input_tokens", 0)
             msg_output = usage.get("completion_tokens", 0) or usage.get("output_tokens", 0)
+            # Provider-reported cost (e.g. OpenRouter)
+            if "cost" in usage and usage["cost"]:
+                provider_cost = (provider_cost or 0.0) + float(usage["cost"])
             # Fallback: streaming mode puts usage in usage_metadata
             if not msg_input and not msg_output:
                 usage_meta = getattr(msg, "usage_metadata", None)
@@ -628,16 +647,25 @@ class BaseAgentRunner:
                 model = meta.get("model_name", "") or meta.get("model", "")
 
         model = model or self._get_model_name()
+
+        # Cost: prefer provider-reported, fallback to catalog price
+        if provider_cost is not None:
+            cost_usd = provider_cost
+        elif total_input or total_output:
+            costs = get_model_cost(model)
+            cost_usd = (total_input * costs["input"] + total_output * costs["output"]) / 1_000_000
+        else:
+            cost_usd = 0.0
+
         self._last_usage = {
             "model": model,
             "input_tokens": total_input,
             "output_tokens": total_output,
             "total_tokens": total_input + total_output,
+            "cost_usd": cost_usd,
         }
 
-        if total_input or total_output:
-            costs = get_model_cost(model)
-            cost_usd = (total_input * costs["input"] + total_output * costs["output"]) / 1_000_000
+        if total_input or total_output or cost_usd > 0:
             _record_overhead(
                 "agent_task", model, total_input, total_output, cost_usd,
                 employee_id=self.employee_id,

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1186,6 +1186,12 @@ class EmployeeManager:
             self._log_node(employee_id, entry.node_id, "result", node.result or "")
 
             # Record token usage to node
+            logger.debug("[COST] employee={} node={} launch_result tokens: input={} output={} total={} model={}",
+                         employee_id, entry.node_id,
+                         launch_result.input_tokens if launch_result else 0,
+                         launch_result.output_tokens if launch_result else 0,
+                         launch_result.total_tokens if launch_result else 0,
+                         launch_result.model_used if launch_result else "")
             if launch_result and launch_result.total_tokens > 0:
                 node.model_used = launch_result.model_used
                 node.input_tokens += launch_result.input_tokens

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -325,6 +325,7 @@ class LaunchResult:
     input_tokens: int = 0
     output_tokens: int = 0
     total_tokens: int = 0
+    cost_usd: float | None = None  # provider-reported cost; None = use catalog price
 
 
 @dataclass
@@ -380,6 +381,7 @@ class LangChainExecutor(Launcher):
             input_tokens=usage.get("input_tokens", 0),
             output_tokens=usage.get("output_tokens", 0),
             total_tokens=usage.get("total_tokens", 0),
+            cost_usd=usage.get("cost_usd"),
         )
 
 
@@ -1196,11 +1198,15 @@ class EmployeeManager:
                 node.model_used = launch_result.model_used
                 node.input_tokens += launch_result.input_tokens
                 node.output_tokens += launch_result.output_tokens
-                from onemancompany.core.model_costs import get_model_cost
-                costs = get_model_cost(node.model_used)
-                node.cost_usd = (
-                    node.input_tokens * costs["input"] + node.output_tokens * costs["output"]
-                ) / 1_000_000
+                # Prefer provider-reported cost, fallback to catalog price
+                if launch_result.cost_usd is not None:
+                    node.cost_usd += launch_result.cost_usd
+                else:
+                    from onemancompany.core.model_costs import get_model_cost
+                    costs = get_model_cost(node.model_used)
+                    node.cost_usd = (
+                        node.input_tokens * costs["input"] + node.output_tokens * costs["output"]
+                    ) / 1_000_000
 
         except asyncio.CancelledError:
             agent_error = True


### PR DESCRIPTION
## Summary
- Fixed project Cost & Budget always showing "No cost data" for company-hosted (LangChain) employees
- Root cause: LangChain's `astream_events` puts token usage in `usage_metadata` attribute, not `response_metadata.usage`. Code only checked `response_metadata`, so streaming token counts were always 0.
- Added `stream_usage=True` to all `ChatOpenAI` instances so `usage_metadata` is populated
- Added `usage_metadata` fallback reads in all 3 token extraction paths: `run_streamed()`, `tracked_ainvoke()`, `_extract_and_record_usage()`

## Cost unit clarification
- `get_model_cost()` returns price per 1M tokens (USD)
- `cost_usd` = `(input_tokens * cost_per_1M + output_tokens * cost_per_1M) / 1_000_000` → USD
- OpenRouter returns `prompt_tokens` / `completion_tokens` (raw token counts, not divided)

## Test plan
- [x] Verified OpenRouter API returns usage data in `response_metadata.token_usage` (non-streaming `ainvoke`)
- [x] Verified `astream_events` `on_chat_model_end` has NO usage in `response_metadata` but HAS it in `usage_metadata` with `stream_usage=True`
- [x] All 1999 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)