### PR TITLE
fix: reject_child status guard, directive chain, plugin auto-install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.517",
+  "version": "0.2.518",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.519",
+  "version": "0.2.520",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.516",
+  "version": "0.2.517",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.518",
+  "version": "0.2.519",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.517"
+version = "0.2.518"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.518"
+version = "0.2.519"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.519"
+version = "0.2.520"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.516"
+version = "0.2.517"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -164,11 +164,18 @@ def dispatch_child(
     acceptance_criteria: list[str],
     timeout_seconds: int = 3600,
     depends_on: list[str] | None = None,
+    directive: str = "",
 ) -> dict:
     """Dispatch a child task to an employee with acceptance criteria.
 
     Creates a child node in the task tree and schedules it for execution.
     The child must complete and be accepted before this task can finish.
+
+    IMPORTANT: The description should preserve the original task from the CEO.
+    Do NOT rewrite or summarize the original problem — pass it through as-is.
+    If you need to add your own analysis, instructions, or context for the
+    executor, use the directive parameter. The executor will see the original
+    description + all directives from the chain (CEO → EA → COO → Employee).
 
     If depends_on is provided, the child will only be scheduled when all dependency
     nodes reach a terminal status. Until then the child is created in the tree
@@ -176,10 +183,11 @@ def dispatch_child(
 
     Args:
         employee_id: Target employee ID
-        description: What the employee should do
+        description: The task description — preserve the original wording from upstream
         acceptance_criteria: List of measurable criteria the result must meet
         timeout_seconds: Max seconds allowed for the child task (default 3600)
         depends_on: List of TaskNode IDs that must complete before this child starts
+        directive: Your analysis, instructions, or context for the executor (appended to directive chain)
     """
     from onemancompany.core.vessel import _current_vessel, _current_task_id
 
@@ -308,6 +316,17 @@ def dispatch_child(
         )
         child.project_id = current_node.project_id
         child.project_dir = project_dir
+
+        # Propagate directive chain: inherit parent's directives + add new directive
+        current_node.load_content(project_dir)
+        child.directives = list(current_node.directives)  # copy parent chain
+        if directive:
+            from datetime import datetime
+            child.directives.append({
+                "from": vessel.employee_id,
+                "directive": directive,
+                "at": datetime.now().isoformat(),
+            })
 
         # Auto-register dispatched employee in project team for project history
         _add_to_project_team(project_dir, employee_id)
@@ -488,15 +507,22 @@ def reject_child(node_id: str, reason: str, retry: bool = True) -> dict:
             if node.employee_id not in em.executors:
                 return {"status": "error", "message": f"No handle for employee {node.employee_id}, cannot push correction task."}
 
-            # Reset to pending and re-schedule
-            node.load_content(project_dir)  # Ensure description is loaded before reading
+            # Reset to pending and re-schedule — keep original description, add rejection as directive
+            node.load_content(project_dir)
             node.set_status(TaskPhase.PENDING)
             node.result = ""
-            node.description = (
-                f"Correction task: {node.description}\n\n"
-                f"Rejection reason: {reason}\n\n"
-                f"Acceptance criteria:\n" + "\n".join(f"- {c}" for c in node.acceptance_criteria)
-            )
+            from datetime import datetime
+            new_directives = list(node.directives)
+            new_directives.append({
+                "from": vessel.employee_id,
+                "directive": (
+                    f"[CORRECTION] Your previous result was rejected.\n"
+                    f"Reason: {reason}\n"
+                    f"Acceptance criteria:\n" + "\n".join(f"- {c}" for c in node.acceptance_criteria)
+                ),
+                "at": datetime.now().isoformat(),
+            })
+            node.directives = new_directives  # reassign to trigger _content_dirty
             _save_tree(project_dir, tree)
 
             em.schedule_node(node.employee_id, node.id, tree_path_str)

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -472,6 +472,15 @@ def reject_child(node_id: str, reason: str, retry: bool = True) -> dict:
         if not node:
             return {"status": "error", "message": f"Node {node_id} not found."}
 
+        current = node.status
+
+        # Only completed tasks can be rejected
+        if current != TaskPhase.COMPLETED.value:
+            return {
+                "status": "error",
+                "message": f"Cannot reject node {node_id}: current status is '{current}', must be 'completed' first. Wait for the employee to finish before rejecting.",
+            }
+
         node.acceptance_result = {"passed": False, "notes": reason}
 
         if retry:

--- a/src/onemancompany/core/claude_session.py
+++ b/src/onemancompany/core/claude_session.py
@@ -154,6 +154,84 @@ def _clear_running_pid(employee_id: str, project_id: str) -> None:
 # Registry of live daemons: key = "employee_id:project_id"
 _daemons: dict[str, "ClaudeDaemon"] = {}
 
