### PR TITLE
feat: CEO avatar + fix retrospective meeting bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.499",
+  "version": "0.2.500",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.498",
+  "version": "0.2.499",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.500",
+  "version": "0.2.501",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.500"
+version = "0.2.501"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.499"
+version = "0.2.500"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.498"
+version = "0.2.499"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -2853,7 +2853,7 @@ async def get_project_tree(project_id: str) -> dict:
                     "name": "CEO",
                     "nickname": "CEO",
                     "role": "Chief Executive Officer",
-                    "avatar_url": "",
+                    "avatar_url": f"/api/employees/{CEO_ID}/avatar",
                 }
             else:
                 _tree_emp = _load_emp(eid)
@@ -2907,6 +2907,11 @@ async def upload_avatar(employee_id: str, request: Request) -> dict:
 async def get_avatar(employee_id: str):
     """Serve an employee's avatar image, falling back to default piggy."""
     from onemancompany.core.config import EMPLOYEES_DIR, HR_DIR
+    # CEO uses dedicated avatar from avatars directory
+    if employee_id == CEO_ID:
+        ceo_avatar = HR_DIR / "avatars" / "ceo.png"
+        if ceo_avatar.exists():
+            return FileResponse(ceo_avatar, media_type="image/png")
     avatar_path = EMPLOYEES_DIR / employee_id / "avatar.png"
     if not avatar_path.exists():
         avatar_path = EMPLOYEES_DIR / employee_id / "avatar.jpg"

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -2907,11 +2907,6 @@ async def upload_avatar(employee_id: str, request: Request) -> dict:
 async def get_avatar(employee_id: str):
     """Serve an employee's avatar image, falling back to default piggy."""
     from onemancompany.core.config import EMPLOYEES_DIR, HR_DIR
-    # CEO uses dedicated avatar from avatars directory
-    if employee_id == CEO_ID:
-        ceo_avatar = HR_DIR / "avatars" / "ceo.png"
-        if ceo_avatar.exists():
-            return FileResponse(ceo_avatar, media_type="image/png")
     avatar_path = EMPLOYEES_DIR / employee_id / "avatar.png"
     if not avatar_path.exists():
         avatar_path = EMPLOYEES_DIR / employee_id / "avatar.jpg"

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -280,7 +280,11 @@ async def _handle_self_evaluation(step: WorkflowStep, ctx: StepContext) -> dict:
             f"{skills_ctx}"
             f"{tools_ctx}"
             f"{culture_ctx}"
-            f"Recently completed task summary: {ctx.task_summary}\n"
+            f"[Meeting Context] This is a PROJECT RETROSPECTIVE (项目复盘会). "
+            f"The project has been completed. The purpose of this meeting is to review and summarize "
+            f"what was done, what went well, and what can be improved. "
+            f"This is NOT a planning session — do NOT propose next steps or new tasks.\n\n"
+            f"Completed project summary: {ctx.task_summary}\n"
             f"{timeline_ctx}\n"
             f"[Your Actual Action Records in This Project]\n{my_actions}\n\n"
             f"Important rules: You must only self-evaluate based on the 'Actual Action Records' above.\n"
