### PR TITLE
feat: show app version in UI, CLI, and startup

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -285,7 +285,7 @@ ${green("What gets installed automatically:")}
 
   console.log();
   console.log(cyan("╔═══════════════════════════════════════════════╗"));
-  console.log(cyan("║   OneManCompany — AI Company OS       ║"));
+  console.log(cyan("║   OneManCompany — AI Company OS               ║"));
   console.log(cyan("╚═══════════════════════════════════════════════╝"));
   console.log();
 
@@ -333,6 +333,15 @@ ${green("What gets installed automatically:")}
     const cloneEnv = { ...process.env, GIT_LFS_SKIP_SMUDGE: "1" };
     run(`git clone --depth 1 ${REPO_URL} "${installDir}"`, { env: cloneEnv });
   }
+
+  // ── Read version from pyproject.toml ─────────────────────────────────
+  let appVersion = "unknown";
+  try {
+    const pyproject = fs.readFileSync(path.join(installDir, "pyproject.toml"), "utf-8");
+    const verMatch = pyproject.match(/^version\s*=\s*"([^"]+)"/m);
+    if (verMatch) appVersion = verMatch[1];
+  } catch {}
+  info(`Version: ${appVersion}`);
 
   // ── Check if already running ─────────────────────────────────────────
   const existingPid = readPidFile(installDir);
@@ -505,7 +514,7 @@ ${green("What gets installed automatically:")}
 
   if (debugMode) {
     // ── Foreground mode: show logs, Ctrl+C to kill ──────────────────
-    info("Starting OneManCompany in debug mode (Ctrl+C to stop)...\n");
+    info(`Starting OneManCompany v${appVersion} in debug mode (Ctrl+C to stop)...\n`);
     const child = spawn(pythonBin, ["-m", "onemancompany.main", ...launchArgs], {
       cwd: installDir,
       stdio: "inherit",
@@ -521,7 +530,7 @@ ${green("What gets installed automatically:")}
     process.on("SIGTERM", () => { child.kill("SIGTERM"); });
   } else {
     // ── Background mode: detach and exit CLI ────────────────────────
-    info("Starting OneManCompany in background...");
+    info(`Starting OneManCompany v${appVersion} in background...`);
     const logFile = path.join(installDir, ".onemancompany", "server.log");
     // Ensure log directory exists
     const logDir = path.dirname(logFile);
@@ -544,7 +553,7 @@ ${green("What gets installed automatically:")}
     await new Promise((r) => setTimeout(r, 5000));
     if (isProcessRunning(child.pid)) {
       console.log();
-      console.log(green("  ✓ OneManCompany is running!"));
+      console.log(green(`  ✓ OneManCompany v${appVersion} is running!`));
       console.log();
       console.log(`  ${cyan("→")} Open ${cyan("http://localhost:8000")} in your browser`);
       console.log(`  ${dim("  Logs:")} ${logFile}`);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -283,9 +283,19 @@ ${green("What gets installed automatically:")}
     return;
   }
 
+  // Read version from package.json (bundled with npm package)
+  let cliVersion = "unknown";
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8"));
+    if (pkg.version) cliVersion = pkg.version;
+  } catch {}
+
   console.log();
+  const verTag = `v${cliVersion}`;
+  const title = `OneManCompany — AI Company OS  ${verTag}`;
+  const pad = Math.max(0, 45 - title.length);
   console.log(cyan("╔═══════════════════════════════════════════════╗"));
-  console.log(cyan("║   OneManCompany — AI Company OS               ║"));
+  console.log(cyan(`║   ${title}${" ".repeat(pad)}║`));
   console.log(cyan("╚═══════════════════════════════════════════════╝"));
   console.log();
 
@@ -334,14 +344,13 @@ ${green("What gets installed automatically:")}
     run(`git clone --depth 1 ${REPO_URL} "${installDir}"`, { env: cloneEnv });
   }
 
-  // ── Read version from pyproject.toml ─────────────────────────────────
-  let appVersion = "unknown";
+  // ── Read actual version from repo (may differ from npm package) ──────
+  let appVersion = cliVersion;
   try {
     const pyproject = fs.readFileSync(path.join(installDir, "pyproject.toml"), "utf-8");
     const verMatch = pyproject.match(/^version\s*=\s*"([^"]+)"/m);
     if (verMatch) appVersion = verMatch[1];
   } catch {}