+_ensured_plugins: set[str] = set()
+
+# Known marketplaces that need to be added before installing plugins from them.
+# Format: marketplace_name -> repo path for `claude plugin marketplace add`
+_KNOWN_MARKETPLACES: dict[str, str] = {
+    "superpowers-marketplace": "obra/superpowers-marketplace",
+}
+
+
+async def _run_claude_cmd(cmd: list[str], label: str, env: dict[str, str]) -> bool:
+    """Run a claude CLI command with timeout and error handling. Returns True on success."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+        out = (stdout or b"").decode("utf-8", errors="replace").strip()
+        err = (stderr or b"").decode("utf-8", errors="replace").strip()
+        if proc.returncode == 0:
+            logger.debug("[claude-plugins] {} ok: {}", label, out[:200])
+            return True
+        logger.warning("[claude-plugins] {} failed (rc={}): {} {}", label, proc.returncode, out[:200], err[:200])
+    except asyncio.TimeoutError:
+        logger.warning("[claude-plugins] {} timed out", label)
+    except asyncio.CancelledError:
+        raise
+    except Exception as e:
+        logger.warning("[claude-plugins] {} error: {}", label, e)
+    return False
+
+
+async def _ensure_plugins(plugins: list[str]) -> None:
+    """Ensure the given Claude CLI plugins are installed and enabled (idempotent).
+
+    Args:
+        plugins: List of plugin identifiers, e.g. ["superpowers@superpowers-marketplace"].
+    """
+    needed = [p for p in plugins if p not in _ensured_plugins]
+    if not needed:
+        return
+
+    _exclude_env = {"CLAUDECODE", "ANTHROPIC_API_KEY"}
+    env = {k: v for k, v in os.environ.items() if k not in _exclude_env}
+
+    # Collect marketplaces that need to be added
+    marketplaces_to_add: set[str] = set()
+    for plugin_id in needed:
+        if "@" in plugin_id:
+            marketplace = plugin_id.split("@", 1)[1]
+            if marketplace in _KNOWN_MARKETPLACES:
+                marketplaces_to_add.add(marketplace)
+
+    # Add marketplaces first
+    for marketplace in marketplaces_to_add:
+        repo = _KNOWN_MARKETPLACES[marketplace]
+        await _run_claude_cmd(
+            ["claude", "plugin", "marketplace", "add", repo],
+            f"marketplace-add:{marketplace}", env,
+        )
+
+    # Install and enable each plugin
+    for plugin_id in needed:
+        ok = await _run_claude_cmd(
+            ["claude", "plugin", "install", plugin_id],
+            f"install:{plugin_id}", env,
+        )
+        if ok:
+            await _run_claude_cmd(
+                ["claude", "plugin", "enable", plugin_id],
+                f"enable:{plugin_id}", env,
+            )
+            _ensured_plugins.add(plugin_id)
+
+    logger.info("[claude-plugins] setup complete for: {}", needed)
+
 
 class ClaudeDaemon:
     """A persistent Claude CLI process that accepts prompts via stream-json stdin."""
@@ -167,11 +245,13 @@ class ClaudeDaemon:
         mcp_config_path: str | None = None,
         work_dir: str = "",
         max_turns: int = 50,
+        claude_plugins: list[str] | None = None,
     ) -> None:
         self.employee_id = employee_id
         self.project_id = project_id
         self.session_id = session_id
         self.is_new = is_new
+        self.claude_plugins = claude_plugins or []
         self.mcp_config_path = mcp_config_path
         # Always launch from employee directory so CLAUDE.md is picked up;
         # task-specific work_dir is communicated via the prompt instead.
@@ -201,6 +281,8 @@ class ClaudeDaemon:
 
     async def start(self) -> None:
         """Spawn the persistent claude process."""
+        if self.claude_plugins:
+            await _ensure_plugins(self.claude_plugins)
         cmd = [
             "claude", "--print", "--verbose",
             "--input-format", "stream-json",
@@ -517,6 +599,11 @@ async def _get_or_start_daemon(
     except Exception as e:
         logger.warning(f"Failed to generate MCP config: {e}")
 
+    # Load claude_plugins from employee profile
+    from onemancompany.core.config import load_employee_profile
+    _profile = load_employee_profile(employee_id)
+    claude_plugins = _profile.get("claude_plugins", [])
+
     # Try to start daemon (may resume existing session)
     session_id, is_new = get_or_create_session(employee_id, project_id, work_dir=work_dir)
 
@@ -528,6 +615,7 @@ async def _get_or_start_daemon(
         mcp_config_path=mcp_config_path,
         work_dir=work_dir,
         max_turns=max_turns,
+        claude_plugins=claude_plugins,
     )
     await daemon.start()
 
@@ -557,6 +645,7 @@ async def _get_or_start_daemon(
             mcp_config_path=mcp_config_path,
             work_dir=work_dir,
             max_turns=max_turns,
+            claude_plugins=claude_plugins,
         )
         await daemon.start()
 

--- a/src/onemancompany/core/task_tree.py
+++ b/src/onemancompany/core/task_tree.py
@@ -70,6 +70,12 @@ class TaskNode:
 
     depends_on: list[str] = field(default_factory=list)
 
+    # Directive chain: preserves the original description while allowing each upstream
+    # node (EA, COO) to add binding instructions. The executor sees both the original
+    # description AND all directives from the chain.
+    # Format: [{"from": employee_id, "role": "COO", "directive": "...", "at": iso_timestamp}]
+    directives: list[dict] = field(default_factory=list)
+
     # Hold reason: when a tool needs the parent to enter HOLDING after execution,
     # it sets this field (e.g. "blocking_child=<node_id>"). vessel.py checks this
     # generically — no child-type-specific detection needed.
@@ -96,7 +102,7 @@ class TaskNode:
                 super().__setattr__("_description_preview", (value or "")[:200])
             except AttributeError:
                 return  # During __init__ before _content_dirty exists
-        elif name == "result":
+        elif name in ("result", "directives"):
             try:
                 super().__setattr__("_content_dirty", True)
             except AttributeError:
@@ -112,7 +118,9 @@ class TaskNode:
             return
         nodes_dir = Path(project_dir) / NODES_DIR
         nodes_dir.mkdir(parents=True, exist_ok=True)
-        content = {"description": self.description, "result": self.result}
+        content: dict = {"description": self.description, "result": self.result}
+        if self.directives:
+            content["directives"] = self.directives
         (nodes_dir / f"{self.id}.yaml").write_text(
             yaml.dump(content, allow_unicode=True, sort_keys=False),
             encoding=ENCODING_UTF8,
@@ -131,6 +139,8 @@ class TaskNode:
             object.__setattr__(self, "description", desc)
             object.__setattr__(self, "result", data.get("result", ""))
             object.__setattr__(self, "_description_preview", (desc or "")[:200])
+            if "directives" in data:
+                object.__setattr__(self, "directives", data["directives"])
         self._content_loaded = True
 
     def set_status(self, target: TaskPhase) -> None:
@@ -180,6 +190,7 @@ class TaskNode:
             "branch_active": self.branch_active,
             "depends_on": list(self.depends_on),
             "hold_reason": self.hold_reason,
+            "directives_count": len(self.directives),
         }
 
     @classmethod

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1988,6 +1988,7 @@ class EmployeeManager:
             lines.append("All subtasks have passed review.")
 
         lines.append("Please call accept_child(node_id, notes) or reject_child(node_id, reason) for unreviewed subtasks.")
+        lines.append("IMPORTANT: Each subtask can only be accepted OR rejected ONCE. Once accepted, it CANNOT be rejected later. Review carefully before deciding.")
         lines.append("If additional tasks are needed, call dispatch_child().")
         lines.append("Once all are handled, your task will auto-complete and report upward.")
 

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -197,6 +197,14 @@ def _build_tree_context(tree, node, project_dir: str) -> str:
     node.load_content(project_dir)
     parts.append(f"=== Current Task ({node.id}) ===")
     parts.append(f"Description: {node.description}")
+    if node.directives:
+        parts.append("")
+        parts.append("=== Directives from upstream ===")
+        for d in node.directives:
+            from_id = d.get("from", "unknown")
+            text = d.get("directive", "")
+            parts.append(f"[{from_id}]: {text}")
+        parts.append("=== End directives ===")
     if node.result:
         parts.append(f"Result: {node.result}")
     parts.append("")

--- a/src/onemancompany/talent_market/talent_spec.py
+++ b/src/onemancompany/talent_market/talent_spec.py
@@ -215,6 +215,7 @@ class TalentProfile:
     tools: list[str] = field(default_factory=list)
     personality_tags: list[str] = field(default_factory=list)
     system_prompt_template: str = ""
+    claude_plugins: list[str] = field(default_factory=list)  # Self-hosted only: Claude CLI plugins to install
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

### reject_child 状态守卫
- `reject_child` 缺少状态前置检查（`accept_child` 有），导致 COO 在任务还是 `processing` 状态时 reject 报错 "illegal transition processing -> pending"
- 添加 `completed` 状态守卫，非 completed 返回明确错误信息
- Review prompt 加一次性决策警告：accept/reject 只能选一次，accept 后无法撤回（因为下游依赖已解锁、父节点可能已自动提升）

### Directive chain（原始 prompt 保留）
- 原来 EA → COO → Employee 传递任务时，每层都改写 description，CEO 原始 prompt 被覆盖
- 现在 `description` 字段保持 CEO 原始任务不变，每层上游通过 `directive` 参数添加自己的分析和指令
- `directives` 列表随任务树向下传播，执行者看到：原始描述 + 所有上游指令链
- `reject_child` 的修正信息也作为 directive 追加，不再覆盖原始 description

### Plugin 自动安装
- `TalentProfile` 新增 `claude_plugins` 字段，self-hosted 员工可声明需要的 Claude CLI plugins
- `ClaudeDaemon.start()` 前自动安装并启用（幂等，按 plugin 去重）
- 支持自定义 marketplace 自动添加（`_KNOWN_MARKETPLACES` 注册表）

## Test plan
- [x] 2001 tests pass
- [ ] COO reject PROCESSING 状态任务 → 返回错误提示
- [ ] COO reject COMPLETED 状态任务 → 正常工作
- [ ] dispatch_child 带 directive → 子节点继承父 directives + 新 directive
- [ ] 执行者 prompt 显示原始 description + directives 区块
- [ ] profile.yaml 配置 claude_plugins → daemon 启动时自动安装

🤖 Generated with [Claude Code](https://claude.com/claude-code)