@@ -351,7 +355,9 @@ async def _handle_senior_review(step: WorkflowStep, ctx: StepContext) -> dict:
         prompt = (
             f"You are {senior_data.get(PF_NAME, '')} (nickname: {senior_data.get(PF_NICKNAME, '')}, Lv.{senior_level}, {senior_data.get(PF_ROLE, '')}).\n"
             f"{culture_ctx}"
-            f"Task summary: {ctx.task_summary}\n"
+            f"[Meeting Context] This is a PROJECT RETROSPECTIVE (项目复盘会). "
+            f"The project is completed. Focus on reviewing what happened, not planning future work.\n\n"
+            f"Completed project summary: {ctx.task_summary}\n"
             f"{timeline_ctx}\n"
             f"Below are the self-evaluations from junior colleagues:\n{junior_info}\n\n"
             f"Important rules: Your review must be strictly based on facts from the project log.\n"
@@ -411,9 +417,11 @@ async def _handle_hr_summary(step: WorkflowStep, ctx: StepContext) -> dict:
     culture_ctx = ctx.format_company_culture()
 
     hr_prompt = (
-        f"You are the HR manager, responsible for summarizing this review meeting.\n"
+        f"You are the HR manager, responsible for summarizing this project retrospective.\n"
         f"{culture_ctx}"
-        f"Task summary: {ctx.task_summary}\n"
+        f"[Meeting Context] This is a PROJECT RETROSPECTIVE (项目复盘会). "
+        f"The project is completed. Focus on reviewing performance, not planning future work.\n\n"
+        f"Completed project summary: {ctx.task_summary}\n"
         f"{timeline_ctx}\n"
         f"Employee self-evaluations:\n{all_evals}\n\n"
         f"Senior employee peer reviews:\n{all_reviews}\n\n"
@@ -486,7 +494,9 @@ async def _handle_coo_report(step: WorkflowStep, ctx: StepContext) -> dict:
     coo_prompt = (
         f"You are the COO, responsible for producing a company operations report.\n"
         f"{culture_ctx}"
-        f"Recently completed task: {ctx.task_summary}\n"
+        f"[Meeting Context] This is a PROJECT RETROSPECTIVE (项目复盘会). "
+        f"The project is completed. Focus on reviewing outcomes and lessons learned, not future plans.\n\n"
+        f"Completed project: {ctx.task_summary}\n"
         f"{timeline_ctx}"
         f"{cost_ctx}"
         f"The company currently has {emp_count} employees, {tool_count} pieces of equipment, and {room_count} meeting rooms.\n\n"
@@ -603,13 +613,17 @@ async def _handle_employee_open_floor(step: WorkflowStep, ctx: StepContext) -> d
             f"{skills_ctx}"
             f"{tools_ctx}"
             f"{culture_ctx}"
-            f"Task summary: {ctx.task_summary}\n"
+            f"[Meeting Context] This is a PROJECT RETROSPECTIVE (项目复盘会). "
+            f"The project has been completed. The purpose is to reflect on the work done, "
+            f"share lessons learned, and identify improvements. "
+            f"Do NOT propose new projects, next steps, or future plans.\n\n"
+            f"Completed project summary: {ctx.task_summary}\n"
             f"{timeline_ctx}"
             f"[Your Actual Action Records in This Project]\n{my_actions}\n\n"
             f"Important rules: Your remarks must be based on your actual action records; do not make up stories.\n"
             f"- Only discuss things you actually experienced and that are verifiable in the records\n"
             f"- No empty platitudes; do not fabricate difficulties or exaggerate contributions\n\n"
-            f"This is the open floor session of the meeting. Based on your actual experience, you may raise:\n"
+            f"This is the open floor session of the retrospective meeting. Based on your actual experience, you may raise:\n"
             f"- Actual difficulties encountered during work\n"
             f"- Missing tools or equipment\n"
             f"- What kind of talent is needed\n"
@@ -647,7 +661,9 @@ async def _handle_action_plan(step: WorkflowStep, ctx: StepContext) -> dict:
     )
 
     action_prompt = (
-        f"You represent both COO and HR in compiling the meeting action plan.\n\n"
+        f"You represent both COO and HR in compiling the retrospective action plan.\n"
+        f"This is a PROJECT RETROSPECTIVE — action items should focus on improvements "
+        f"and lessons learned, not new project tasks.\n\n"
         f"COO operations report: {ctx.coo_report}\n\n"
         f"Employee remarks:\n{feedback_text}\n\n"
         f"Review improvement suggestions:\n{phase1_improvements}\n\n"
@@ -1033,7 +1049,8 @@ async def run_post_task_routine(
         return
 
     if participants is None:
-        participants = list(all_emps.keys())
+        # Exclude CEO — CEO is a real person and does not participate in AI-driven meetings
+        participants = [eid for eid in all_emps if eid != CEO_ID]
 
     # Load project record for retrospective reference
     project_record: dict = {}
@@ -1786,7 +1803,9 @@ async def _run_review_phase2(
     )
 
     action_prompt = (
-        f"You represent both COO and HR in compiling the meeting action plan.\n\n"
+        f"You represent both COO and HR in compiling the retrospective action plan.\n"
+        f"This is a PROJECT RETROSPECTIVE — action items should focus on improvements "
+        f"and lessons learned, not new project tasks.\n\n"
         f"COO operations report: {result['coo_report']}\n\n"
         f"Employee remarks:\n{feedback_text}\n\n"
         f"Phase 1 improvement suggestions:\n{phase1_improvements}\n\n"


### PR DESCRIPTION
## Summary

- **CEO avatar_url**: Task tree employee_info for CEO now includes avatar_url (was empty string), uses standard random pool fallback
- **Fix: CEO excluded from retrospective**: CEO (00001) is a real person — removed from AI-driven retrospective participants, preventing AI from generating fake CEO responses
- **Fix: retrospective context**: All retrospective prompts now include explicit `[Meeting Context]` telling employees this is a 项目复盘会 (project retrospective), not a planning session — prevents AI from proposing next steps instead of reviewing

## Test plan

- [x] All existing tests pass (2001)
- [ ] Verify CEO avatar shows in task tree views
- [ ] Run a retrospective and verify CEO is not a participant
- [ ] Verify employee responses focus on review/summary, not future plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)