### PR TITLE
fix: missing STATUS_WORKING import crashes /api/employees

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.556",
+  "version": "0.2.557",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.556"
+version = "0.2.557"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -32,6 +32,7 @@ from onemancompany.core.config import (
     PF_NICKNAME,
     PF_SPRITE,
     STATUS_IDLE,
+    STATUS_WORKING,
     SYSTEM_AGENT,
     SYSTEM_SENDER,
     TASK_TREE_FILENAME,


### PR DESCRIPTION
## Summary
- `/api/employees` endpoint crashed with `NameError: name 'STATUS_WORKING' is not defined`
- Added missing import from `onemancompany.core.config`

## Root cause
PR #91 added employee status reconciliation using `STATUS_WORKING` but forgot to import it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)