### PR TITLE
feat: show talent description.md in shortlist detail

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -3144,6 +3144,7 @@ class AppController {
         <div><div class="detail-label">Hosting</div><div class="detail-text">${hostingLabel}</div></div>
         <div><div class="detail-label">Auth</div><div class="detail-text">${authLabel}</div></div>
       </div>
+      ${c.description_md ? `<div class="detail-section"><div class="detail-label">Description</div><div class="detail-description md-rendered">${this._renderMarkdown(c.description_md)}</div></div>` : ''}
     `;
 
     // Wire up panel buttons

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -2233,6 +2233,17 @@ body {
   color: var(--pixel-white);
   line-height: 1.5;
 }
+.detail-description {
+  font-size: 10px;
+  color: var(--pixel-white);
+  line-height: 1.6;
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 6px;
+  background: var(--bg-dark);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
 .detail-tags-list,
 .detail-skills-list,
 .detail-tools-list {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.493",
+  "version": "0.2.494",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.493"
+version = "0.2.494"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Render candidate's `description_md` field as markdown in the shortlist detail panel
- Uses existing `_renderMarkdown()` method, displayed below the detail grid
- Scrollable container with max-height 300px for long descriptions

## Test plan
- [x] All 1999 tests pass
- [ ] Manual: open shortlist, click a candidate, verify description renders below the grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)