### PR TITLE
fix: model save button not working for company-hosted employees

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2700,6 +2700,9 @@ class AppController {
     });
 
     this._loadModelDropdown(empId, empData);
+
+    // Wire save button to saveEmployeeModel
+    document.getElementById('emp-model-save-btn').addEventListener('click', () => this.saveEmployeeModel());
   }
 
   async _loadModelDropdown(empId, empData) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.511",
+  "version": "0.2.512",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.510",
+  "version": "0.2.511",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.510"
+version = "0.2.511"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.511"
+version = "0.2.512"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/default_skills/ontology/SKILL.md
+++ b/src/onemancompany/default_skills/ontology/SKILL.md
@@ -70,7 +70,7 @@ Default: `memory/ontology/graph.jsonl`
 {"op":"relate","from":"proj_001","rel":"has_owner","to":"p_001"}
 ```
 
-Query via scripts or direct file ops. For complex graphs, migrate to SQLite.
+Query via scripts or direct file ops. All data lives on the filesystem — do NOT use SQLite or any database.
 
 ## Workflows
 


### PR DESCRIPTION
## Summary
- The Save button in the fallback model section (`_renderFallbackModelSection`) was created but never connected to `saveEmployeeModel()` via a click handler
- Company-hosted employees without a manifest hit this code path, so clicking Save did nothing

## Test plan
- [ ] Open employee detail for a company-hosted employee (non-founding, non-self-hosted)
- [ ] Change model selection, click Save
- [ ] Verify model updates and persists after page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)