### PR TITLE
feat: full SFT trace for LLM fine-tuning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.531",
+  "version": "0.2.532",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.530",
+  "version": "0.2.531",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.530"
+version = "0.2.531"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.531"
+version = "0.2.532"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -331,16 +331,24 @@ async def tracked_ainvoke(
 
         # Write SFT trace (full conversation record for fine-tuning)
         try:
-            from onemancompany.core.llm_trace import write_sft_record
+            from onemancompany.core.llm_trace import write_sft_record_async
             from onemancompany.core.project_archive import get_project_dir
             _proj_dir = get_project_dir(project_id)
             if _proj_dir:
+                # Resolve node_id from contextvar if available
+                _node_id = ""
+                try:
+                    from onemancompany.core.agent_loop import _current_task_id
+                    _node_id = _current_task_id.get("")
+                except Exception as _e:
+                    logger.debug("[sft_trace] failed to resolve node_id: {}", _e)
                 # Build structured message list from input
                 _sft_msgs = messages if isinstance(messages, list) else [messages]
                 _sft_msgs_out = list(_sft_msgs) + [result]
-                write_sft_record(
+                write_sft_record_async(
                     _proj_dir,
                     employee_id=employee_id,
+                    node_id=_node_id,
                     source="tracked_ainvoke",
                     messages=_sft_msgs_out,
                     model=model_name,
@@ -711,11 +719,16 @@ class BaseAgentRunner:
 
         return self._last_usage
 
+    # Class-level cache: serialized tool schemas per employee_id
+    _sft_tool_cache: dict[str, list] = {}
+
     def _write_sft_trace(self, result: dict, usage_info: dict) -> None:
         """Write a complete SFT training record from a LangGraph ainvoke result."""
         try:
-            from onemancompany.core.agent_loop import _current_vessel, _current_task_id
-            from onemancompany.core.llm_trace import write_sft_record
+            from pathlib import Path as _Path
+
+            from onemancompany.core.agent_loop import _current_vessel
+            from onemancompany.core.llm_trace import write_sft_record_async
             from onemancompany.core.tool_registry import tool_registry
 
             vessel = _current_vessel.get(None)
@@ -729,20 +742,32 @@ class BaseAgentRunner:
             tree = get_tree(entry.tree_path)
             node = tree.get_node(entry.node_id) if tree else None
             project_dir = (node.project_dir if node else "") or str(
-                __import__("pathlib").Path(entry.tree_path).parent
+                _Path(entry.tree_path).parent
             )
             if not project_dir:
                 return
 
             messages = result.get(_LG_MESSAGES_KEY, [])
-            tools = tool_registry.get_proxied_tools_for(self.employee_id)
-            write_sft_record(
+
+            # Cache tool schemas — they don't change within a session
+            if self.employee_id not in self._sft_tool_cache:
+                from onemancompany.core.llm_trace import _serialize_tool_schema
+                tools = tool_registry.get_proxied_tools_for(self.employee_id)
+                serialized = []
+                for t in tools:
+                    try:
+                        serialized.append(_serialize_tool_schema(t))
+                    except Exception:
+                        logger.debug("[sft_trace] failed to serialize tool {}", getattr(t, "name", "?"))
+                self._sft_tool_cache[self.employee_id] = serialized
+
+            write_sft_record_async(
                 project_dir,
                 employee_id=self.employee_id,
                 node_id=entry.node_id,
                 source="langchain",
                 messages=messages,
-                tools=tools,
+                tools=self._sft_tool_cache[self.employee_id],
                 model=usage_info.get("model", ""),
                 usage={
                     "input_tokens": usage_info.get("input_tokens", 0),

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -305,7 +305,7 @@ async def tracked_ainvoke(
     # Always record overhead
     _record_overhead(category, model_name, input_tokens, output_tokens, cost_usd)
 
-    # Write to project-level LLM trace JSONL
+    # Write to project-level LLM trace JSONL (legacy per-event trace)
     if project_id:
         from datetime import datetime, timezone
         from onemancompany.core.claude_session import write_llm_trace
@@ -328,6 +328,26 @@ async def tracked_ainvoke(
             "model": model_name,
             "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
         })
+
+        # Write SFT trace (full conversation record for fine-tuning)
+        try:
+            from onemancompany.core.llm_trace import write_sft_record
+            from onemancompany.core.project_archive import get_project_dir
+            _proj_dir = get_project_dir(project_id)
+            if _proj_dir:
+                # Build structured message list from input
+                _sft_msgs = messages if isinstance(messages, list) else [messages]
+                _sft_msgs_out = list(_sft_msgs) + [result]
+                write_sft_record(
+                    _proj_dir,
+                    employee_id=employee_id,
+                    source="tracked_ainvoke",
+                    messages=_sft_msgs_out,
+                    model=model_name,
+                    usage={"input_tokens": input_tokens, "output_tokens": output_tokens},
+                )
+        except Exception as e:
+            logger.debug("[sft_trace] tracked_ainvoke write failed: {}", e)
 
     return result
 
@@ -517,6 +537,8 @@ class BaseAgentRunner:
         model_used = ""
         last_tool_calls: list[str] = []  # track tool names for fallback
         last_tool_results: list[str] = []
+        # SFT trace: accumulate full message objects from streaming events
+        sft_messages: list = []
 
         async for event in self._agent.astream_events(
             messages_input, version="v2", config={"recursion_limit": 50},
@@ -526,6 +548,9 @@ class BaseAgentRunner:
             if kind == "on_chat_model_start":
                 inp = data.get("input", "")
                 if isinstance(inp, list) and inp:
+                    # Capture all input messages for SFT on first LLM call
+                    if not sft_messages:
+                        sft_messages.extend(inp)
                     last_msg = inp[-1]
                     if hasattr(last_msg, "content"):
                         content = last_msg.content or ""
@@ -534,6 +559,8 @@ class BaseAgentRunner:
             elif kind == "on_chat_model_end":
                 output = data.get("output", None)
                 if output:
+                    # Capture AI message for SFT trace
+                    sft_messages.append(output)
                     # Extract token usage — try response_metadata first, then usage_metadata
                     meta = getattr(output, "response_metadata", {}) or {}
                     usage = meta.get("usage", {}) or meta.get("token_usage", {}) or {}
@@ -574,6 +601,10 @@ class BaseAgentRunner:
                 result_str = str(output)
                 last_tool_results.append(f"{name} → {result_str[:300]}")
                 on_log("tool_result", f"{name} → {result_str}")
+                # Capture ToolMessage for SFT trace
+                raw_output = data.get("output")
+                if raw_output and hasattr(raw_output, "content"):
+                    sft_messages.append(raw_output)
 
         # If no text content from LLM, synthesize from last tool calls
         if not final_content.strip() and last_tool_calls:
@@ -604,6 +635,13 @@ class BaseAgentRunner:
         # Record streaming usage into overhead
         if total_input_tokens or total_output_tokens or _cost_usd > 0:
             _record_overhead("agent_task", _model, total_input_tokens, total_output_tokens, _cost_usd)
+
+        # Write SFT trace from accumulated streaming messages
+        if sft_messages:
+            self._write_sft_trace(
+                {_LG_MESSAGES_KEY: sft_messages},
+                self._last_usage,
+            )
 
         self._set_status(STATUS_IDLE)
         await self._publish("agent_done", {"role": self.role, "summary": (final_content or "")[:MAX_SUMMARY_LEN]})
@@ -672,6 +710,47 @@ class BaseAgentRunner:
             )
 
         return self._last_usage
+
+    def _write_sft_trace(self, result: dict, usage_info: dict) -> None:
+        """Write a complete SFT training record from a LangGraph ainvoke result."""
+        try:
+            from onemancompany.core.agent_loop import _current_vessel, _current_task_id
+            from onemancompany.core.llm_trace import write_sft_record
+            from onemancompany.core.tool_registry import tool_registry
+
+            vessel = _current_vessel.get(None)
+            if not vessel:
+                return
+            # Get project_dir from current running task entry
+            entry = vessel.manager._current_entries.get(self.employee_id)
+            if not entry:
+                return
+            from onemancompany.core.task_tree import get_tree
+            tree = get_tree(entry.tree_path)
+            node = tree.get_node(entry.node_id) if tree else None
+            project_dir = (node.project_dir if node else "") or str(
+                __import__("pathlib").Path(entry.tree_path).parent
+            )
+            if not project_dir:
+                return
+
+            messages = result.get(_LG_MESSAGES_KEY, [])
+            tools = tool_registry.get_proxied_tools_for(self.employee_id)
+            write_sft_record(
+                project_dir,
+                employee_id=self.employee_id,
+                node_id=entry.node_id,
+                source="langchain",
+                messages=messages,
+                tools=tools,
+                model=usage_info.get("model", ""),
+                usage={
+                    "input_tokens": usage_info.get("input_tokens", 0),
+                    "output_tokens": usage_info.get("output_tokens", 0),
+                },
+            )
+        except Exception as e:
+            logger.debug("[sft_trace] failed to write SFT record for {}: {}", self.employee_id, e)
 
     def _get_model_name(self) -> str:
         """Return the LLM model name configured for this employee."""
@@ -1020,8 +1099,12 @@ class EmployeeAgent(BaseAgentRunner):
             ]}
         )
 
-        self._extract_and_record_usage(result)
+        usage_info = self._extract_and_record_usage(result)
         final = extract_final_content(result)
+
+        # Write SFT trace — full conversation for fine-tuning
+        self._write_sft_trace(result, usage_info)
+
         self._set_status(STATUS_IDLE)
         await self._publish("agent_done", {"role": self.role, "summary": final[:MAX_SUMMARY_LEN]})
         return final

--- a/src/onemancompany/core/claude_session.py
+++ b/src/onemancompany/core/claude_session.py
@@ -457,17 +457,16 @@ class ClaudeDaemon:
                         if isinstance(block.get("content"), str)
                         else json.dumps(block.get("content", ""), ensure_ascii=False),
                 })
-        # Build assistant entry
-        entry: dict = {"role": "assistant"}
-        if text_parts:
-            entry["content"] = "\n".join(text_parts)
-        elif not tool_calls:
-            entry["content"] = ""
-        if tool_calls:
-            entry["tool_calls"] = tool_calls
-            if "content" not in entry:
-                entry["content"] = ""
-        sft_messages.append(entry)
+        # Build assistant entry only if there's actual content or tool_calls
+        if text_parts or tool_calls:
+            entry: dict = {"role": "assistant"}
+            if text_parts:
+                entry["content"] = "\n".join(text_parts)
+            if tool_calls:
+                entry["tool_calls"] = tool_calls
+                if "content" not in entry:
+                    entry["content"] = ""
+            sft_messages.append(entry)
 
     def _write_sft_trace(
         self, sft_messages: list[dict], model: str,
@@ -475,14 +474,22 @@ class ClaudeDaemon:
     ) -> None:
         """Write a complete SFT record for one daemon turn."""
         try:
-            from onemancompany.core.llm_trace import write_sft_record
+            from onemancompany.core.llm_trace import write_sft_record_async
             from onemancompany.core.project_archive import get_project_dir
             project_dir = get_project_dir(self.project_id)
             if not project_dir:
                 return
-            write_sft_record(
+            # Resolve node_id from contextvar if available
+            _node_id = ""
+            try:
+                from onemancompany.core.vessel import _current_task_id
+                _node_id = _current_task_id.get("")
+            except Exception as _e:
+                logger.debug("[sft_trace] failed to resolve node_id: {}", _e)
+            write_sft_record_async(
                 project_dir,
                 employee_id=self.employee_id,
+                node_id=_node_id,
                 source="daemon",
                 messages=sft_messages,
                 model=model,

--- a/src/onemancompany/core/claude_session.py
+++ b/src/onemancompany/core/claude_session.py
@@ -427,6 +427,70 @@ class ClaudeDaemon:
                     "model": model,
                 })
 
+    @staticmethod
+    def _accumulate_sft_assistant(sft_messages: list[dict], message: dict) -> None:
+        """Parse a Claude daemon assistant message into SFT-format dicts."""
+        content_blocks = message.get("content", [])
+        text_parts = []
+        tool_calls = []
+        for block in content_blocks:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "")
+            if btype == "text":
+                text_parts.append(block.get("text", ""))
+            elif btype == "tool_use":
+                tool_calls.append({
+                    "id": block.get("id", ""),
+                    "type": "function",
+                    "function": {
+                        "name": block.get("name", ""),
+                        "arguments": json.dumps(block.get("input", {}), ensure_ascii=False),
+                    },
+                })
+            elif btype == "tool_result":
+                # Tool results come as separate messages in SFT format
+                sft_messages.append({
+                    "role": "tool",
+                    "tool_call_id": block.get("tool_use_id", ""),
+                    "content": block.get("content", "")
+                        if isinstance(block.get("content"), str)
+                        else json.dumps(block.get("content", ""), ensure_ascii=False),
+                })
+        # Build assistant entry
+        entry: dict = {"role": "assistant"}
+        if text_parts:
+            entry["content"] = "\n".join(text_parts)
+        elif not tool_calls:
+            entry["content"] = ""
+        if tool_calls:
+            entry["tool_calls"] = tool_calls
+            if "content" not in entry:
+                entry["content"] = ""
+        sft_messages.append(entry)
+
+    def _write_sft_trace(
+        self, sft_messages: list[dict], model: str,
+        input_tokens: int, output_tokens: int,
+    ) -> None:
+        """Write a complete SFT record for one daemon turn."""
+        try:
+            from onemancompany.core.llm_trace import write_sft_record
+            from onemancompany.core.project_archive import get_project_dir
+            project_dir = get_project_dir(self.project_id)
+            if not project_dir:
+                return
+            write_sft_record(
+                project_dir,
+                employee_id=self.employee_id,
+                source="daemon",
+                messages=sft_messages,
+                model=model,
+                usage={"input_tokens": input_tokens, "output_tokens": output_tokens},
+            )
+        except Exception as e:
+            logger.debug("[sft_trace] daemon write failed for {}: {}", self.employee_id, e)
+
     async def send_prompt(self, prompt: str, timeout: int = 600) -> dict:
         """Send a prompt and collect the full response.
 
@@ -459,6 +523,8 @@ class ClaudeDaemon:
         total_input_tokens = 0
         total_output_tokens = 0
         model_used = ""
+        # SFT trace: accumulate structured messages for this turn
+        sft_messages: list[dict] = [{"role": "user", "content": prompt}]
 
         try:
             async with asyncio.timeout(timeout):
@@ -508,6 +574,8 @@ class ClaudeDaemon:
                             total_output_tokens = max(total_output_tokens, usage["output_tokens"])
                         if message.get("model"):
                             model_used = message["model"]
+                        # SFT: capture assistant message with tool_calls
+                        self._accumulate_sft_assistant(sft_messages, message)
 
                     elif msg_type == "result":
                         # Final result — response complete
@@ -532,6 +600,11 @@ class ClaudeDaemon:
                                 "output_tokens": total_output_tokens,
                             },
                         })
+                        # Write SFT trace for this turn
+                        self._write_sft_trace(
+                            sft_messages, model_used,
+                            total_input_tokens, total_output_tokens,
+                        )
                         _mark_session_used(self.employee_id, self.project_id)
                         break
 

--- a/src/onemancompany/core/llm_trace.py
+++ b/src/onemancompany/core/llm_trace.py
@@ -1,16 +1,29 @@
 """LLM interaction trace logger.
 
