### PR TITLE
feat: employee retro popup + unify work_principles/guidance loading

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2020,8 +2020,7 @@ class AppController {
         container.querySelectorAll('.emp-project-item').forEach(el => {
           el.addEventListener('click', () => {
             const pid = el.dataset.projectId;
-            this.closeEmployeeDetail();
-            this._openProjectFromId(pid);
+            this._showRetroPopup(employeeId, pid);
           });
         });
       })
@@ -2035,6 +2034,51 @@ class AppController {
     this._loadIterationDetail(projectId, projectId);
     const detailEl = document.getElementById('project-detail');
     if (detailEl) detailEl.classList.remove('hidden');
+  }
+
+  async _showRetroPopup(employeeId, projectId) {
+    try {
+      const resp = await fetch(`/api/employees/${employeeId}/projects/${projectId}/retrospective`);
+      const data = await resp.json();
+
+      let html = '';
+
+      if (data.self_evaluation) {
+        html += `<div class="retro-section"><h4>Self Evaluation</h4><p>${this._escHtml(data.self_evaluation)}</p></div>`;
+      }
+      if (data.feedback) {
+        html += `<div class="retro-section"><h4>Feedback</h4><p>${this._escHtml(data.feedback)}</p></div>`;
+      }
+      if (data.senior_reviews && data.senior_reviews.length > 0) {
+        html += '<div class="retro-section"><h4>Senior Reviews</h4>';
+        for (const sr of data.senior_reviews) {
+          html += `<p><strong>${this._escHtml(sr.reviewer)}:</strong> ${this._escHtml(sr.review)}</p>`;
+        }
+        html += '</div>';
+      }
+      if (data.hr_improvements && data.hr_improvements.length > 0) {
+        html += '<div class="retro-section"><h4>Improvements</h4>';
+        for (const item of data.hr_improvements) {
+          html += `<p>${this._escHtml(item)}</p>`;
+        }
+        html += '</div>';
+      }
+
+      if (!html) {
+        html = '<p class="empty-hint">No retrospective data for this project yet.</p>';
+      }
+
+      this.openPopup({
+        title: 'Project Retrospective',
+        type: 'info',
+      });
+
+      const body = document.getElementById('generic-popup-body');
+      body.innerHTML = html;
+    } catch (err) {
+      console.error('[showRetroPopup] failed:', err);
+      this.openPopup({ title: 'Error', message: 'Failed to load retrospective data.' });
+    }
   }
 
   // ===== Code Update Banner =====

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -4260,6 +4260,29 @@ body {
   justify-content: flex-end;
 }
 
