### PR TITLE
fix: talent无CLAUDE.md时自动生成，self-hosted员工能看到自己profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.564",
+  "version": "0.2.565",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.564"
+version = "0.2.565"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -755,11 +755,29 @@ def copy_talent_assets(talent_dir: Path, emp_dir) -> None:
                     dst_persona.write_text(spt.strip() + "\n", encoding=ENCODING_UTF8)
 
     # Copy CLAUDE.md for Claude CLI discovery
+    dst_claude_md = emp_dir / CLAUDE_MD_FILENAME
     talent_claude_md = talent_dir / CLAUDE_MD_FILENAME
     if talent_claude_md.exists():
-        dst_claude_md = emp_dir / CLAUDE_MD_FILENAME
         if not dst_claude_md.exists():
             shutil.copy2(str(talent_claude_md), str(dst_claude_md))
+
+    # Generate CLAUDE.md if talent didn't provide one (self-hosted employees need it)
+    if not dst_claude_md.exists():
+        from onemancompany.core.config import EMPLOYEES_DIR as _EMP_DIR
+        emp_id = emp_dir.name
+        profile_path = _EMP_DIR / emp_id / "profile.yaml"
+        claude_md_content = (
+            f"# Employee {emp_id}\n\n"
+            f"You are an employee of One Man Company.\n"
+            f"Your profile is at: {profile_path}\n"
+            f"Your employee directory is: {emp_dir}\n\n"
+            f"## Important\n"
+            f"- All company data is stored on the filesystem. There is no database.\n"
+            f"- Read your task description carefully — it contains your role, context, and acceptance criteria.\n"
+            f"- Save all outputs to the project workspace path specified in your task.\n"
+            f"- Do NOT loop or re-analyze. Produce output, verify once, then finish.\n"
+        )
+        dst_claude_md.write_text(claude_md_content, encoding=ENCODING_UTF8)
 
     # Copy manifest.json (frontend UI config — OAuth buttons, settings sections)
     talent_manifest_json = talent_dir / MANIFEST_FILENAME


### PR DESCRIPTION
## Summary
- Self-hosted 员工（Claude CLI）cwd 在 employee 目录，依赖 CLAUDE.md 获取系统上下文
- 如果 talent repo 没有提供 CLAUDE.md（如 Superpowers），员工完全不知道自己是谁
- 现在 onboarding 时如果 talent 没有 CLAUDE.md，自动生成包含 employee ID、profile 路径、基本行为准则的 CLAUDE.md

## Test plan
- [x] 全量单元测试通过 (2080 passed)
- [ ] 验证新招聘的 self-hosted 员工能看到自己的 profile 信息

🤖 Generated with [Claude Code](https://claude.com/claude-code)