-Appends one JSON line per interaction to {project_dir}/llm_trace.jsonl.
-Records prompts, responses, tool calls, and tool results for each TaskNode.
+Two trace formats:
+  1. Per-event JSONL (legacy LlmTracer) — one line per prompt/response/tool_call
+  2. SFT JSONL — one line per complete conversation, suitable for fine-tuning
+
+SFT records are written to {project_dir}/sft_trace.jsonl with full messages,
+tool schemas, model info, and token usage.
 """
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
+
+from loguru import logger
 
 from onemancompany.core.config import ENCODING_UTF8
 
+SFT_TRACE_FILENAME = "sft_trace.jsonl"
+
+
+# ---------------------------------------------------------------------------
+# Legacy per-event tracer (unchanged)
+# ---------------------------------------------------------------------------
 
 class LlmTracer:
     """Append-only JSONL logger for LLM interactions."""
@@ -48,3 +61,146 @@ class LlmTracer:
             "node_id": node_id, "employee_id": employee_id, "type": "tool_result",
             "content": result,
         })
+
+
+# ---------------------------------------------------------------------------
+# SFT trace — full conversation records for fine-tuning
+# ---------------------------------------------------------------------------
+
+def _serialize_message(msg) -> dict[str, Any]:
+    """Convert a LangChain message object to an SFT-compatible dict.
+
+    Handles SystemMessage, HumanMessage, AIMessage (with tool_calls),
+    and ToolMessage.
+    """
+    from langchain_core.messages import (
+        AIMessage, HumanMessage, SystemMessage, ToolMessage,
+    )
+
+    if isinstance(msg, SystemMessage):
+        return {"role": "system", "content": msg.content}
+    elif isinstance(msg, HumanMessage):
+        return {"role": "user", "content": msg.content}
+    elif isinstance(msg, AIMessage):
+        entry: dict[str, Any] = {"role": "assistant"}
+        # Content can be str or list of blocks
+        if isinstance(msg.content, str):
+            entry["content"] = msg.content
+        elif isinstance(msg.content, list):
+            # Multi-block content (text + tool_use mixed)
+            entry["content"] = msg.content
+        else:
+            entry["content"] = str(msg.content)
+        # Tool calls
+        tool_calls = getattr(msg, "tool_calls", None)
+        if tool_calls:
+            entry["tool_calls"] = [
+                {
+                    "id": tc.get("id", ""),
+                    "type": "function",
+                    "function": {
+                        "name": tc.get("name", ""),
+                        "arguments": json.dumps(tc.get("args", {}), ensure_ascii=False),
+                    },
+                }
+                for tc in tool_calls
+            ]
+        return entry
+    elif isinstance(msg, ToolMessage):
+        return {
+            "role": "tool",
+            "tool_call_id": getattr(msg, "tool_call_id", ""),
+            "content": msg.content if isinstance(msg.content, str) else str(msg.content),
+        }
+    else:
+        # Fallback for unknown message types
+        return {
+            "role": getattr(msg, "type", "unknown"),
+            "content": str(getattr(msg, "content", "")),
+        }
+
+
+def _serialize_tool_schema(tool) -> dict[str, Any]:
+    """Convert a LangChain StructuredTool to an OpenAI-compatible tool schema."""
+    schema = {}
+    if hasattr(tool, "args_schema") and tool.args_schema:
+        schema = tool.args_schema.model_json_schema()
+    return {
+        "type": "function",
+        "function": {
+            "name": getattr(tool, "name", ""),
+            "description": getattr(tool, "description", ""),
+            "parameters": schema,
+        },
+    }
+
+
+def write_sft_record(
+    project_dir: str,
+    *,
+    employee_id: str,
+    node_id: str = "",
+    source: str = "langchain",
+    messages: list | None = None,
+    tools: list | None = None,
+    model: str = "",
+    usage: dict | None = None,
+) -> None:
+    """Write one complete conversation as an SFT training record.
+
+    Args:
+        project_dir: Project workspace directory (sft_trace.jsonl lives here).
+        employee_id: The employee who ran this conversation.
+        node_id: Task node ID (for traceability).
+        source: "langchain" | "daemon" | "tracked_ainvoke".
+        messages: List of LangChain message objects or pre-serialized dicts.
+        tools: List of LangChain StructuredTool objects or pre-serialized dicts.
+        model: Model name/ID used.
+        usage: Token usage dict {input_tokens, output_tokens, ...}.
+    """
+    if not project_dir or not messages:
+        return
+
+    path = Path(project_dir) / SFT_TRACE_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Serialize messages
+    serialized_msgs = []
+    for msg in messages:
+        if isinstance(msg, dict):
+            serialized_msgs.append(msg)
+        elif isinstance(msg, str):
+            serialized_msgs.append({"role": "user", "content": msg})
+        else:
+            serialized_msgs.append(_serialize_message(msg))
+
+    # Serialize tools
+    serialized_tools = []
+    if tools:
+        for t in tools:
+            if isinstance(t, dict):
+                serialized_tools.append(t)
+            else:
+                try:
+                    serialized_tools.append(_serialize_tool_schema(t))
+                except Exception as e:
+                    logger.debug("[sft_trace] failed to serialize tool {}: {}", getattr(t, "name", "?"), e)
+
+    record: dict[str, Any] = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "employee_id": employee_id,
+        "node_id": node_id,
+        "source": source,
+        "model": model,
+        "messages": serialized_msgs,
+    }
+    if serialized_tools:
+        record["tools"] = serialized_tools
+    if usage:
+        record["usage"] = usage
+
+    try:
+        with path.open("a", encoding=ENCODING_UTF8) as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except OSError as e:
+        logger.debug("[sft_trace] write failed: {}", e)

--- a/src/onemancompany/core/llm_trace.py
+++ b/src/onemancompany/core/llm_trace.py
@@ -200,7 +200,27 @@ def write_sft_record(
         record["usage"] = usage
 
     try:
+        _line = json.dumps(record, ensure_ascii=False) + "\n"
         with path.open("a", encoding=ENCODING_UTF8) as f:
-            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+            f.write(_line)
     except OSError as e:
         logger.debug("[sft_trace] write failed: {}", e)
+
+
+def write_sft_record_async(
+    project_dir: str, **kwargs: Any,
+) -> None:
+    """Schedule write_sft_record in a background thread (non-blocking).
+
+    Safe to call from async contexts — avoids blocking the event loop
+    with synchronous file I/O and JSON serialization.
+    """
+    import asyncio
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop — fall back to sync write
+        write_sft_record(project_dir, **kwargs)
+        return
+    loop.run_in_executor(None, lambda: write_sft_record(project_dir, **kwargs))

--- a/tests/unit/core/test_sft_trace.py
+++ b/tests/unit/core/test_sft_trace.py
@@ -1,0 +1,322 @@
+"""Tests for SFT (Supervised Fine-Tuning) trace functionality."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from onemancompany.core.llm_trace import (
+    SFT_TRACE_FILENAME,
+    _serialize_message,
+    _serialize_tool_schema,
+    write_sft_record,
+)
+
+
+class TestSerializeMessage:
+    """Test _serialize_message for all LangChain message types."""
+
+    def test_system_message(self):
+        from langchain_core.messages import SystemMessage
+        msg = SystemMessage(content="You are a helpful assistant.")
+        result = _serialize_message(msg)
+        assert result == {"role": "system", "content": "You are a helpful assistant."}
+
+    def test_human_message(self):
+        from langchain_core.messages import HumanMessage
+        msg = HumanMessage(content="Hello world")
+        result = _serialize_message(msg)
+        assert result == {"role": "user", "content": "Hello world"}
+
+    def test_ai_message_text(self):
+        from langchain_core.messages import AIMessage
+        msg = AIMessage(content="I can help with that.")
+        result = _serialize_message(msg)
+        assert result["role"] == "assistant"
+        assert result["content"] == "I can help with that."
+        assert "tool_calls" not in result
+
+    def test_ai_message_with_tool_calls(self):
+        from langchain_core.messages import AIMessage
+        msg = AIMessage(
+            content="Let me check that.",
+            tool_calls=[
+                {"id": "tc_1", "name": "list_files", "args": {"path": "/workspace"}},
+            ],
+        )
+        result = _serialize_message(msg)
+        assert result["role"] == "assistant"
+        assert result["content"] == "Let me check that."
+        assert len(result["tool_calls"]) == 1
+        tc = result["tool_calls"][0]
+        assert tc["id"] == "tc_1"
+        assert tc["type"] == "function"
+        assert tc["function"]["name"] == "list_files"
+        assert json.loads(tc["function"]["arguments"]) == {"path": "/workspace"}
+
+    def test_ai_message_list_content(self):
+        from langchain_core.messages import AIMessage
+        msg = AIMessage(content=[
+            {"type": "text", "text": "Some text"},
+            {"type": "tool_use", "id": "tc_1", "name": "foo", "input": {}},
+        ])
+        result = _serialize_message(msg)
+        assert result["role"] == "assistant"
+        assert isinstance(result["content"], list)
+
+    def test_tool_message(self):
+        from langchain_core.messages import ToolMessage
+        msg = ToolMessage(content="File not found", tool_call_id="tc_1")
+        result = _serialize_message(msg)
+        assert result["role"] == "tool"
+        assert result["tool_call_id"] == "tc_1"
+        assert result["content"] == "File not found"
+
+    def test_unknown_message_type(self):
+        """Unknown message types should produce a fallback dict."""
+        class CustomMsg:
+            type = "custom"
+            content = "custom content"
+        result = _serialize_message(CustomMsg())
+        assert result["role"] == "custom"
+        assert result["content"] == "custom content"
+
+
+class TestSerializeToolSchema:
+    """Test _serialize_tool_schema for LangChain StructuredTool."""
+
+    def test_basic_tool(self):
+        tool = MagicMock()
+        tool.name = "read_file"
+        tool.description = "Read a file from disk"
+        tool.args_schema = None
+        result = _serialize_tool_schema(tool)
+        assert result["type"] == "function"
+        assert result["function"]["name"] == "read_file"
+        assert result["function"]["description"] == "Read a file from disk"
+        assert result["function"]["parameters"] == {}
+
+    def test_tool_with_schema(self):
+        from pydantic import BaseModel, Field
+
+        class ReadFileArgs(BaseModel):
+            path: str = Field(description="File path to read")
+
+        tool = MagicMock()
+        tool.name = "read_file"
+        tool.description = "Read a file"
+        tool.args_schema = ReadFileArgs
+        result = _serialize_tool_schema(tool)
+        params = result["function"]["parameters"]
+        assert "properties" in params
+        assert "path" in params["properties"]
+
+
+class TestWriteSftRecord:
+    """Test write_sft_record output format and behavior."""
+
+    def test_writes_jsonl(self, tmp_path):
+        from langchain_core.messages import SystemMessage, HumanMessage, AIMessage
+        messages = [
+            SystemMessage(content="You are a COO."),
+            HumanMessage(content="Plan the sprint"),
+            AIMessage(content="Here is the plan."),
+        ]
+        write_sft_record(
+            str(tmp_path),
+            employee_id="00003",
+            node_id="node_abc",
+            source="langchain",
+            messages=messages,
+            model="claude-sonnet-4-6",
+            usage={"input_tokens": 500, "output_tokens": 200},
+        )
+
+        sft_path = tmp_path / SFT_TRACE_FILENAME
+        assert sft_path.exists()
+
+        record = json.loads(sft_path.read_text().strip())
+        assert record["employee_id"] == "00003"
+        assert record["node_id"] == "node_abc"
+        assert record["source"] == "langchain"
+        assert record["model"] == "claude-sonnet-4-6"
+        assert len(record["messages"]) == 3
+        assert record["messages"][0]["role"] == "system"
+        assert record["messages"][1]["role"] == "user"
+        assert record["messages"][2]["role"] == "assistant"
+        assert record["usage"]["input_tokens"] == 500
+        assert "ts" in record
+
+    def test_with_tool_calls(self, tmp_path):
+        from langchain_core.messages import (
+            SystemMessage, HumanMessage, AIMessage, ToolMessage,
+        )
+        messages = [
+            SystemMessage(content="You are an agent."),
+            HumanMessage(content="List files"),
+            AIMessage(
+                content="",
+                tool_calls=[{"id": "tc_1", "name": "ls", "args": {"path": "/"}}],
+            ),
+            ToolMessage(content="file1.txt\nfile2.txt", tool_call_id="tc_1"),
+            AIMessage(content="Found 2 files."),
+        ]
+        write_sft_record(
+            str(tmp_path),
+            employee_id="00010",
+            source="langchain",
+            messages=messages,
+            model="test-model",
+        )
+
+        record = json.loads((tmp_path / SFT_TRACE_FILENAME).read_text().strip())
+        assert len(record["messages"]) == 5
+        # Check tool call format
+        ai_msg = record["messages"][2]
+        assert ai_msg["role"] == "assistant"
+        assert len(ai_msg["tool_calls"]) == 1
+        assert ai_msg["tool_calls"][0]["function"]["name"] == "ls"
+        # Check tool result
+        tool_msg = record["messages"][3]
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "tc_1"
+
+    def test_with_tools_schema(self, tmp_path):
+        from langchain_core.messages import HumanMessage, AIMessage
+        tool = MagicMock()
+        tool.name = "dispatch_child"
+        tool.description = "Dispatch a subtask"
+        tool.args_schema = None
+
+        write_sft_record(
+            str(tmp_path),
+            employee_id="00003",
+            source="langchain",
+            messages=[HumanMessage(content="Do something"), AIMessage(content="OK")],
+            tools=[tool],
+        )
+
+        record = json.loads((tmp_path / SFT_TRACE_FILENAME).read_text().strip())
+        assert "tools" in record
+        assert len(record["tools"]) == 1
+        assert record["tools"][0]["function"]["name"] == "dispatch_child"
+
+    def test_pre_serialized_dicts(self, tmp_path):
+        """Pre-serialized dict messages should pass through as-is."""
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there"},
+        ]
+        write_sft_record(
+            str(tmp_path),
+            employee_id="00003",
+            source="daemon",
+            messages=messages,
+        )
+
+        record = json.loads((tmp_path / SFT_TRACE_FILENAME).read_text().strip())
+        assert record["messages"][0] == {"role": "user", "content": "Hello"}
+
+    def test_string_message_converted(self, tmp_path):
+        """Plain string messages should be converted to user role."""
+        write_sft_record(
+            str(tmp_path),
+            employee_id="00003",
+            source="tracked_ainvoke",
+            messages=["What is 2+2?"],
+        )
+        record = json.loads((tmp_path / SFT_TRACE_FILENAME).read_text().strip())
+        assert record["messages"][0] == {"role": "user", "content": "What is 2+2?"}
+
+    def test_skips_empty_messages(self, tmp_path):
+        """Should not write if messages is empty or project_dir is empty."""
+        write_sft_record("", employee_id="00003", messages=[{"role": "user", "content": "hi"}])
+        write_sft_record(str(tmp_path), employee_id="00003", messages=[])
+        write_sft_record(str(tmp_path), employee_id="00003", messages=None)
+        assert not (tmp_path / SFT_TRACE_FILENAME).exists()
+
+    def test_appends_multiple_records(self, tmp_path):
+        from langchain_core.messages import HumanMessage, AIMessage
+        for i in range(3):
+            write_sft_record(
+                str(tmp_path),
+                employee_id="00003",
+                source="langchain",
+                messages=[HumanMessage(content=f"msg {i}"), AIMessage(content=f"resp {i}")],
+            )
+
+        lines = (tmp_path / SFT_TRACE_FILENAME).read_text().strip().split("\n")
+        assert len(lines) == 3
+        for i, line in enumerate(lines):
+            record = json.loads(line)
+            assert record["messages"][0]["content"] == f"msg {i}"
+
+    def test_no_tools_key_when_empty(self, tmp_path):
+        from langchain_core.messages import HumanMessage, AIMessage
+        write_sft_record(
+            str(tmp_path),
+            employee_id="00003",
+            source="langchain",
+            messages=[HumanMessage(content="hi"), AIMessage(content="hello")],
+        )
+        record = json.loads((tmp_path / SFT_TRACE_FILENAME).read_text().strip())
+        assert "tools" not in record
+
+
+class TestDaemonSftAccumulation:
+    """Test ClaudeDaemon._accumulate_sft_assistant."""
+
+    def test_text_only(self):
+        from onemancompany.core.claude_session import ClaudeDaemon
+        sft_messages = []
+        message = {
+            "content": [{"type": "text", "text": "Hello world"}],
+        }
+        ClaudeDaemon._accumulate_sft_assistant(sft_messages, message)
+        assert len(sft_messages) == 1
+        assert sft_messages[0]["role"] == "assistant"
+        assert sft_messages[0]["content"] == "Hello world"
+        assert "tool_calls" not in sft_messages[0]
+
+    def test_tool_use(self):
+        from onemancompany.core.claude_session import ClaudeDaemon
+        sft_messages = []
+        message = {
+            "content": [
+                {"type": "text", "text": "Let me check."},
+                {"type": "tool_use", "id": "tc_1", "name": "ls", "input": {"path": "/"}},
+            ],
+        }
+        ClaudeDaemon._accumulate_sft_assistant(sft_messages, message)
+        assert len(sft_messages) == 1
+        entry = sft_messages[0]
+        assert entry["role"] == "assistant"
+        assert entry["content"] == "Let me check."
+        assert len(entry["tool_calls"]) == 1
+        assert entry["tool_calls"][0]["function"]["name"] == "ls"
+
+    def test_tool_result(self):
+        from onemancompany.core.claude_session import ClaudeDaemon
+        sft_messages = []
+        message = {
+            "content": [
+                {"type": "tool_result", "tool_use_id": "tc_1", "content": "file.txt"},
+            ],
+        }
+        ClaudeDaemon._accumulate_sft_assistant(sft_messages, message)
+        # Tool result comes as a tool message, plus an empty assistant
+        tool_msgs = [m for m in sft_messages if m["role"] == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["tool_call_id"] == "tc_1"
+        assert tool_msgs[0]["content"] == "file.txt"
+
+    def test_empty_content(self):
+        from onemancompany.core.claude_session import ClaudeDaemon
+        sft_messages = []
+        message = {"content": []}
+        ClaudeDaemon._accumulate_sft_assistant(sft_messages, message)
+        assert len(sft_messages) == 1
+        assert sft_messages[0]["role"] == "assistant"
+        assert sft_messages[0]["content"] == ""

--- a/tests/unit/core/test_sft_trace.py
+++ b/tests/unit/core/test_sft_trace.py
@@ -12,6 +12,7 @@ from onemancompany.core.llm_trace import (
     _serialize_message,
     _serialize_tool_schema,
     write_sft_record,
+    write_sft_record_async,
 )
 
 
@@ -306,17 +307,52 @@ class TestDaemonSftAccumulation:
             ],
         }
         ClaudeDaemon._accumulate_sft_assistant(sft_messages, message)
