### PR TITLE
fix: correct import name in claude_session.py

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.520",
+  "version": "0.2.521",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.520"
+version = "0.2.521"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/claude_session.py
+++ b/src/onemancompany/core/claude_session.py
@@ -600,8 +600,8 @@ async def _get_or_start_daemon(
         logger.warning(f"Failed to generate MCP config: {e}")
 
     # Load claude_plugins from employee profile
-    from onemancompany.core.config import load_employee_profile
-    _profile = load_employee_profile(employee_id)
+    from onemancompany.core.config import load_employee_profile_yaml
+    _profile = load_employee_profile_yaml(employee_id)
     claude_plugins = _profile.get("claude_plugins", [])
 
     # Try to start daemon (may resume existing session)


### PR DESCRIPTION
## Summary
- Fix `ImportError: cannot import name 'load_employee_profile'` when starting Claude daemon for self-hosted employees
- The function in `config.py` is `load_employee_profile_yaml`, not `load_employee_profile`

## Test plan
- [x] All unit tests pass
- [ ] Start self-hosted employee and verify daemon launches without ImportError

🤖 Generated with [Claude Code](https://claude.com/claude-code)