### PR TITLE
fix: 启动时自动confirm卡在pending_confirmation的项目

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.567",
+  "version": "0.2.568",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.567"
+version = "0.2.568"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/main.py
+++ b/src/onemancompany/main.py
@@ -553,6 +553,24 @@ async def lifespan(app: FastAPI):
         print(f"[startup] Restored {restored_count} task(s) from disk — auto-resuming")
         _em.drain_pending()
 
+    # Recover projects stuck in pending_confirmation (auto-confirm timer lost on restart)
+    from onemancompany.core.project_archive import (
+        list_projects,
+        ITER_STATUS_PENDING_CONFIRMATION,
+        ITER_STATUS_COMPLETED,
+        load_iteration,
+        update_project_status,
+    )
+    for _proj in list_projects():
+        _iters = _proj.get("iterations", [])
+        if not _iters:
+            continue
+        _latest = load_iteration(_proj.get("project_id", "").split("/")[0], _iters[-1])
+        if _latest and _latest.get("status") == ITER_STATUS_PENDING_CONFIRMATION:
+            _pid = _proj.get("project_id", "")
+            update_project_status(f"{_pid}/{_iters[-1]}" if "/" not in _pid else _pid, ITER_STATUS_COMPLETED)
+            print(f"[startup] Auto-confirmed pending project: {_pid}")
+
     # Start background WebSocket event broadcaster
     broadcaster_task = asyncio.create_task(ws_manager.event_broadcaster())
 


### PR DESCRIPTION
## Summary
- `_pending_ceo_reports` 是内存字典，服务器重启后 auto-confirm timer 丢失
- 项目永远卡在 `pending_confirmation`（前端显示黄色）
- 现在 lifespan 启动时扫描所有 `pending_confirmation` 的项目，自动 confirm 为 `completed`

## Test plan
- [x] 全量单元测试通过 (2080 passed)
- [ ] 验证重启后 pending_confirmation 项目自动变为 completed（绿色）

🤖 Generated with [Claude Code](https://claude.com/claude-code)