### PR TITLE
fix: move EA auto-reply toggle to CEO Inbox sidebar header

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -925,6 +925,21 @@ class AppController {
       if (el) el.addEventListener('change', () => this._onRosterFilterChange());
     });
 
+    // EA auto-reply toggle in CEO Inbox header
+    const eaToggleEl = document.getElementById('ea-autoreply-toggle');
+    const eaCheckbox = document.getElementById('ea-autoreply-checkbox');
+    if (eaToggleEl) {
+      // Prevent collapsible header click from toggling when clicking the EA toggle
+      eaToggleEl.addEventListener('click', (e) => e.stopPropagation());
+    }
+    if (eaCheckbox) {
+      eaCheckbox.addEventListener('change', () => {
+        if (this._currentConvNodeId) {
+          this._toggleEaAutoReply(this._currentConvNodeId, eaCheckbox.checked);
+        }
+      });
+    }
+
     // 1-on-1 meeting modal bindings
     const oneononeModal = document.getElementById('oneonone-modal');
     document.getElementById('guidance-toolbar-btn').addEventListener('click', () => {
@@ -2223,7 +2238,11 @@ class AppController {
       this._chatPanel.onSend((id, text) => this._sendCeoInboxMessage(id, text));
       this._chatPanel.onClear(null);
       this._chatPanel.onClose((id) => this._completeCeoConversation(id));
-      this._chatPanel.onEaToggle((id, enabled) => this._toggleEaAutoReply(id, enabled));
+      // Show and reset EA auto-reply toggle in sidebar header
+      const eaToggle = document.getElementById('ea-autoreply-toggle');
+      const eaCb = document.getElementById('ea-autoreply-checkbox');
+      if (eaToggle) eaToggle.classList.remove('hidden');
+      if (eaCb) eaCb.checked = false;
 
       const nickname = data.employee_nickname || data.employee_id || 'Employee';
       this._chatPanel.setConversation(nodeId, 'ceo_inbox', nickname);
@@ -2271,6 +2290,9 @@ class AppController {
     // Restore right panel
     const chatContainer = document.getElementById('right-panel-chat');
     chatContainer.classList.add('hidden');
+    // Hide EA auto-reply toggle
+    const eaToggle = document.getElementById('ea-autoreply-toggle');
+    if (eaToggle) eaToggle.classList.add('hidden');
     this._restoreConsoleSections();
     this._chatPanel = null;
     this._currentConvNodeId = null;
@@ -5768,6 +5790,9 @@ class AppController {
       const header = body?.previousElementSibling;
       if (header?.classList.contains('collapsible-header')) header.style.display = '';
     }
+    // Hide EA auto-reply toggle when returning to inbox list
+    const eaToggle = document.getElementById('ea-autoreply-toggle');
+    if (eaToggle) eaToggle.classList.add('hidden');
   }
 
 

--- a/frontend/conversation.js
+++ b/frontend/conversation.js
@@ -33,10 +33,6 @@ class ChatPanel {
                     <span class="chat-panel-typing-dot">.</span>
                     <span class="chat-panel-typing-dot">.</span>
                 </div>
-                <label class="chat-panel-ea-toggle hidden" title="EA auto-reply if CEO doesn't respond in 60s">
-                    <input type="checkbox" class="chat-panel-ea-checkbox" />
-                    <span class="chat-panel-ea-label">EA auto-reply</span>
-                </label>
                 <div class="chat-panel-input-row">
                     <textarea class="chat-panel-input" rows="2" placeholder="Type a message..."></textarea>
                     <div class="chat-panel-actions">
@@ -56,14 +52,7 @@ class ChatPanel {
         this._closeBtn = this._container.querySelector('.chat-panel-close-btn');
         this._typingEl = this._container.querySelector('.chat-panel-typing');
         this._fileInput = this._container.querySelector('.chat-panel-file');
-        this._eaToggle = this._container.querySelector('.chat-panel-ea-toggle');
-        this._eaCheckbox = this._container.querySelector('.chat-panel-ea-checkbox');
-        this._onEaToggleCb = null;
-
         this._sendBtn.addEventListener('click', () => this._handleSend());
-        this._eaCheckbox.addEventListener('change', () => {
-            if (this._onEaToggleCb) this._onEaToggleCb(this._convId, this._eaCheckbox.checked);
-        });
         this._clearBtn.addEventListener('click', () => {
             if (this._onClearCb) this._onClearCb(this._convId);
         });
@@ -112,12 +101,7 @@ class ChatPanel {
         this._container.querySelector('.chat-panel-employee').textContent = employeeName;
         this._clearBtn.style.display = convType === 'oneonone' ? '' : 'none';
         this._closeBtn.textContent = convType === 'ceo_inbox' ? 'Complete' : 'End';
-        // Show EA auto-reply toggle only for CEO inbox conversations
-        this._eaToggle.classList.toggle('hidden', convType !== 'ceo_inbox');
-        this._eaCheckbox.checked = false;
     }
-
-    onEaToggle(cb) { this._onEaToggleCb = cb; }
 
     renderMessages(messages) {
         this._messagesEl.innerHTML = '';

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -111,6 +111,10 @@
       <div class="collapsible-header" data-target="ceo-inbox-body">
         <span class="collapse-arrow">&#9660;</span>
         <h3 class="pixel-title">&#128229; CEO INBOX <span id="ceo-inbox-badge" class="inbox-badge hidden">0</span></h3>
+        <label id="ea-autoreply-toggle" class="ea-autoreply-sidebar hidden" title="EA auto-reply if CEO doesn't respond in 60s">
+          <input type="checkbox" id="ea-autoreply-checkbox" />
+          <span>EA auto</span>
+        </label>
       </div>
       <div id="ceo-inbox-body" class="collapsible-body">
         <div id="ceo-inbox-list">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5056,14 +5056,16 @@ body {
     padding: 1px 4px; font-weight: bold;
 }
 .chat-panel-employee { flex: 1; }
-.chat-panel-ea-toggle {
+/* EA auto-reply toggle in CEO Inbox header */
+.ea-autoreply-sidebar {
     display: flex; align-items: center; gap: 4px; cursor: pointer;
     font-size: 6px; font-family: 'Press Start 2P', monospace; color: var(--text-dim);
-    padding: 2px 4px; border-top: 1px solid #344;
+    margin-left: auto; padding: 2px 6px;
+    border: 1px solid #344; border-radius: 3px; background: rgba(0,0,0,0.2);
 }
-.chat-panel-ea-toggle:hover { color: var(--pixel-green); }
-.chat-panel-ea-checkbox { width: 10px; height: 10px; cursor: pointer; }
-.chat-panel-ea-checkbox:checked + .chat-panel-ea-label { color: var(--pixel-green); }
+.ea-autoreply-sidebar:hover { color: var(--pixel-green); border-color: var(--pixel-green); }
+.ea-autoreply-sidebar input[type="checkbox"] { width: 10px; height: 10px; cursor: pointer; }
+.ea-autoreply-sidebar input[type="checkbox"]:checked + span { color: var(--pixel-green); }
 .chat-panel-clear-btn {
     font-size: 7px; font-family: 'Press Start 2P', monospace; cursor: pointer;
     background: #355; color: #fff; border: 1px solid #688; padding: 1px 6px;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.545",
+  "version": "0.2.546",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.545"
+version = "0.2.546"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- EA auto-reply toggle moved from inside the chat panel (conversation.js) to the CEO Inbox collapsible header in the right sidebar
- Toggle now appears next to "CEO INBOX" title when a conversation is open, hidden otherwise
- Prevents collapsible header toggle when clicking the checkbox (stopPropagation)

## Test plan
- [ ] Open a CEO inbox conversation — EA auto toggle should appear next to "CEO INBOX" title
- [ ] Toggle checkbox — should call `/api/ceo/inbox/{id}/ea-auto-reply`
- [ ] Click checkbox area — inbox section should NOT collapse/expand
- [ ] Complete/close conversation — toggle should disappear
- [ ] Open a 1-on-1 — toggle should NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)