-        # Tool result comes as a tool message, plus an empty assistant
-        tool_msgs = [m for m in sft_messages if m["role"] == "tool"]
-        assert len(tool_msgs) == 1
-        assert tool_msgs[0]["tool_call_id"] == "tc_1"
-        assert tool_msgs[0]["content"] == "file.txt"
+        # Tool result only — no spurious empty assistant entry
+        assert len(sft_messages) == 1
+        assert sft_messages[0]["role"] == "tool"
+        assert sft_messages[0]["tool_call_id"] == "tc_1"
+        assert sft_messages[0]["content"] == "file.txt"
 
     def test_empty_content(self):
         from onemancompany.core.claude_session import ClaudeDaemon
         sft_messages = []
         message = {"content": []}
         ClaudeDaemon._accumulate_sft_assistant(sft_messages, message)
-        assert len(sft_messages) == 1
-        assert sft_messages[0]["role"] == "assistant"
-        assert sft_messages[0]["content"] == ""
+        # Empty content — no entry appended
+        assert len(sft_messages) == 0
+
+
+class TestWriteSftRecordAsync:
+    """Test the non-blocking write_sft_record_async wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_async_write_produces_file(self, tmp_path):
+        """Async write should eventually produce the same JSONL output."""
+        import asyncio
+        write_sft_record_async(
+            str(tmp_path),
+            employee_id="00003",
+            source="langchain",
+            messages=[{"role": "user", "content": "hello"}],
+            model="test",
+        )
+        # Give the executor a moment to flush
+        await asyncio.sleep(0.1)
+        sft_path = tmp_path / SFT_TRACE_FILENAME
+        assert sft_path.exists()
+        record = json.loads(sft_path.read_text().strip())
+        assert record["employee_id"] == "00003"
+        assert record["messages"][0]["content"] == "hello"
+
+    def test_sync_fallback_no_loop(self, tmp_path):
+        """Without a running event loop, falls back to synchronous write."""
+        write_sft_record_async(
+            str(tmp_path),
+            employee_id="00003",
+            source="langchain",
+            messages=[{"role": "user", "content": "sync fallback"}],
+        )
+        sft_path = tmp_path / SFT_TRACE_FILENAME
+        assert sft_path.exists()
+        record = json.loads(sft_path.read_text().strip())
+        assert record["messages"][0]["content"] == "sync fallback"


### PR DESCRIPTION
## Summary
- Add complete conversation trace in OpenAI-compatible JSONL format (`sft_trace.jsonl`) for SFT training
- Captures system prompt, all messages (user/assistant/tool), tool call arguments/results, tool schemas, model info, and token usage
- Instruments all three LLM call paths: LangChain agent (`run`/`run_streamed`), `tracked_ainvoke` (direct LLM), and Claude daemon subprocess
- New `write_sft_record()` + `_serialize_message()` + `_serialize_tool_schema()` in `llm_trace.py`
- 21 new tests covering serialization, output format, and daemon message accumulation

## Test plan
- [x] 21 new tests in `test_sft_trace.py` — all pass
- [x] All 2052 existing tests pass
- [ ] Manual verification: run a project task and check `sft_trace.jsonl` contains complete conversation with system prompt, tool schemas, and all message turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)