### PR TITLE
fix: system node不再进入HOLDING，避免任务链断裂

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.570",
+  "version": "0.2.571",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.570"
+version = "0.2.571"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1371,7 +1371,8 @@ class EmployeeManager:
                     f"Tool-requested HOLDING: {node.hold_reason}",
                 )
 
-            if holding_meta is not None:
+            # System nodes (REVIEW, WATCHDOG_NUDGE) never HOLD — always auto-finish
+            if holding_meta is not None and node.node_type not in SYSTEM_NODE_TYPES:
                 logger.debug("[TASK LIFECYCLE] employee={} node={} → HOLDING meta={}",
                              employee_id, entry.node_id, holding_meta)
                 node.set_status(TaskPhase.HOLDING)


### PR DESCRIPTION
## Summary
WATCHDOG_NUDGE/REVIEW 等 system node 执行时，如果 agent dispatch 了子任务并输出 `__HOLDING:`，
节点会进入 HOLDING 而非 auto-FINISHED。导致：
- system node 卡在 HOLDING，`_on_child_complete` 不触发
- parent 永远卡在 processing/awaiting_children
- 整个任务链断裂

## Root cause
`_execute_task` 中 HOLDING 检查在 system node auto-finish 检查之前：
```python
if holding_meta is not None:    # ← system node 也走这里
    node.set_status(HOLDING)    # ← 卡住
else:
    if node_type in SYSTEM_NODE_TYPES:
        node.set_status(FINISHED)  # ← 永远不到
```

## Fix
System node 跳过 HOLDING：`if holding_meta is not None and node.node_type not in SYSTEM_NODE_TYPES`

## Test plan
- [x] 全量单元测试通过 (2080 passed)
- [ ] 验证 WATCHDOG_NUDGE dispatch 子任务后正常 auto-finish

🤖 Generated with [Claude Code](https://claude.com/claude-code)