### PR TITLE
fix: EA auto-reply不再需要CEO手动点开inbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.567",
+  "version": "0.2.568",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.567"
+version = "0.2.568"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -352,6 +352,15 @@ def dispatch_child(
             main_loop = getattr(employee_manager, "_event_loop", None)
             if main_loop and main_loop.is_running():
                 asyncio.run_coroutine_threadsafe(coro, main_loop)
+                # Auto-open conversation so EA auto-reply works without CEO clicking
+                async def _auto_open_inbox(nid: str):
+                    try:
+                        from onemancompany.api.routes import open_ceo_conversation
+                        await open_ceo_conversation(nid)
+                        logger.info("[dispatch_child] Auto-opened CEO inbox conversation for {}", nid)
+                    except Exception as _e:
+                        logger.debug("[dispatch_child] Auto-open inbox failed for {}: {}", nid, _e)
+                asyncio.run_coroutine_threadsafe(_auto_open_inbox(child.id), main_loop)
             else:
                 logger.warning("No event loop for ceo_inbox_updated publish")
             return {

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -5546,7 +5546,7 @@ async def open_ceo_conversation(node_id: str):
     emp = _load_emp(employee_id) if employee_id else None
     nickname = emp.get("nickname", emp.get("name", "")) if emp else ""
 
-    # Create session
+    # Create session with EA auto-reply enabled by default
     session = ConversationSession(
         node_id=node_id,
         employee_id=employee_id,
@@ -5554,6 +5554,8 @@ async def open_ceo_conversation(node_id: str):
         broadcast_fn=ws_manager.broadcast,
     )
     register_session(session)
+    # Auto-enable EA auto-reply so CEO doesn't need to manually toggle it
+    session.set_ea_auto_reply(True, node.description or node.description_preview or "")
 
     # Start conversation loop as background task
     spawn_background(_run_conversation_loop(session, node, tree, project_dir))


### PR DESCRIPTION
## Summary
- 之前 CEO_REQUEST 创建后，必须 CEO 点开 inbox 消息才会创建 conversation session，EA auto-reply 才能启动
- 现在 dispatch_child 创建 CEO_REQUEST 时自动 open conversation session
- Session 创建时默认启用 EA auto-reply（60s 超时自动回复）
- CEO 不点开也会自动处理

## Changes
1. `tree_tools.py`: CEO_REQUEST 创建后自动调用 `open_ceo_conversation` 
2. `routes.py`: session 创建时默认 `set_ea_auto_reply(True, description)`

## Test plan
- [x] 全量单元测试通过 (2080 passed)
- [ ] 验证 CEO_REQUEST 创建后 60s 内 EA 自动回复（不需要 CEO 点开）

🤖 Generated with [Claude Code](https://claude.com/claude-code)