### PR TITLE
fix: Talent Market SSE断开后自动重连

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.567",
+  "version": "0.2.568",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.567"
+version = "0.2.568"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/recruitment.py
+++ b/src/onemancompany/agents/recruitment.py
@@ -310,6 +310,7 @@ class TalentMarketClient:
         self._session: ClientSession | None = None
         self._stack: AsyncExitStack | None = None
         self._api_key: str = ""
+        self._url: str = ""
 
     async def connect(self, url: str, api_key: str) -> None:
         """Establish an SSE connection to the Talent Market MCP server."""
@@ -325,6 +326,7 @@ class TalentMarketClient:
         self._session = session
         self._stack = stack
         self._api_key = api_key
+        self._url = url
         logger.info("Connected to Talent Market at {}", url)
 
     async def disconnect(self) -> None:
@@ -344,14 +346,21 @@ class TalentMarketClient:
         """Return True if an active session exists."""
         return self._session is not None
 
-    async def _call(self, tool_name: str, **kwargs) -> dict:
-        """Invoke an MCP tool, auto-injecting the API key."""
+    async def _call(self, tool_name: str, _retry: bool = True, **kwargs) -> dict:
+        """Invoke an MCP tool, auto-injecting the API key. Auto-reconnects on connection error."""
         if not self._session:
             raise RuntimeError("Not connected to Talent Market")
         kwargs["api_key"] = self._api_key
         logger.debug("[TalentMarket] calling tool={} args={}", tool_name,
                      {k: v[:30] + "..." if isinstance(v, str) and len(v) > 30 else v for k, v in kwargs.items() if k != "api_key"})
-        result = await self._session.call_tool(tool_name, arguments=kwargs)
+        try:
+            result = await self._session.call_tool(tool_name, arguments=kwargs)
+        except Exception as e:
+            if not _retry:
+                raise
+            logger.warning("[TalentMarket] call failed ({}), reconnecting and retrying...", e)
+            await self._reconnect()
+            return await self._call(tool_name, _retry=False, **kwargs)
         logger.debug("[TalentMarket] result content blocks: {}", len(result.content))
         for item in result.content:
             try:
@@ -364,6 +373,19 @@ class TalentMarketClient:
         logger.warning("[TalentMarket] No dict found in response, raw content: {}",
                       [getattr(item, 'text', '')[:200] for item in result.content])
         return {}
+
+    async def _reconnect(self) -> None:
+        """Tear down stale connection and reconnect."""
+        url = self._url
+        api_key = self._api_key
+        try:
+            await self.disconnect()
+        except Exception:
+            self._session = None
+            self._stack = None
+        if url and api_key:
+            await self.connect(url, api_key)
+            logger.info("[TalentMarket] auto-reconnected")
 
     async def search(self, job_description: str) -> dict:
         """Search for candidates matching a job description."""

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -261,13 +261,7 @@ async def talent_market_keepalive() -> list | None:
     except Exception as e:
         logger.warning("[talent_market_keepalive] ping failed ({}), reconnecting...", e)
         try:
-            await talent_market.disconnect()
-        except Exception:
-            # Force-clear stale state even if disconnect fails
-            talent_market._session = None
-            talent_market._stack = None
-        try:
-            await start_talent_market()
+            await talent_market._reconnect()
             logger.info("[talent_market_keepalive] reconnected successfully")
         except Exception as e2:
             logger.error("[talent_market_keepalive] reconnect failed: {}", e2)


### PR DESCRIPTION
## Summary
Talent Market MCP SSE 连接被远端关闭时（`peer closed connection without sending complete message body`），
`_session` 仍非 None，keepalive ping 可能成功但实际 tool call 会失败。

## Fix
- `_call()` 捕获连接错误，自动 `_reconnect()` 后重试一次
- 新增 `_reconnect()` 方法，保存 `_url` 用于重连
- keepalive 失败时也走 `_reconnect()`（去掉重复的 disconnect + start 逻辑）

## Test plan
- [x] 全量单元测试通过 (2080 passed)
- [ ] 验证 SSE 断开后下次 search_candidates 调用自动重连成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)