+/* ===== Retro Popup Sections ===== */
+.retro-section {
+  margin-bottom: 10px;
+}
+.retro-section h4 {
+  font-size: 8px;
+  color: var(--pixel-cyan);
+  margin: 0 0 4px 0;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.retro-section p {
+  font-size: 7px;
+  color: var(--pixel-white);
+  line-height: 1.6;
+  margin: 2px 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.retro-section strong {
+  color: var(--pixel-yellow);
+}
+
 /* ===== Chat Attach Button ===== */
 .chat-attach-btn {
   display: flex;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.499",
+  "version": "0.2.500",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.498",
+  "version": "0.2.499",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.500",
+  "version": "0.2.501",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.502",
+  "version": "0.2.503",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.503",
+  "version": "0.2.504",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.501",
+  "version": "0.2.502",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.503"
+version = "0.2.504"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.502"
+version = "0.2.503"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.500"
+version = "0.2.501"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.501"
+version = "0.2.502"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.499"
+version = "0.2.500"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.498"
+version = "0.2.499"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -1001,14 +1001,10 @@ async def execute_hire(
             encoding=ENCODING_UTF8,
         )
 
-    # Generate work principles as a skill (autoloaded)
-    wp_dir = skills_dir / "work-principles"
-    wp_dir.mkdir(parents=True, exist_ok=True)
-    wp_file = wp_dir / SKILL_FILENAME
-    if not wp_file.exists():
-        wp_file.write_text(
-            f"---\nname: work-principles\nautoload: true\n"
-            f"description: Personal work principles and code of conduct.\n---\n\n"
+    # Generate initial work_principles.md (unified location for all hosting modes)
+    wp_path = emp_dir / "work_principles.md"
+    if not wp_path.exists():
+        wp_path.write_text(
             f"# {name} ({nickname}) Work Principles\n\n"
             f"**Department**: {department}\n"
             f"**Title**: {make_title(1, role)}\n"

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -1002,7 +1002,8 @@ async def execute_hire(
         )
 
     # Generate initial work_principles.md (unified location for all hosting modes)
-    wp_path = emp_dir / "work_principles.md"
+    from onemancompany.core.store import WORK_PRINCIPLES_FILENAME
+    wp_path = emp_dir / WORK_PRINCIPLES_FILENAME
     if not wp_path.exists():
         wp_path.write_text(
             f"# {name} ({nickname}) Work Principles\n\n"

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -5269,11 +5269,7 @@ async def stop_all_crons_endpoint(employee_id: str) -> dict:
 @router.get("/api/employees")
 async def list_employees():
     """List all active employees — reads from disk."""
-    from onemancompany.core.store import (
-        load_all_employees,
-        load_employee_guidance,
-        load_employee_work_principles,
-    )
+    from onemancompany.core.store import load_all_employees
     employees = load_all_employees()
     result = []
     for emp_id, data in employees.items():
@@ -5287,9 +5283,6 @@ async def list_employees():
         data[PF_CURRENT_TASK_SUMMARY] = runtime.get(PF_CURRENT_TASK_SUMMARY, "")
         data["api_online"] = runtime.get("api_online", True)
         data["needs_setup"] = runtime.get("needs_setup", False)
-        # Load work principles and guidance from separate files
-        data["work_principles"] = load_employee_work_principles(emp_id)
-        data["guidance_notes"] = load_employee_guidance(emp_id)
         result.append(data)
     return result
 

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -28,6 +28,8 @@ from onemancompany.core.config import (
     MANIFEST_FILENAME,
     MAX_SUMMARY_LEN,
     PF_CURRENT_TASK_SUMMARY,
+    PF_NAME,
+    PF_NICKNAME,
     STATUS_IDLE,
     SYSTEM_AGENT,
     SYSTEM_SENDER,
@@ -2989,8 +2991,8 @@ async def get_employee_project_retrospective(employee_id: str, project_id: str) 
 
     # Extract senior reviews mentioning this employee
     emp_data = _load_emp(employee_id)
-    emp_name = emp_data.get("name", "") if emp_data else ""
-    emp_nickname = emp_data.get("nickname", "") if emp_data else ""
+    emp_name = emp_data.get(PF_NAME, "") if emp_data else ""
+    emp_nickname = emp_data.get(PF_NICKNAME, "") if emp_data else ""
     for entry in timeline_entries:
         action = entry.get(TL_FIELD_ACTION, "")
         detail = entry.get(TL_FIELD_DETAIL, "")
@@ -2999,7 +3001,7 @@ async def get_employee_project_retrospective(employee_id: str, project_id: str) 
             if emp_name and emp_name in detail or emp_nickname and emp_nickname in detail:
                 reviewer_id = entry.get(TL_FIELD_EMPLOYEE_ID, "")
                 reviewer_data = _load_emp(reviewer_id)
-                reviewer_name = reviewer_data.get("name", reviewer_id) if reviewer_data else reviewer_id
+                reviewer_name = reviewer_data.get(PF_NAME, reviewer_id) if reviewer_data else reviewer_id
                 result["senior_reviews"].append({
                     "reviewer": reviewer_name,
                     "review": detail,

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -2937,6 +2937,78 @@ async def get_employee_projects(employee_id: str) -> list[dict]:
     return _scan_employee_projects(employee_id)
 
 
+@router.get("/api/employees/{employee_id}/projects/{project_id}/retrospective")
+async def get_employee_project_retrospective(employee_id: str, project_id: str) -> dict:
+    """Get an employee's retrospective summary for a specific project.
+
+    Extracts self-evaluation and feedback from the project timeline.
+    """
+    from onemancompany.core.config import PROJECTS_DIR
+    import yaml
+
+    result: dict = {
+        "employee_id": employee_id,
+        "project_id": project_id,
+        "self_evaluation": "",
+        "feedback": "",
+        "senior_reviews": [],
+        "hr_improvements": [],
+    }
+
+    # Scan project.yaml and iteration yamls for timeline entries
+    pdir = PROJECTS_DIR / project_id
+    if not pdir.exists():
+        return result
+
+    # Collect timeline entries from project.yaml and all iteration yamls
+    timeline_entries: list[dict] = []
+    for yaml_file in pdir.glob("*.yaml"):
+        try:
+            data = yaml.safe_load(yaml_file.read_text(encoding=ENCODING_UTF8)) or {}
+        except Exception as exc:
+            logger.debug("Failed to parse {}: {}", yaml_file, exc)
+            continue
+        timeline_entries.extend(data.get("timeline", []))
+
+    # Extract this employee's retrospective content
+    for entry in timeline_entries:
+        eid = entry.get("employee_id", "")
+        action = entry.get("action", "")
+        detail = entry.get("detail", "")
+        if eid == employee_id and action == "self-evaluation":
+            result["self_evaluation"] = detail
+        elif eid == employee_id and action == "employee feedback":
+            result["feedback"] = detail
+
+    # Extract senior reviews mentioning this employee
+    emp_data = _load_emp(employee_id)
+    emp_name = emp_data.get("name", "") if emp_data else ""
+    emp_nickname = emp_data.get("nickname", "") if emp_data else ""
+    for entry in timeline_entries:
+        action = entry.get("action", "")
+        detail = entry.get("detail", "")
+        if action == "senior review" and detail:
+            # Check if the review mentions this employee by name or nickname
+            if emp_name and emp_name in detail or emp_nickname and emp_nickname in detail:
+                reviewer_id = entry.get("employee_id", "")
+                reviewer_data = _load_emp(reviewer_id)
+                reviewer_name = reviewer_data.get("name", reviewer_id) if reviewer_data else reviewer_id
+                result["senior_reviews"].append({
+                    "reviewer": reviewer_name,
+                    "review": detail,
+                })
+
+    # Extract HR improvement suggestions for this employee
+    for entry in timeline_entries:
+        action = entry.get("action", "")
+        detail = entry.get("detail", "")
+        if action == "improvement item" and detail:
+            if emp_name and emp_name in detail or emp_nickname and emp_nickname in detail:
+                result["hr_improvements"].append(detail)
+
+    return result
+
+
 # ===== Plugin System Endpoints =====
 
 @router.get("/api/plugins")

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -32,6 +32,13 @@ from onemancompany.core.config import (
     SYSTEM_AGENT,
     SYSTEM_SENDER,
     TASK_TREE_FILENAME,
+    TL_ACTION_EMPLOYEE_FEEDBACK,
+    TL_ACTION_IMPROVEMENT,
+    TL_ACTION_SELF_EVAL,
+    TL_ACTION_SENIOR_REVIEW,
+    TL_FIELD_ACTION,
+    TL_FIELD_DETAIL,
+    TL_FIELD_EMPLOYEE_ID,
 )
 from onemancompany.core.events import CompanyEvent, event_bus
 from onemancompany.core.models import AuthMethod, DecisionStatus, EventType, HostingMode
@@ -2972,12 +2979,12 @@ async def get_employee_project_retrospective(employee_id: str, project_id: str) 
 
     # Extract this employee's retrospective content
     for entry in timeline_entries:
-        eid = entry.get("employee_id", "")
-        action = entry.get("action", "")
-        detail = entry.get("detail", "")
-        if eid == employee_id and action == "self-evaluation":
+        eid = entry.get(TL_FIELD_EMPLOYEE_ID, "")
+        action = entry.get(TL_FIELD_ACTION, "")
+        detail = entry.get(TL_FIELD_DETAIL, "")
+        if eid == employee_id and action == TL_ACTION_SELF_EVAL:
             result["self_evaluation"] = detail
-        elif eid == employee_id and action == "employee feedback":
+        elif eid == employee_id and action == TL_ACTION_EMPLOYEE_FEEDBACK:
             result["feedback"] = detail
 
     # Extract senior reviews mentioning this employee
@@ -2985,12 +2992,12 @@ async def get_employee_project_retrospective(employee_id: str, project_id: str) 
     emp_name = emp_data.get("name", "") if emp_data else ""
     emp_nickname = emp_data.get("nickname", "") if emp_data else ""
     for entry in timeline_entries:
-        action = entry.get("action", "")
-        detail = entry.get("detail", "")
-        if action == "senior review" and detail:
+        action = entry.get(TL_FIELD_ACTION, "")
+        detail = entry.get(TL_FIELD_DETAIL, "")
+        if action == TL_ACTION_SENIOR_REVIEW and detail:
             # Check if the review mentions this employee by name or nickname
             if emp_name and emp_name in detail or emp_nickname and emp_nickname in detail:
-                reviewer_id = entry.get("employee_id", "")
+                reviewer_id = entry.get(TL_FIELD_EMPLOYEE_ID, "")
                 reviewer_data = _load_emp(reviewer_id)
                 reviewer_name = reviewer_data.get("name", reviewer_id) if reviewer_data else reviewer_id
                 result["senior_reviews"].append({
@@ -3000,9 +3007,9 @@ async def get_employee_project_retrospective(employee_id: str, project_id: str) 
 
     # Extract HR improvement suggestions for this employee
     for entry in timeline_entries:
-        action = entry.get("action", "")
-        detail = entry.get("detail", "")
-        if action == "improvement item" and detail:
+        action = entry.get(TL_FIELD_ACTION, "")
+        detail = entry.get(TL_FIELD_DETAIL, "")
+        if action == TL_ACTION_IMPROVEMENT and detail:
             if emp_name and emp_name in detail or emp_nickname and emp_nickname in detail:
                 result["hr_improvements"].append(detail)
 

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -5269,7 +5269,11 @@ async def stop_all_crons_endpoint(employee_id: str) -> dict:
 @router.get("/api/employees")
 async def list_employees():
     """List all active employees — reads from disk."""
-    from onemancompany.core.store import load_all_employees
+    from onemancompany.core.store import (
+        load_all_employees,
+        load_employee_guidance,
+        load_employee_work_principles,
+    )
     employees = load_all_employees()
     result = []
     for emp_id, data in employees.items():
@@ -5283,6 +5287,9 @@ async def list_employees():
         data[PF_CURRENT_TASK_SUMMARY] = runtime.get(PF_CURRENT_TASK_SUMMARY, "")
         data["api_online"] = runtime.get("api_online", True)
         data["needs_setup"] = runtime.get("needs_setup", False)
+        # Load work principles and guidance from separate files
+        data["work_principles"] = load_employee_work_principles(emp_id)
+        data["guidance_notes"] = load_employee_guidance(emp_id)
         result.append(data)
     return result
 

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -108,6 +108,7 @@ TL_ACTION_OPS_REPORT = "operations report"
 TL_FIELD_EMPLOYEE_ID = "employee_id"
 TL_FIELD_ACTION = "action"
 TL_FIELD_DETAIL = "detail"
+TL_FIELD_TIME = "time"
 
 # ---------------------------------------------------------------------------
 # Common identifiers — canonical strings for sender/role/scope fields

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -95,6 +95,19 @@ PF_TALENT_ID = "talent_id"
 PF_SPRITE = "sprite"
 PF_ID = "id"
 PF_CURRENT_TASK_SUMMARY = "current_task_summary"
+PF_GUIDANCE_NOTES = "guidance_notes"
+
+# ---------------------------------------------------------------------------
+# Timeline action constants — used in project_archive append_action calls
+# ---------------------------------------------------------------------------
+TL_ACTION_SELF_EVAL = "self-evaluation"
+TL_ACTION_SENIOR_REVIEW = "senior review"
+TL_ACTION_EMPLOYEE_FEEDBACK = "employee feedback"
+TL_ACTION_IMPROVEMENT = "improvement item"
+TL_ACTION_OPS_REPORT = "operations report"
+TL_FIELD_EMPLOYEE_ID = "employee_id"
+TL_FIELD_ACTION = "action"
+TL_FIELD_DETAIL = "detail"
 
 # ---------------------------------------------------------------------------
 # Common identifiers — canonical strings for sender/role/scope fields

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -20,7 +20,16 @@ from pathlib import Path
 
 import yaml
 
-from onemancompany.core.config import ENCODING_UTF8, NODES_DIR_NAME, PROJECT_YAML_FILENAME, PROJECTS_DIR, TASK_TREE_FILENAME
+from onemancompany.core.config import (
+    ENCODING_UTF8,
+    NODES_DIR_NAME,
+    PROJECT_YAML_FILENAME,
+    PROJECTS_DIR,
+    TASK_TREE_FILENAME,
+    TL_FIELD_ACTION,
+    TL_FIELD_DETAIL,
+    TL_FIELD_EMPLOYEE_ID,
+)
 
 ITERATIONS_DIR_NAME = "iterations"
 
@@ -497,9 +506,9 @@ def append_action(project_id: str, employee_id: str, action: str, detail: str = 
         return
     doc.setdefault("timeline", []).append({
         "time": datetime.now().isoformat(),
-        "employee_id": employee_id,
-        "action": action,
-        "detail": detail[:500],
+        TL_FIELD_EMPLOYEE_ID: employee_id,
+        TL_FIELD_ACTION: action,
+        TL_FIELD_DETAIL: detail[:500],
     })
     if employee_id:
         doc["current_owner"] = employee_id
@@ -517,9 +526,9 @@ def complete_project(project_id: str, output: str = "") -> None:
     doc["current_owner"] = ""
 
     actual_contributors = {
-        entry["employee_id"]
+        entry[TL_FIELD_EMPLOYEE_ID]
         for entry in doc.get("timeline", [])
-        if entry.get("employee_id")
+        if entry.get(TL_FIELD_EMPLOYEE_ID)
     }
     if actual_contributors:
         doc["participants"] = [
@@ -762,7 +771,7 @@ def record_project_cost(
     tokens["total"] = tokens.get("total", 0) + input_tokens + output_tokens
     breakdown = cost.setdefault("breakdown", [])
     breakdown.append({
-        "employee_id": employee_id,
+        TL_FIELD_EMPLOYEE_ID: employee_id,
         "model": model,
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
@@ -813,7 +822,7 @@ def get_cost_summary() -> dict:
             total_input += proj_input
             total_output += proj_output
             for entry in cost.get("breakdown", []):
-                eid = entry.get("employee_id", "")
+                eid = entry.get(TL_FIELD_EMPLOYEE_ID, "")
                 from onemancompany.core.store import load_employee as _load_emp, load_ex_employees as _load_ex
                 _emp_d = _load_emp(eid)
                 if not _emp_d:

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -29,6 +29,7 @@ from onemancompany.core.config import (
     TL_FIELD_ACTION,
     TL_FIELD_DETAIL,
     TL_FIELD_EMPLOYEE_ID,
+    TL_FIELD_TIME,
 )
 
 ITERATIONS_DIR_NAME = "iterations"
@@ -42,6 +43,7 @@ PA_COMPLETED_AT = "completed_at"
 PA_OUTPUT = "output"
 PA_COST = "cost"
 PA_BREAKDOWN = "breakdown"
+PA_TOKEN_USAGE = "token_usage"
 
 # Internal infrastructure files excluded from user-facing document listing
 _INTERNAL_FILE_NAMES = frozenset({PROJECT_YAML_FILENAME, TASK_TREE_FILENAME})
@@ -397,7 +399,7 @@ def create_iteration(project_id: str, task: str, routed_to: str) -> str:
         PA_COST: {
             "budget_estimate_usd": 0.0,
             "actual_cost_usd": 0.0,
-            "token_usage": {"input": 0, "output": 0, "total": 0},
+            PA_TOKEN_USAGE: {"input": 0, "output": 0, "total": 0},
             PA_BREAKDOWN: [],
         },
         "project_dir": str(iter_dir),
@@ -515,7 +517,7 @@ def append_action(project_id: str, employee_id: str, action: str, detail: str = 
     if not doc:
         return
     doc.setdefault(PA_TIMELINE, []).append({
-        "time": datetime.now().isoformat(),
+        TL_FIELD_TIME: datetime.now().isoformat(),
         TL_FIELD_EMPLOYEE_ID: employee_id,
         TL_FIELD_ACTION: action,
         TL_FIELD_DETAIL: detail,
@@ -771,11 +773,11 @@ def record_project_cost(
     cost = doc.setdefault(PA_COST, {
         "budget_estimate_usd": 0.0,
         "actual_cost_usd": 0.0,
-        "token_usage": {"input": 0, "output": 0, "total": 0},
+        PA_TOKEN_USAGE: {"input": 0, "output": 0, "total": 0},
         PA_BREAKDOWN: [],
     })
     cost["actual_cost_usd"] = cost.get("actual_cost_usd", 0.0) + cost_usd
-    tokens = cost.setdefault("token_usage", {"input": 0, "output": 0, "total": 0})
+    tokens = cost.setdefault(PA_TOKEN_USAGE, {"input": 0, "output": 0, "total": 0})
     tokens["input"] = tokens.get("input", 0) + input_tokens
     tokens["output"] = tokens.get("output", 0) + output_tokens
     tokens["total"] = tokens.get("total", 0) + input_tokens + output_tokens
@@ -825,7 +827,7 @@ def get_cost_summary() -> dict:
                 continue
             cost = iter_doc.get(PA_COST, {})
             proj_cost = cost.get("actual_cost_usd", 0.0)
-            tokens = cost.get("token_usage", {})
+            tokens = cost.get(PA_TOKEN_USAGE, {})
             proj_input = tokens.get("input", 0)
             proj_output = tokens.get("output", 0)
             total_cost += proj_cost

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -33,6 +33,16 @@ from onemancompany.core.config import (
 
 ITERATIONS_DIR_NAME = "iterations"
 
+# Project YAML schema field keys
+PA_TIMELINE = "timeline"
+PA_CURRENT_OWNER = "current_owner"
+PA_PARTICIPANTS = "participants"
+PA_STATUS = "status"
+PA_COMPLETED_AT = "completed_at"
+PA_OUTPUT = "output"
+PA_COST = "cost"
+PA_BREAKDOWN = "breakdown"
+
 # Internal infrastructure files excluded from user-facing document listing
 _INTERNAL_FILE_NAMES = frozenset({PROJECT_YAML_FILENAME, TASK_TREE_FILENAME})
 _INTERNAL_DIR_NAMES = frozenset({NODES_DIR_NAME})
@@ -78,7 +88,7 @@ def _rebase_project_dir(stored_path: str) -> Path:
         p.relative_to(PROJECTS_DIR)
         return p
     except ValueError:
-        pass  # not under PROJECTS_DIR — fall through to rebase logic
+        logger.debug("Path {} not under PROJECTS_DIR, attempting rebase", p)
     # Try to find the 'company/business/projects' marker and rebase
     parts = p.parts
     for i, part in enumerate(parts):
@@ -374,21 +384,21 @@ def create_iteration(project_id: str, task: str, routed_to: str) -> str:
         "task": task,
         "status": ITER_STATUS_IN_PROGRESS,
         "routed_to": routed_to,
-        "current_owner": routed_to.lower() if routed_to else "",
+        PA_CURRENT_OWNER: routed_to.lower() if routed_to else "",
         "created_at": datetime.now().isoformat(),
         "completed_at": None,
-        "timeline": [],
+        PA_TIMELINE: [],
         "output": None,
         "acceptance_criteria": [],
         "responsible_officer": "",
         "dispatches": [],
         "acceptance_result": None,
         "ea_review_result": None,
-        "cost": {
+        PA_COST: {
             "budget_estimate_usd": 0.0,
             "actual_cost_usd": 0.0,
             "token_usage": {"input": 0, "output": 0, "total": 0},
-            "breakdown": [],
+            PA_BREAKDOWN: [],
         },
         "project_dir": str(iter_dir),
     }
@@ -504,14 +514,14 @@ def append_action(project_id: str, employee_id: str, action: str, detail: str = 
     version, doc, key = _resolve_and_load(project_id)
     if not doc:
         return
-    doc.setdefault("timeline", []).append({
+    doc.setdefault(PA_TIMELINE, []).append({
         "time": datetime.now().isoformat(),
         TL_FIELD_EMPLOYEE_ID: employee_id,
         TL_FIELD_ACTION: action,
-        TL_FIELD_DETAIL: detail[:500],
+        TL_FIELD_DETAIL: detail,
     })
     if employee_id:
-        doc["current_owner"] = employee_id
+        doc[PA_CURRENT_OWNER] = employee_id
     _save_resolved(version, key, doc)
 
 
@@ -523,16 +533,16 @@ def complete_project(project_id: str, output: str = "") -> None:
     doc["status"] = ITER_STATUS_COMPLETED
     doc["completed_at"] = datetime.now().isoformat()
     doc["output"] = output
-    doc["current_owner"] = ""
+    doc[PA_CURRENT_OWNER] = ""
 
     actual_contributors = {
         entry[TL_FIELD_EMPLOYEE_ID]
-        for entry in doc.get("timeline", [])
+        for entry in doc.get(PA_TIMELINE, [])
         if entry.get(TL_FIELD_EMPLOYEE_ID)
     }
     if actual_contributors:
-        doc["participants"] = [
-            pid for pid in doc.get("participants", [])
+        doc[PA_PARTICIPANTS] = [
+            pid for pid in doc.get(PA_PARTICIPANTS, [])
             if pid in actual_contributors
         ]
 
@@ -700,7 +710,7 @@ def list_projects() -> list[dict]:
             if latest_iter:
                 latest_task = latest_iter.get("task", "")
                 latest_iter_status = latest_iter.get("status", "")
-                latest_owner = latest_iter.get("current_owner", "")
+                latest_owner = latest_iter.get(PA_CURRENT_OWNER, "")
             # Aggregate cost across all iterations
             for iter_id in iterations:
                 iter_doc = load_iteration(d.name, iter_id)
@@ -712,7 +722,7 @@ def list_projects() -> list[dict]:
             "status": project_status,
             "latest_iter_status": latest_iter_status,
             "routed_to": "",
-            "current_owner": latest_owner,
+            PA_CURRENT_OWNER: latest_owner,
             "created_at": doc.get("created_at", ""),
             "completed_at": doc.get("archived_at"),
             "participant_count": 0,
@@ -758,18 +768,18 @@ def record_project_cost(
     version, doc, key = _resolve_and_load(project_id)
     if not doc:
         return
-    cost = doc.setdefault("cost", {
+    cost = doc.setdefault(PA_COST, {
         "budget_estimate_usd": 0.0,
         "actual_cost_usd": 0.0,
         "token_usage": {"input": 0, "output": 0, "total": 0},
-        "breakdown": [],
+        PA_BREAKDOWN: [],
     })
     cost["actual_cost_usd"] = cost.get("actual_cost_usd", 0.0) + cost_usd
     tokens = cost.setdefault("token_usage", {"input": 0, "output": 0, "total": 0})
     tokens["input"] = tokens.get("input", 0) + input_tokens
     tokens["output"] = tokens.get("output", 0) + output_tokens
     tokens["total"] = tokens.get("total", 0) + input_tokens + output_tokens
-    breakdown = cost.setdefault("breakdown", [])
+    breakdown = cost.setdefault(PA_BREAKDOWN, [])
     breakdown.append({
         TL_FIELD_EMPLOYEE_ID: employee_id,
         "model": model,
@@ -813,7 +823,7 @@ def get_cost_summary() -> dict:
             iter_doc = load_iteration(d.name, iter_id)
             if not iter_doc:
                 continue
-            cost = iter_doc.get("cost", {})
+            cost = iter_doc.get(PA_COST, {})
             proj_cost = cost.get("actual_cost_usd", 0.0)
             tokens = cost.get("token_usage", {})
             proj_input = tokens.get("input", 0)
@@ -821,7 +831,7 @@ def get_cost_summary() -> dict:
             total_cost += proj_cost
             total_input += proj_input
             total_output += proj_output
-            for entry in cost.get("breakdown", []):
+            for entry in cost.get(PA_BREAKDOWN, []):
                 eid = entry.get(TL_FIELD_EMPLOYEE_ID, "")
                 from onemancompany.core.store import load_employee as _load_emp, load_ex_employees as _load_ex
                 _emp_d = _load_emp(eid)

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -41,6 +41,13 @@ from onemancompany.core.config import (
     PF_PERFORMANCE_HISTORY,
     PF_ROLE,
     PF_WORK_PRINCIPLES,
+    TL_ACTION_IMPROVEMENT,
+    TL_ACTION_OPS_REPORT,
+    TL_ACTION_SELF_EVAL,
+    TL_ACTION_SENIOR_REVIEW,
+    TL_FIELD_ACTION,
+    TL_FIELD_DETAIL,
+    TL_FIELD_EMPLOYEE_ID,
     STATUS_IDLE,
     STATUS_IN_MEETING,
     SYSTEM_AGENT,
@@ -167,12 +174,12 @@ class StepContext:
             return ""
         lines = []
         for entry in timeline[-max_entries:]:
-            emp_id = entry.get("employee_id", "?")
+            emp_id = entry.get(TL_FIELD_EMPLOYEE_ID, "?")
             # Resolve name from store
             emp_data = load_employee(emp_id)
             name = f"{emp_data.get(PF_NAME, emp_id)}({emp_data.get(PF_NICKNAME, '')})" if emp_data else emp_id
-            action = entry.get("action", "")
-            detail = entry.get("detail", "")[:200]
+            action = entry.get(TL_FIELD_ACTION, "")
+            detail = entry.get(TL_FIELD_DETAIL, "")[:200]
             lines.append(f"- [{name}] {action}: {detail}")
         return "\n".join(lines)
 
@@ -191,9 +198,9 @@ class StepContext:
             return "(No action records found for you in the project log)"
         lines = []
         for entry in timeline:
-            if entry.get("employee_id") == emp_id:
-                action = entry.get("action", "")
-                detail = entry.get("detail", "")[:200]
+            if entry.get(TL_FIELD_EMPLOYEE_ID) == emp_id:
+                action = entry.get(TL_FIELD_ACTION, "")
+                detail = entry.get(TL_FIELD_DETAIL, "")[:200]
                 lines.append(f"- {action}: {detail}")
         if not lines:
             return "(No action records found for you in the project log)"
@@ -1195,13 +1202,13 @@ async def run_post_task_routine(
             from onemancompany.core.project_archive import append_action
             # Record each participant's self-evaluation
             for ev in ctx.self_evaluations:
-                append_action(project_id, ev.get("employee_id", ""), "self-evaluation", ev.get("evaluation", "")[:MAX_SUMMARY_LEN])
+                append_action(project_id, ev.get(TL_FIELD_EMPLOYEE_ID, ""), TL_ACTION_SELF_EVAL, ev.get("evaluation", "")[:MAX_SUMMARY_LEN])
             for rv in ctx.senior_reviews:
-                append_action(project_id, rv.get("reviewer_id", ""), "senior review", rv.get("review", "")[:MAX_SUMMARY_LEN])
+                append_action(project_id, rv.get("reviewer_id", ""), TL_ACTION_SENIOR_REVIEW, rv.get("review", "")[:MAX_SUMMARY_LEN])
             if ctx.coo_report:
-                append_action(project_id, COO_ID, "operations report", ctx.coo_report[:MAX_SUMMARY_LEN])
+                append_action(project_id, COO_ID, TL_ACTION_OPS_REPORT, ctx.coo_report[:MAX_SUMMARY_LEN])
             for ai in ctx.action_items:
-                append_action(project_id, ai.get("source", ""), "improvement item", ai.get("description", "")[:MAX_SUMMARY_LEN])
+                append_action(project_id, ai.get("source", ""), TL_ACTION_IMPROVEMENT, ai.get("description", "")[:MAX_SUMMARY_LEN])
 
     finally:
         # Release meeting room

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -1195,7 +1195,7 @@ async def run_post_task_routine(
             from onemancompany.core.project_archive import append_action
             # Record each participant's self-evaluation
             for ev in ctx.self_evaluations:
-                append_action(project_id, ev.get("id", ""), "self-evaluation", ev.get("evaluation", "")[:MAX_SUMMARY_LEN])
+                append_action(project_id, ev.get("employee_id", ""), "self-evaluation", ev.get("evaluation", "")[:MAX_SUMMARY_LEN])
             for rv in ctx.senior_reviews:
                 append_action(project_id, rv.get("reviewer_id", ""), "senior review", rv.get("review", "")[:MAX_SUMMARY_LEN])
             if ctx.coo_report:

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -311,11 +311,11 @@ async def _handle_self_evaluation(step: WorkflowStep, ctx: StepContext) -> dict:
         resp = await tracked_ainvoke(llm, prompt, category="routine", employee_id=emp_id)
         eval_text = resp.content
         ctx.self_evaluations.append({
-            "employee_id": emp_id,
-            "name": emp_name,
-            "nickname": emp_nickname,
-            "level": emp_level,
-            "evaluation": eval_text,
+            TL_FIELD_EMPLOYEE_ID: emp_id,
+            PF_NAME: emp_name,
+            PF_NICKNAME: emp_nickname,
+            PF_LEVEL: emp_level,
+            CTX_KEY_EVALUATION: eval_text,
         })
         display = emp_nickname or emp_name
         await _chat(ctx.room_id, display, emp_role, eval_text)
@@ -347,7 +347,7 @@ async def _handle_senior_review(step: WorkflowStep, ctx: StepContext) -> dict:
         junior_info = "\n".join(
             f"- {jd.get(PF_NAME, '')}（{jd.get(PF_NICKNAME, '')}，Lv.{jd.get(PF_LEVEL, 1)}）: "
             + next(
-                (se["evaluation"] for se in ctx.self_evaluations if se["employee_id"] == jid),
+                (se[CTX_KEY_EVALUATION] for se in ctx.self_evaluations if se[TL_FIELD_EMPLOYEE_ID] == jid),
                 "No self-evaluation",
             )
             for jid, jd in juniors
@@ -483,17 +483,18 @@ async def _handle_coo_report(step: WorkflowStep, ctx: StepContext) -> dict:
     # Build cost context from project record
     cost_ctx = ""
     if ctx.project_record:
-        cost_data = ctx.project_record.get("cost", {})
+        from onemancompany.core.project_archive import PA_COST, PA_BREAKDOWN, PA_TOKEN_USAGE
+        cost_data = ctx.project_record.get(PA_COST, {})
         if cost_data and (cost_data.get("actual_cost_usd", 0) > 0 or cost_data.get("budget_estimate_usd", 0) > 0):
             budget = cost_data.get("budget_estimate_usd", 0)
             actual = cost_data.get("actual_cost_usd", 0)
-            tokens = cost_data.get("token_usage", {})
-            breakdown = cost_data.get("breakdown", [])
+            tokens = cost_data.get(PA_TOKEN_USAGE, {})
+            breakdown = cost_data.get(PA_BREAKDOWN, [])
             cost_lines = [f"Budget: ${budget:.4f}, Actual: ${actual:.4f}"]
             cost_lines.append(f"Token usage: input={tokens.get('input', 0)}, output={tokens.get('output', 0)}")
             for entry in breakdown:
-                emp_data = load_employee(entry.get("employee_id", ""))
-                name = emp_data.get(PF_NAME, entry.get("employee_id", "?")) if emp_data else entry.get("employee_id", "?")
+                emp_data = load_employee(entry.get(TL_FIELD_EMPLOYEE_ID, ""))
+                name = emp_data.get(PF_NAME, entry.get(TL_FIELD_EMPLOYEE_ID, "?")) if emp_data else entry.get(TL_FIELD_EMPLOYEE_ID, "?")
                 cost_lines.append(f"  - {name}: {entry.get('model', '?')}, {entry.get('total_tokens', 0)} tokens, ${entry.get('cost_usd', 0):.4f}")
             cost_ctx = "\n\nProject cost data:\n" + "\n".join(cost_lines) + "\n"
 
@@ -1608,11 +1609,11 @@ async def _run_review_phase1(
         resp = await tracked_ainvoke(llm, prompt, category="routine", employee_id=emp_id)
         eval_text = resp.content
         result["self_evaluations"].append({
-            "employee_id": emp_id,
-            "name": emp_name,
-            "nickname": emp_nickname,
-            "level": emp_level,
-            "evaluation": eval_text,
+            TL_FIELD_EMPLOYEE_ID: emp_id,
+            PF_NAME: emp_name,
+            PF_NICKNAME: emp_nickname,
+            PF_LEVEL: emp_level,
+            CTX_KEY_EVALUATION: eval_text,
         })
         display = emp_nickname or emp_name
         await _chat(room_id, display, emp_role, eval_text)
@@ -1636,7 +1637,7 @@ async def _run_review_phase1(
         junior_info = "\n".join(
             f"- {jd.get(PF_NAME, '')}（{jd.get(PF_NICKNAME, '')}，Lv.{jd.get(PF_LEVEL, 1)}）: "
             + next(
-                (se["evaluation"] for se in result["self_evaluations"] if se["employee_id"] == jid),
+                (se[CTX_KEY_EVALUATION] for se in result["self_evaluations"] if se[TL_FIELD_EMPLOYEE_ID] == jid),
                 "No self-evaluation",
             )
             for jid, jd in juniors

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -72,6 +72,13 @@ from loguru import logger
 REPORTS_DIR = MEETING_REPORTS_DIR
 _AGENT_ROUTINE = "ROUTINE"
 
+# Context dict keys used in StepContext data structures
+CTX_KEY_EVALUATION = "evaluation"
+CTX_KEY_REVIEWER_ID = "reviewer_id"
+CTX_KEY_REVIEW = "review"
+CTX_KEY_SOURCE = "source"
+CTX_KEY_DESCRIPTION = "description"
+
 
 # ---------------------------------------------------------------------------
 # Shared helpers to reduce repetition across routine handlers
@@ -1202,13 +1209,13 @@ async def run_post_task_routine(
             from onemancompany.core.project_archive import append_action
             # Record each participant's self-evaluation
             for ev in ctx.self_evaluations:
-                append_action(project_id, ev.get(TL_FIELD_EMPLOYEE_ID, ""), TL_ACTION_SELF_EVAL, ev.get("evaluation", "")[:MAX_SUMMARY_LEN])
+                append_action(project_id, ev.get(TL_FIELD_EMPLOYEE_ID, ""), TL_ACTION_SELF_EVAL, ev.get(CTX_KEY_EVALUATION, "")[:MAX_SUMMARY_LEN])
             for rv in ctx.senior_reviews:
-                append_action(project_id, rv.get("reviewer_id", ""), TL_ACTION_SENIOR_REVIEW, rv.get("review", "")[:MAX_SUMMARY_LEN])
+                append_action(project_id, rv.get(CTX_KEY_REVIEWER_ID, ""), TL_ACTION_SENIOR_REVIEW, rv.get(CTX_KEY_REVIEW, "")[:MAX_SUMMARY_LEN])
             if ctx.coo_report:
                 append_action(project_id, COO_ID, TL_ACTION_OPS_REPORT, ctx.coo_report[:MAX_SUMMARY_LEN])
             for ai in ctx.action_items:
-                append_action(project_id, ai.get("source", ""), TL_ACTION_IMPROVEMENT, ai.get("description", "")[:MAX_SUMMARY_LEN])
+                append_action(project_id, ai.get(CTX_KEY_SOURCE, ""), TL_ACTION_IMPROVEMENT, ai.get(CTX_KEY_DESCRIPTION, "")[:MAX_SUMMARY_LEN])
 
     finally:
         # Release meeting room

--- a/src/onemancompany/core/store.py
+++ b/src/onemancompany/core/store.py
@@ -42,6 +42,7 @@ from onemancompany.core.config import (
 # Filename constants (single-file, used only in store.py)
 # ---------------------------------------------------------------------------
 WORK_PRINCIPLES_FILENAME = "work_principles.md"
+_GUIDANCE_NOTES_KEY = "notes"  # key inside guidance.yaml
 ACTIVITY_LOG_FILENAME = "activity_log.yaml"
 OVERHEAD_FILENAME = "overhead.yaml"
 TASK_INDEX_FILENAME = "task_index.yaml"
@@ -209,7 +210,7 @@ def load_employee_guidance(emp_id: str) -> list[str]:
         return []
     if isinstance(data, list):
         return data
-    return data.get("notes", []) if isinstance(data, dict) else []
+    return data.get(_GUIDANCE_NOTES_KEY, []) if isinstance(data, dict) else []
 
 
 def load_employee_work_principles(emp_id: str) -> str:
@@ -258,7 +259,7 @@ async def save_guidance(emp_id: str, notes: list[str]) -> None:
     """Write guidance.yaml for an employee."""
     path = EMPLOYEES_DIR / emp_id / GUIDANCE_FILENAME
     async with _get_lock(str(path)):
-        _write_yaml(path, {"notes": notes})
+        _write_yaml(path, {_GUIDANCE_NOTES_KEY: notes})
     mark_dirty(DirtyCategory.EMPLOYEES)
 
 

--- a/src/onemancompany/core/store.py
+++ b/src/onemancompany/core/store.py
@@ -151,12 +151,23 @@ def _ex_employee_profile_path(emp_id: str) -> Path:
 # ---------------------------------------------------------------------------
 
 def load_employee(emp_id: str) -> dict:
-    """Read profile.yaml for a single employee. Returns full dict including runtime."""
-    return _read_yaml(_employee_profile_path(emp_id))
+    """Read profile.yaml for a single employee. Returns full dict including runtime.
+
+    Also loads work_principles.md and guidance.yaml into the dict so all
+    callers get these fields without separate file reads.
+    """
+    data = _read_yaml(_employee_profile_path(emp_id))
+    if data:
+        data["work_principles"] = load_employee_work_principles(emp_id)
+        data["guidance_notes"] = load_employee_guidance(emp_id)
+    return data
 
 
 def load_all_employees() -> dict[str, dict]:
-    """Read all employee profile.yamls from disk. Returns {emp_id: profile_dict}."""
+    """Read all employee profile.yamls from disk. Returns {emp_id: profile_dict}.
+
+    Also loads work_principles and guidance_notes from their separate files.
+    """
     result: dict[str, dict] = {}
     if not EMPLOYEES_DIR.exists():
         return result
@@ -165,7 +176,11 @@ def load_all_employees() -> dict[str, dict]:
             continue
         profile_path = emp_dir / PROFILE_FILENAME
         if profile_path.exists():
-            result[emp_dir.name] = _read_yaml(profile_path)
+            data = _read_yaml(profile_path)
+            emp_id = emp_dir.name
+            data["work_principles"] = load_employee_work_principles(emp_id)
+            data["guidance_notes"] = load_employee_guidance(emp_id)
+            result[emp_id] = data
     return result
 
 

--- a/src/onemancompany/core/store.py
+++ b/src/onemancompany/core/store.py
@@ -24,6 +24,8 @@ from onemancompany.core.config import (
     COMPANY_DIR,
     DATA_ROOT,  # noqa: F401 — re-exported, used by test fixtures
     ENCODING_UTF8,
+    PF_GUIDANCE_NOTES,
+    PF_WORK_PRINCIPLES,
     PROJECTS_DIR,  # noqa: F401 — re-exported, used by test fixtures
     DirtyCategory,
     EMPLOYEES_DIR,
@@ -158,8 +160,8 @@ def load_employee(emp_id: str) -> dict:
     """
     data = _read_yaml(_employee_profile_path(emp_id))
     if data:
-        data["work_principles"] = load_employee_work_principles(emp_id)
-        data["guidance_notes"] = load_employee_guidance(emp_id)
+        data[PF_WORK_PRINCIPLES] = load_employee_work_principles(emp_id)
+        data[PF_GUIDANCE_NOTES] = load_employee_guidance(emp_id)
     return data
 
 
@@ -178,8 +180,8 @@ def load_all_employees() -> dict[str, dict]:
         if profile_path.exists():
             data = _read_yaml(profile_path)
             emp_id = emp_dir.name
-            data["work_principles"] = load_employee_work_principles(emp_id)
-            data["guidance_notes"] = load_employee_guidance(emp_id)
+            data[PF_WORK_PRINCIPLES] = load_employee_work_principles(emp_id)
+            data[PF_GUIDANCE_NOTES] = load_employee_guidance(emp_id)
             result[emp_id] = data
     return result
 

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -48,6 +48,9 @@ from onemancompany.core.config import (
     STATUS_WORKING,
     SYSTEM_AGENT,
     TASK_TREE_FILENAME,
+    TL_FIELD_ACTION,
+    TL_FIELD_DETAIL,
+    TL_FIELD_EMPLOYEE_ID,
 )
 from onemancompany.core.project_archive import ITER_STATUS_FAILED
 from onemancompany.core.events import CompanyEvent, event_bus
@@ -1634,9 +1637,9 @@ class EmployeeManager:
                 for j, entry in enumerate(shown):
                     ts = entry.get("time", "")
                     time_short = ts[11:19] if len(ts) >= 19 else ts[:8]
-                    emp_entry = entry.get("employee_id", "?")
-                    action = entry.get("action", "")
-                    detail = (entry.get("detail") or "")[:self._CTX_TIMELINE_DETAIL_CHARS]
+                    emp_entry = entry.get(TL_FIELD_EMPLOYEE_ID, "?")
+                    action = entry.get(TL_FIELD_ACTION, "")
+                    detail = (entry.get(TL_FIELD_DETAIL) or "")[:self._CTX_TIMELINE_DETAIL_CHARS]
                     line = f"  [{time_short}] {emp_entry} — {action}"
                     if detail:
                         line += f": {detail}"

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -51,8 +51,9 @@ from onemancompany.core.config import (
     TL_FIELD_ACTION,
     TL_FIELD_DETAIL,
     TL_FIELD_EMPLOYEE_ID,
+    TL_FIELD_TIME,
 )
-from onemancompany.core.project_archive import ITER_STATUS_FAILED
+from onemancompany.core.project_archive import ITER_STATUS_FAILED, PA_TOKEN_USAGE
 from onemancompany.core.events import CompanyEvent, event_bus
 from onemancompany.core.models import EventType
 from onemancompany.core.state import company_state  # noqa: F401 — tests patch this
@@ -1635,7 +1636,7 @@ class EmployeeManager:
 
                 parts.append(f"Log ({total_entries} entries):")
                 for j, entry in enumerate(shown):
-                    ts = entry.get("time", "")
+                    ts = entry.get(TL_FIELD_TIME, "")
                     time_short = ts[11:19] if len(ts) >= 19 else ts[:8]
                     emp_entry = entry.get(TL_FIELD_EMPLOYEE_ID, "?")
                     action = entry.get(TL_FIELD_ACTION, "")
@@ -1654,7 +1655,7 @@ class EmployeeManager:
             cost = it.get("cost", {})
             iter_cost = cost.get("actual_cost_usd", 0.0)
             iter_budget = cost.get("budget_estimate_usd", 0.0)
-            tokens = cost.get("token_usage", {})
+            tokens = cost.get(PA_TOKEN_USAGE, {})
             tok_in = tokens.get("input", 0)
             tok_out = tokens.get("output", 0)
             if iter_cost > 0 or tok_in > 0:

--- a/tests/unit/agents/test_onboarding.py
+++ b/tests/unit/agents/test_onboarding.py
@@ -324,13 +324,12 @@ class TestExecuteHire:
         assert emp_dir.exists()
         assert (emp_dir / "skills").is_dir()
 
-        # Verify work-principles skill created (autoloaded)
-        wp_path = emp_dir / "skills" / "work-principles" / "SKILL.md"
+        # Verify work_principles.md created (unified location)
+        wp_path = emp_dir / "work_principles.md"
         assert wp_path.exists()
         content = wp_path.read_text()
         assert "Test Developer" in content
         assert "追风" in content
-        assert "autoload: true" in content
 
         # Verify skill stubs created (folder-based)
         assert (emp_dir / "skills" / "python" / "SKILL.md").exists()


### PR DESCRIPTION
## Summary
- Add `GET /api/employees/{eid}/projects/{pid}/retrospective` endpoint — returns self-evaluation, feedback, senior reviews, HR improvements from project timeline
- Click project in employee detail opens retro summary popup instead of navigating to project detail
- Fix `ev.get("id")` → `ev.get("employee_id")` bug in routine.py timeline recording
- **Unify work_principles and guidance_notes loading**: `load_employee()` and `load_all_employees()` now include `work_principles.md` and `guidance.yaml` in returned dict — fixes all prompt injection and frontend display being empty
- **Remove work-principles skill from onboarding**: was creating a conflicting `skills/work-principles/SKILL.md` that diverged from `work_principles.md` for self-hosted employees. Now writes directly to `work_principles.md`

## Root cause
`work_principles` was written to `work_principles.md` but read from `profile.yaml` (where it never existed), so all `emp_data.get("work_principles")` calls returned empty — affecting agent prompts, 1-on-1 reflection, retrospective meetings, and frontend display.

## Test plan
- [x] All 2001 tests pass
- [ ] Verify project click in employee detail shows retro popup
- [ ] Verify work principles and guidance notes display in employee detail page
- [ ] Verify 1-on-1 meeting correctly reads and updates work principles

🤖 Generated with [Claude Code](https://claude.com/claude-code)