### PR TITLE
fix: retrospective only includes task tree participants

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.515",
+  "version": "0.2.516",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.515"
+version = "0.2.516"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2231,7 +2231,29 @@ class EmployeeManager:
         if run_retrospective:
             try:
                 from onemancompany.core.routine import run_post_task_routine
-                await run_post_task_routine(node.description, project_id=project_id)
+                # Extract actual participants from the task tree so only
+                # employees who worked on the project join the retrospective.
+                _retro_participants = None
+                tree_dir = node.project_dir or ""
+                if tree_dir:
+                    try:
+                        from onemancompany.core.task_tree import TaskTree
+                        _tree = TaskTree.load(Path(tree_dir) / "task_tree.yaml")
+                        _retro_participants = list({
+                            n.employee_id for n in _tree.nodes.values()
+                            if n.employee_id
+                        })
+                        logger.debug(
+                            "[cleanup] Retrospective participants from tree: {}",
+                            _retro_participants,
+                        )
+                    except Exception as _tree_err:
+                        logger.debug("[cleanup] Could not load tree for participants: {}", _tree_err)
+                await run_post_task_routine(
+                    node.description,
+                    participants=_retro_participants,
+                    project_id=project_id,
+                )
             except Exception as e:
                 traceback.print_exc()
                 if not project_id.startswith("_auto_"):


### PR DESCRIPTION
## Summary
- `_full_cleanup` called `run_post_task_routine` without `participants`, defaulting to all employees
- When timeline filtering had no data, every employee joined the retrospective even if only EA worked on the task
- Now extracts participant list from the task tree so only actual contributors attend

## Test plan
- [ ] Submit a task that only EA handles (no COO dispatch)
- [ ] Verify retrospective only includes EA and CEO, not all employees

🤖 Generated with [Claude Code](https://claude.com/claude-code)