### PR TITLE
feat: department signs + fix child-failure stuck HOLDING parent

### DIFF
--- a/frontend/office.js
+++ b/frontend/office.js
@@ -538,11 +538,11 @@ class OfficeRenderer {
       const zone = zones[i];
       const label = zone.label_en || zone.department;
       const color = zone.label_color || '#888';
-      // Place sign at start of zone, vertically at last dept row
-      const signX = (zone.start_col + 0.5) * TILE;
-      const signY = (deptEndRow + WALL_ROWS + 1) * TILE;
+      // Place sign centered in zone, below dept area (above tools/rooms)
+      const zoneMidX = ((zone.start_col + zone.end_col) / 2) * TILE;
+      const signY = (deptEndRow + WALL_ROWS + 1.8) * TILE;
 
-      this._drawDeptSign(signX, signY, label, color);
+      this._drawDeptSign(zoneMidX, signY, label, color);
 
       // Zone divider line
       if (i > 0) {
@@ -560,29 +560,29 @@ class OfficeRenderer {
       }
     }
 
-    // Executive row label as sign
+    // Executive row label as sign — centered in exec area
     const execRowH = layout.exec_row_height || 2;
-    const execSignX = 0.5 * TILE;
+    const execMidX = (MAP_COLS / 2) * TILE;
     const execSignY = (execRow + execRowH + WALL_ROWS) * TILE;
-    this._drawDeptSign(execSignX, execSignY, 'Executive', '#c0b060');
+    this._drawDeptSign(execMidX, execSignY, 'Executive', '#c0b060');
   }
 
   /** Draw a pixel-art garden-style sign: stake + board with label text. */
   _drawDeptSign(cx, bottomY, label, color) {
     const ctx = this.ctx;
-    const stakeW = 2;
-    const stakeH = 18;
+    const stakeW = 3;
+    const stakeH = 22;
     const stakeColor = '#6b4226';
     const stakeHighlight = '#8a5a35';
 
     // Measure text to size the board
     ctx.save();
-    ctx.font = 'bold 8px monospace';
+    ctx.font = 'bold 11px monospace';
     const textW = ctx.measureText(label).width;
-    const boardPadX = 5;
-    const boardPadY = 3;
+    const boardPadX = 8;
+    const boardPadY = 5;
     const boardW = textW + boardPadX * 2;
-    const boardH = 12 + boardPadY * 2;
+    const boardH = 14 + boardPadY * 2;
     const boardX = cx - boardW / 2;
     const boardY = bottomY - stakeH - boardH;
 
@@ -599,18 +599,18 @@ class OfficeRenderer {
     this._rect(boardX, boardY, boardW, boardH, boardBg);
     // Border (2px frame)
     ctx.strokeStyle = boardBorder;
-    ctx.lineWidth = 1.5;
+    ctx.lineWidth = 2;
     ctx.strokeRect(boardX + 0.5, boardY + 0.5, boardW - 1, boardH - 1);
 
     // Top decorative line (colored accent)
-    this._rect(boardX + 2, boardY + 2, boardW - 4, 2, color);
+    this._rect(boardX + 2, boardY + 2, boardW - 4, 3, color);
 
     // Label text
     ctx.fillStyle = '#2a2018';
-    ctx.font = 'bold 8px monospace';
+    ctx.font = 'bold 11px monospace';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText(label, cx, boardY + boardH / 2 + 1);
+    ctx.fillText(label, cx, boardY + boardH / 2 + 2);
     ctx.restore();
   }
 

--- a/frontend/office.js
+++ b/frontend/office.js
@@ -534,27 +534,20 @@ class OfficeRenderer {
 
     if (zones.length === 0) return;
 
-    const zoneMidCanvasY = ((deptStartRow + deptEndRow) / 2 + WALL_ROWS) * TILE + TILE / 2;
-
     for (let i = 0; i < zones.length; i++) {
       const zone = zones[i];
-      const zoneWidthPx = (zone.end_col - zone.start_col) * TILE;
-      const centerX = ((zone.start_col + zone.end_col) / 2) * TILE;
       const label = zone.label_en || zone.department;
-      const fontSize = Math.min(Math.floor(zoneWidthPx / label.length * 1.6), 32);
+      const color = zone.label_color || '#888';
+      // Place sign at start of zone, vertically at last dept row
+      const signX = (zone.start_col + 0.5) * TILE;
+      const signY = (deptEndRow + WALL_ROWS + 1) * TILE;
 
-      ctx.save();
-      ctx.globalAlpha = 0.12;
-      ctx.fillStyle = zone.label_color || '#888';
-      ctx.font = `bold ${fontSize}px monospace`;
-      ctx.textAlign = 'center';
-      ctx.textBaseline = 'middle';
-      ctx.fillText(label, centerX, zoneMidCanvasY);
-      ctx.restore();
+      this._drawDeptSign(signX, signY, label, color);
 
+      // Zone divider line
       if (i > 0) {
         const divX = zone.start_col * TILE;
-        ctx.strokeStyle = zone.label_color || '#555';
+        ctx.strokeStyle = color;
         ctx.globalAlpha = 0.25;
         ctx.lineWidth = 1;
         ctx.setLineDash([3, 3]);
@@ -567,17 +560,60 @@ class OfficeRenderer {
       }
     }
 
+    // Executive row label as sign
     const execRowH = layout.exec_row_height || 2;
-    const execMidCanvasY = (execRow + execRowH / 2 + WALL_ROWS) * TILE;
+    const execSignX = 0.5 * TILE;
+    const execSignY = (execRow + execRowH + WALL_ROWS) * TILE;
+    this._drawDeptSign(execSignX, execSignY, 'Executive', '#c0b060');
+  }
+
+  /** Draw a pixel-art garden-style sign: stake + board with label text. */
+  _drawDeptSign(cx, bottomY, label, color) {
+    const ctx = this.ctx;
+    const stakeW = 2;
+    const stakeH = 18;
+    const stakeColor = '#6b4226';
+    const stakeHighlight = '#8a5a35';
+
+    // Measure text to size the board
     ctx.save();
-    ctx.globalAlpha = 0.1;
-    ctx.fillStyle = '#c0b060';
-    ctx.font = 'bold 22px monospace';
+    ctx.font = 'bold 8px monospace';
+    const textW = ctx.measureText(label).width;
+    const boardPadX = 5;
+    const boardPadY = 3;
+    const boardW = textW + boardPadX * 2;
+    const boardH = 12 + boardPadY * 2;
+    const boardX = cx - boardW / 2;
+    const boardY = bottomY - stakeH - boardH;
+
+    // Stake (wooden post)
+    this._rect(cx - stakeW / 2, bottomY - stakeH, stakeW, stakeH, stakeColor);
+    this._rect(cx - stakeW / 2, bottomY - stakeH, 1, stakeH, stakeHighlight);
+
+    // Board background
+    const boardBg = '#f5eed6';
+    const boardBorder = this._darken(color, 30);
+    // Shadow
+    this._rect(boardX + 1, boardY + 1, boardW, boardH, 'rgba(0,0,0,0.2)');
+    // Main board
+    this._rect(boardX, boardY, boardW, boardH, boardBg);
+    // Border (2px frame)
+    ctx.strokeStyle = boardBorder;
+    ctx.lineWidth = 1.5;
+    ctx.strokeRect(boardX + 0.5, boardY + 0.5, boardW - 1, boardH - 1);
+
+    // Top decorative line (colored accent)
+    this._rect(boardX + 2, boardY + 2, boardW - 4, 2, color);
+
+    // Label text
+    ctx.fillStyle = '#2a2018';
+    ctx.font = 'bold 8px monospace';
     ctx.textAlign = 'center';
     ctx.textBaseline = 'middle';
-    ctx.fillText('Executive', 10 * TILE, execMidCanvasY);
+    ctx.fillText(label, cx, boardY + boardH / 2 + 1);
     ctx.restore();
   }
+
 
   // ── Bulletin Board ─────────────────────────────────────────────────────────
 

--- a/frontend/office.js
+++ b/frontend/office.js
@@ -614,7 +614,6 @@ class OfficeRenderer {
     ctx.restore();
   }
 
-
   // ── Bulletin Board ─────────────────────────────────────────────────────────
 
   drawBulletinBoard() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.494",
+  "version": "0.2.495",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.495",
+  "version": "0.2.496",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.496",
+  "version": "0.2.497",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.497",
+  "version": "0.2.498",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.497"
+version = "0.2.498"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.494"
+version = "0.2.495"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.495"
+version = "0.2.496"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.496"
+version = "0.2.497"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1903,10 +1903,8 @@ class EmployeeManager:
                     notify_node.node_type = NodeType.WATCHDOG_NUDGE
                     notify_node.project_id = project_id
                     notify_node.project_dir = parent_node.project_dir or str(Path(entry.tree_path).parent)
-                    from onemancompany.core.task_tree import save_tree_async
                     save_tree_async(entry.tree_path)
-                    tree_path = entry.tree_path
-                    self.schedule_node(parent_node.employee_id, notify_node.id, tree_path)
+                    self.schedule_node(parent_node.employee_id, notify_node.id, entry.tree_path)
                     self._schedule_next(parent_node.employee_id)
 
                 elif needs_review and not has_active_review:

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1862,7 +1862,54 @@ class EmployeeManager:
                     if c.node_type == NodeType.REVIEW
                     and c.status in (TaskPhase.PENDING.value, TaskPhase.PROCESSING.value)
                 )
-                if needs_review and not has_active_review:
+                # Check for failed children when parent is HOLDING — resume parent
+                # so it can react (retry via reject_child, reassign, or escalate).
+                has_failed_child = any(
+                    c for c in non_review_children
+                    if c.status == TaskPhase.FAILED.value
+                )
+                if has_failed_child and parent_node.status == TaskPhase.HOLDING.value:
+                    failed_children = [
+                        c for c in non_review_children
+                        if c.status == TaskPhase.FAILED.value
+                    ]
+                    failure_summary = "; ".join(
+                        f"[{c.employee_id}] {c.description_preview}: {(c.result or 'no details')[:150]}"
+                        for c in failed_children
+                    )
+                    resume_desc = (
+                        f"[子任务失败通知] 以下子任务执行失败，请决定后续处理：\n\n"
+                        f"{failure_summary}\n\n"
+                        f"可选操作：\n"
+                        f"- reject_child(node_id, reason, retry=True) 重新分配任务\n"
+                        f"- reject_child(node_id, reason, retry=False) 放弃该任务\n"
+                        f"- dispatch_child 分配给其他员工重试\n"
+                        f"- 如项目无法继续，请说明原因"
+                    )
+                    logger.info(
+                        "[ON_CHILD_COMPLETE] child {} FAILED — resuming HOLDING parent {} with failure context",
+                        node.id, parent_node.id,
+                    )
+                    # Transition parent back to PROCESSING so it can be re-executed
+                    parent_node.set_status(TaskPhase.PROCESSING)
+                    logger.debug("[TASK LIFECYCLE] parent={} HOLDING → PROCESSING (child failed, resuming)", parent_node.id)
+                    # Inject failure context into parent's description for re-execution
+                    notify_node = tree.add_child(
+                        parent_id=parent_node.id,
+                        employee_id=parent_node.employee_id,
+                        description=resume_desc,
+                        acceptance_criteria=[],
+                    )
+                    notify_node.node_type = NodeType.WATCHDOG_NUDGE
+                    notify_node.project_id = project_id
+                    notify_node.project_dir = parent_node.project_dir or str(Path(entry.tree_path).parent)
+                    from onemancompany.core.task_tree import save_tree_async
+                    save_tree_async(entry.tree_path)
+                    tree_path = entry.tree_path
+                    self.schedule_node(parent_node.employee_id, notify_node.id, tree_path)
+                    self._schedule_next(parent_node.employee_id)
+
+                elif needs_review and not has_active_review:
                     logger.info(
                         "[ON_CHILD_COMPLETE] child {} completed — triggering incremental review for parent {}",
                         node.id, parent_node.id,

--- a/tests/unit/core/test_vessel.py
+++ b/tests/unit/core/test_vessel.py
@@ -647,3 +647,121 @@ class TestAbortProject:
 
         # emp02's running task must NOT be cancelled
         mock_task_02.cancel.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _on_child_complete_inner — child FAILED resumes HOLDING parent
+# ---------------------------------------------------------------------------
+
+class TestChildFailedResumesHoldingParent:
+    """When a child task FAILS and its parent is HOLDING, the parent should be
+    resumed so it can react (retry, reassign, or escalate)."""
+
+    @pytest.mark.asyncio
+    async def test_child_failed_resumes_holding_parent(self, tmp_path):
+        """Parent in HOLDING should be resumed when child FAILS."""
+        mgr = EmployeeManager()
+
+        # Build tree: root (CEO) → EA parent (HOLDING) → worker child (FAILED)
+        tree = TaskTree(project_id="proj-stuck")
+        root = tree.create_root(employee_id="ceo", description="CEO prompt")
+        root.node_type = "ceo_prompt"
+        root.status = TaskPhase.PENDING.value
+
+        ea_parent = tree.add_child(
+            parent_id=root.id, employee_id="00002",
+            description="EA manages project", acceptance_criteria=[],
+        )
+        ea_parent.set_status(TaskPhase.PROCESSING)
+        ea_parent.set_status(TaskPhase.HOLDING)
+        ea_parent.project_id = "proj-stuck"
+        ea_parent.project_dir = str(tmp_path)
+
+        worker_child = tree.add_child(
+            parent_id=ea_parent.id, employee_id="emp10",
+            description="Do the work", acceptance_criteria=[],
+        )
+        worker_child.set_status(TaskPhase.PROCESSING)
+        worker_child.set_status(TaskPhase.FAILED)
+        worker_child.result = "Error: connection timeout"
+        worker_child.project_id = "proj-stuck"
+        worker_child.project_dir = str(tmp_path)
+
+        tree_path = tmp_path / "task_tree.yaml"
+        tree.save(tree_path)
+
+        entry = ScheduleEntry(node_id=worker_child.id, tree_path=str(tree_path))
+
+        # Schedule EA parent so resume can find it
+        mgr._schedule["00002"] = [
+            ScheduleEntry(node_id=ea_parent.id, tree_path=str(tree_path)),
+        ]
+
+        with patch("onemancompany.core.task_tree.get_tree", return_value=tree), \
+             patch("onemancompany.core.task_tree.save_tree_async"), \
+             patch("onemancompany.core.vessel._store") as mock_store, \
+             patch.object(mgr, "_publish_node_update"), \
+             patch.object(mgr, "schedule_node"), \
+             patch.object(mgr, "_schedule_next"):
+            mock_store.save_employee_runtime = AsyncMock()
+
+            await mgr._on_child_complete_inner("emp10", entry, project_id="proj-stuck")
+
+        # EA parent should no longer be HOLDING — it should be re-scheduled
+        # to process again with the failure context
+        assert ea_parent.status != TaskPhase.HOLDING.value, \
+            "Parent should not remain HOLDING after child FAILS"
+
+    @pytest.mark.asyncio
+    async def test_child_completed_does_not_trigger_failure_resume(self, tmp_path):
+        """COMPLETED child should NOT trigger the failure-resume path."""
+        mgr = EmployeeManager()
+
+        tree = TaskTree(project_id="proj-ok")
+        root = tree.create_root(employee_id="ceo", description="CEO prompt")
+        root.node_type = "ceo_prompt"
+        root.status = TaskPhase.PENDING.value
+
+        ea_parent = tree.add_child(
+            parent_id=root.id, employee_id="00002",
+            description="EA manages project", acceptance_criteria=[],
+        )
+        ea_parent.set_status(TaskPhase.PROCESSING)
+        ea_parent.set_status(TaskPhase.HOLDING)
+        ea_parent.project_id = "proj-ok"
+        ea_parent.project_dir = str(tmp_path)
+
+        worker_child = tree.add_child(
+            parent_id=ea_parent.id, employee_id="emp10",
+            description="Do the work", acceptance_criteria=[],
+        )
+        worker_child.set_status(TaskPhase.PROCESSING)
+        worker_child.set_status(TaskPhase.COMPLETED)
+        worker_child.result = "Done successfully"
+        worker_child.project_id = "proj-ok"
+        worker_child.project_dir = str(tmp_path)
+
+        tree_path = tmp_path / "task_tree.yaml"
+        tree.save(tree_path)
+
+        entry = ScheduleEntry(node_id=worker_child.id, tree_path=str(tree_path))
+
+        mgr._schedule["00002"] = [
+            ScheduleEntry(node_id=ea_parent.id, tree_path=str(tree_path)),
+        ]
+
+        with patch("onemancompany.core.task_tree.get_tree", return_value=tree), \
+             patch("onemancompany.core.task_tree.save_tree_async"), \
+             patch("onemancompany.core.vessel._store") as mock_store, \
+             patch.object(mgr, "_publish_node_update"), \
+             patch.object(mgr, "schedule_node"), \
+             patch.object(mgr, "_schedule_next"), \
+             patch.object(mgr, "_spawn_review_or_escalate", new_callable=AsyncMock):
+            mock_store.save_employee_runtime = AsyncMock()
+
+            await mgr._on_child_complete_inner("emp10", entry, project_id="proj-ok")
+
+        # Parent should still be HOLDING — COMPLETED child triggers review, not failure resume
+        # (it goes through Gate 2 incremental review path instead)
+        assert ea_parent.status == TaskPhase.HOLDING.value, \
+            "COMPLETED child should not trigger failure-resume on HOLDING parent"


### PR DESCRIPTION
## Summary

- **Department signs**: Replace watermark text with pixel-art garden-style standing signs (立牌) for department labels — wooden stake + cream board + colored accent stripe
- **Bigger & centered**: Enlarged signs (11px bold font), centered in each department zone, positioned below dept area to avoid overlapping meeting rooms
- **Fix HOLDING parent stuck on child failure**: When a child task FAILS and its parent is HOLDING, `_on_child_complete_inner` now detects the failure, creates a notification node with failure details, and re-schedules the parent to handle it (retry, reassign, or escalate). Previously the parent stayed HOLDING forever.

## Test plan

- [x] Unit tests for child-failure resuming HOLDING parent (2 new tests)
- [ ] Visual check: department signs render correctly in office canvas
- [ ] Verify stuck project recovery: child fails → parent gets notified and can act

🤖 Generated with [Claude Code](https://claude.com/claude-code)