### PR TITLE
fix: review dispatch, EA approval button, CEO inbox content

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2234,7 +2234,7 @@ class AppController {
       }));
       // Prepend description as initial agent message if no messages exist yet
       if (data.description && messages.length === 0) {
-        messages.unshift({ role: nickname, content: data.description, sender: 'employee' });
+        messages.unshift({ role: nickname, text: data.description, sender: 'employee' });
       }
       this._chatPanel.renderMessages(messages);
       this._chatPanel.setInputEnabled(true);

--- a/frontend/conversation.js
+++ b/frontend/conversation.js
@@ -24,10 +24,6 @@ class ChatPanel {
                 <div class="chat-panel-header">
                     <span class="chat-panel-type"></span>
                     <span class="chat-panel-employee"></span>
-                    <label class="chat-panel-ea-toggle hidden" title="EA auto-reply if CEO doesn't respond in 60s">
-                        <input type="checkbox" class="chat-panel-ea-checkbox" />
-                        <span class="chat-panel-ea-label">EA</span>
-                    </label>
                     <button class="chat-panel-clear-btn">Clear</button>
                     <button class="chat-panel-close-btn">End</button>
                 </div>
@@ -37,6 +33,10 @@ class ChatPanel {
                     <span class="chat-panel-typing-dot">.</span>
                     <span class="chat-panel-typing-dot">.</span>
                 </div>
+                <label class="chat-panel-ea-toggle hidden" title="EA auto-reply if CEO doesn't respond in 60s">
+                    <input type="checkbox" class="chat-panel-ea-checkbox" />
+                    <span class="chat-panel-ea-label">EA auto-reply</span>
+                </label>
                 <div class="chat-panel-input-row">
                     <textarea class="chat-panel-input" rows="2" placeholder="Type a message..."></textarea>
                     <div class="chat-panel-actions">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5057,8 +5057,9 @@ body {
 }
 .chat-panel-employee { flex: 1; }
 .chat-panel-ea-toggle {
-    display: flex; align-items: center; gap: 2px; cursor: pointer;
+    display: flex; align-items: center; gap: 4px; cursor: pointer;
     font-size: 6px; font-family: 'Press Start 2P', monospace; color: var(--text-dim);
+    padding: 2px 4px; border-top: 1px solid #344;
 }
 .chat-panel-ea-toggle:hover { color: var(--pixel-green); }
 .chat-panel-ea-checkbox { width: 10px; height: 10px; cursor: pointer; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.533",
+  "version": "0.2.534",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.533"
+version = "0.2.534"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2048,9 +2048,21 @@ class EmployeeManager:
         else:
             lines.append("All subtasks have passed review.")
 
+        # Show active sibling tasks so reviewer doesn't dispatch duplicates
+        active_siblings = [
+            c for c in children
+            if c.node_type not in _SKIP_REVIEW_TYPES
+            and c.status in (TaskPhase.PENDING.value, TaskPhase.PROCESSING.value, TaskPhase.HOLDING.value)
+        ]
+        if active_siblings:
+            lines.append("The following sibling tasks are currently in progress (DO NOT dispatch duplicates):")
+            for sib in active_siblings:
+                lines.append(f"  ⏳ ({sib.employee_id}): {sib.description_preview[:80]} [status={sib.status}]")
+            lines.append("")
+
         lines.append("Please call accept_child(node_id, notes) or reject_child(node_id, reason) for unreviewed subtasks.")
         lines.append("IMPORTANT: Each subtask can only be accepted OR rejected ONCE. Once accepted, it CANNOT be rejected later. Review carefully before deciding.")
-        lines.append("If additional tasks are needed, call dispatch_child().")
+        lines.append("IMPORTANT: Do NOT call dispatch_child() to create new tasks during review. Your job is ONLY to review and accept/reject existing subtasks.")
         lines.append("Once all are handled, your task will auto-complete and report upward.")
 
         review_prompt = "\n".join(lines)


### PR DESCRIPTION
## Summary
- **Review node dispatch bug**: COO was spawning duplicate tasks during REVIEW because the prompt said "If additional tasks are needed, call dispatch_child()". Changed to explicitly forbid dispatching during review, and added active sibling task awareness so reviewer sees what's already running.
- **EA approval button unreachable**: Toggle was in chat header (hidden in 1-on-1 context). Moved to above CEO input box where it's always visible and clickable for inbox conversations.
- **CEO inbox empty content**: Clicking inbox item showed employee name but no message content. Field name mismatch: used `content` instead of `text` that ChatPanel expects.

## Test plan
- [x] All 2058 unit tests pass
- [ ] Manual: open CEO inbox item → description text should now display
- [ ] Manual: open CEO inbox → EA auto-reply toggle visible above input box
- [ ] Manual: verify review nodes no longer dispatch new tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)