-  info(`Version: ${appVersion}`);
 
   // ── Check if already running ─────────────────────────────────────────
   const existingPid = readPidFile(installDir);

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -105,6 +105,10 @@ class AppController {
           office_layout: stateData.office_layout,
         });
       }
+      // Show version
+      if (stateData.version) {
+        document.getElementById('app-version').textContent = `v${stateData.version}`;
+      }
       // Update counters
       document.getElementById('employee-count').textContent = `👥 ${employees.length}`;
       document.getElementById('tool-count').textContent = `🔧 ${tools.length}`;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -49,7 +49,7 @@
     <!-- Center: Pixel art office -->
     <div id="office-panel">
       <div class="panel-header">
-        <h1 class="pixel-title">&#127970; ONE MAN COMPANY</h1>
+        <h1 class="pixel-title">&#127970; ONE MAN COMPANY <span id="app-version" class="version-badge"></span></h1>
         <div id="status-bar">
           <span class="status-item" id="employee-count">&#128101; 2</span>
           <span class="status-item status-clickable" id="tool-count" onclick="window.app.openToolList()">&#128295; 0</span>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -156,6 +156,13 @@ body {
   text-shadow: 2px 2px 0 rgba(0,0,0,0.5);
 }
 
+.version-badge {
+  font-size: 5px;
+  color: var(--pixel-blue);
+  opacity: 0.7;
+  margin-left: 4px;
+}
+
 #status-bar {
   display: flex;
   gap: 12px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.521",
+  "version": "0.2.522",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.521"
+version = "0.2.522"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -337,7 +337,14 @@ async def get_state() -> dict:
     employees = load_all_employees()
     ex_employees = load_ex_employees()
     overhead = load_overhead()
+    from importlib.metadata import version as _pkg_version
+    try:
+        app_version = _pkg_version("onemancompany")
+    except Exception:
+        app_version = "dev"
+
     return {
+        "version": app_version,
         "employees": list(employees.values()),
         "ex_employees": list(ex_employees.values()),
         "tools": [t.to_dict() for t in company_state.tools.values()],

--- a/src/onemancompany/main.py
+++ b/src/onemancompany/main.py
@@ -578,7 +578,12 @@ async def lifespan(app: FastAPI):
         print(f"[startup] Restored {_crons_restored} cron(s), {_webhooks_restored} webhook(s)")
 
     from onemancompany.core.config import settings as _settings
-    print(f"🏢 One Man Company HQ is open!")
+    from importlib.metadata import version as _pkg_version
+    try:
+        _app_ver = _pkg_version("onemancompany")
+    except Exception:
+        _app_ver = "dev"
+    print(f"🏢 One Man Company HQ v{_app_ver} is running!")
     print(f"   Frontend: http://localhost:{_settings.port}")
     yield
 


### PR DESCRIPTION
## Summary
- Display version badge (e.g. `v0.2.521`) next to "ONE MAN COMPANY" title in the frontend header
- Show version during `npx` install/update (reads from `pyproject.toml`)
- Include version in CLI startup success message (`✓ OneManCompany v0.2.521 is running!`)
- Include version in Python backend startup log (`🏢 One Man Company HQ v0.2.521 is running!`)
- Add `version` field to `/api/state` response for frontend consumption

## Test plan
- [x] All unit tests pass
- [ ] Verify version badge appears in frontend header
- [ ] Run `npx @1mancompany/onemancompany` and verify version shown during install and startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)