### PR TITLE
fix: LLM单次请求5分钟超时，避免hang住

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.568",
+  "version": "0.2.569",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.568"
+version = "0.2.569"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -184,6 +184,7 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
                 api_key=effective_key,
                 temperature=effective_temp,
                 max_retries=3,
+                timeout=300.0,
                 default_headers=extra_headers or None,
             )
 
@@ -201,6 +202,7 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
                 base_url=base_url,
                 temperature=effective_temp,
                 max_retries=3,
+                request_timeout=300.0,
                 stream_usage=True,
             )
 
@@ -219,6 +221,7 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
         base_url=settings.openrouter_base_url,
         temperature=effective_temp,
         max_retries=3,
+        request_timeout=300.0,
         stream_usage=True,
     )
 

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1274,7 +1274,7 @@ class EmployeeManager:
                     self._log_node(employee_id, entry.node_id, "error", f"Agent hit recursion limit: {rec_err!s}")
                     break
                 except TimeoutError:
-                    raise  # Don't retry — let outer except TimeoutError handle it
+                    raise  # Don't retry task-level timeout — LLM request_timeout handles per-call retries
                 except Exception as run_err:
                     last_err = run_err
                     if attempt < max_retries - 1:


### PR DESCRIPTION
## Summary
- `ChatOpenAI` / `ChatAnthropic` 没有设置 `request_timeout`，LLM API hang 住后要等整个 task timeout（3600s）
- 现在所有 LLM 客户端设置 `request_timeout=300s`（5分钟）
- LangChain 内置 `max_retries=3` 会自动重试超时的单次请求

## Test plan
- [x] 全量单元测试通过 (2080 passed)
- [ ] 验证 LLM hang 时 5 分钟后自动超时重试

🤖 Generated with [Claude Code](https://claude.com/claude-code)