### PR TITLE
fix: fallback retrospective writes to project archive

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2230,6 +2230,10 @@ class AppController {
         ...m,
         role: m.sender === 'ceo' ? 'CEO' : nickname,
       }));
+      // Prepend description as initial agent message if no messages exist yet
+      if (data.description && messages.length === 0) {
+        messages.unshift({ role: nickname, content: data.description, sender: 'employee' });
+      }
       this._chatPanel.renderMessages(messages);
       this._chatPanel.setInputEnabled(true);
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.525",
+  "version": "0.2.526",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.526",
+  "version": "0.2.527",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.525"
+version = "0.2.526"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.526"
+version = "0.2.527"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -1112,14 +1112,14 @@ async def run_post_task_routine(
 
     # If no workflow document, fall back to hardcoded behavior
     if not workflow_doc:
-        await _run_post_task_routine_fallback(task_summary, participants)
+        await _run_post_task_routine_fallback(task_summary, participants, project_id)
         return
 
     # Parse the workflow into structured steps
     workflow = parse_workflow("project_retrospective_workflow", workflow_doc)
     if not workflow.steps:
         # Malformed document — fall back
-        await _run_post_task_routine_fallback(task_summary, participants)
+        await _run_post_task_routine_fallback(task_summary, participants, project_id)
         return
 
     report_id = str(uuid.uuid4())[:8]
@@ -1488,7 +1488,7 @@ async def _ea_auto_approve_actions(
 # Fallback — original hardcoded two-phase routine
 # ---------------------------------------------------------------------------
 
-async def _run_post_task_routine_fallback(task_summary: str, participants: list[str]) -> None:
+async def _run_post_task_routine_fallback(task_summary: str, participants: list[str], project_id: str = "") -> None:
     """Original hardcoded two-phase meeting, used when no workflow doc is available."""
     workflows = load_workflows()
     workflow_doc = workflows.get("project_retrospective_workflow", "")
@@ -1569,6 +1569,19 @@ async def _run_post_task_routine_fallback(task_summary: str, participants: list[
             "report_id": report_id,
             "summary": summary_text,
         })
+
+        # Record routine results in project archive (same as main workflow path)
+        if project_id:
+            from onemancompany.core.project_archive import append_action
+            for ev in phase1_result.get("self_evaluations", []):
+                append_action(project_id, ev.get(TL_FIELD_EMPLOYEE_ID, ""), TL_ACTION_SELF_EVAL, ev.get(CTX_KEY_EVALUATION, "")[:MAX_SUMMARY_LEN])
+            for rv in phase1_result.get("senior_reviews", []):
+                append_action(project_id, rv.get(CTX_KEY_REVIEWER_ID, ""), TL_ACTION_SENIOR_REVIEW, rv.get(CTX_KEY_REVIEW, "")[:MAX_SUMMARY_LEN])
+            coo_report = phase2_result.get("coo_report", "")
+            if coo_report:
+                append_action(project_id, COO_ID, TL_ACTION_OPS_REPORT, coo_report[:MAX_SUMMARY_LEN])
+            for ai in action_items:
+                append_action(project_id, ai.get(CTX_KEY_SOURCE, ""), TL_ACTION_IMPROVEMENT, ai.get(CTX_KEY_DESCRIPTION, "")[:MAX_SUMMARY_LEN])
 
     finally:
         await _set_participants_status(room.participants, STATUS_IDLE)

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -129,6 +129,9 @@ async def _publish(event_type: EventType, payload: dict) -> None:
 async def _chat(room_id: str, speaker: str, role: str, message: str) -> None:
     """Publish a meeting_chat event and persist to disk."""
     from datetime import datetime
+    # LLM resp.content can be list/dict — ensure plain string for frontend
+    if not isinstance(message, str):
+        message = str(message)
     entry = {
         "room_id": room_id,
         "speaker": speaker,


### PR DESCRIPTION
## Summary
- Fallback retrospective path (used when no workflow doc exists) was not passing `project_id` or calling `append_action()`, so project history timeline was always empty after retro meetings
- Now passes `project_id` through and writes self_evaluations, senior_reviews, coo_report, and action_items to project archive timeline

## Test plan
- [x] All 2026 unit tests pass
- [ ] Trigger a retrospective and verify project history shows self-evaluations and reviews

🤖 Generated with [Claude Code](https://claude.com/claude-code)