### PR TITLE
feat: archive自动cancel任务 + 看门狗跳过archived项目

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.570",
+  "version": "0.2.571",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.570"
+version = "0.2.571"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -2494,13 +2494,24 @@ async def get_named_project_detail(project_id: str) -> dict:
 
 @router.post("/api/projects/{project_id}/archive")
 async def archive_project_endpoint(project_id: str) -> dict:
-    """Archive a named project."""
+    """Archive a named project — cancels all running tasks first."""
     from onemancompany.core.project_archive import archive_project, load_named_project
     proj = load_named_project(project_id)
     if not proj:
         return {"error": "Named project not found"}
+
+    # Cancel all running/pending tasks for all iterations of this project
+    from onemancompany.core.agent_loop import employee_manager
+    iterations = proj.get("iterations", [])
+    total_cancelled = 0
+    for iter_id in iterations:
+        full_pid = f"{project_id}/{iter_id}"
+        total_cancelled += employee_manager.abort_project(full_pid)
+
     archive_project(project_id)
-    return {"status": "archived", "project_id": project_id}
+    logger.info("[archive] Archived project {} — cancelled {} task(s)", project_id, total_cancelled)
+    await event_bus.publish(CompanyEvent(type=EventType.STATE_SNAPSHOT, payload={}, agent=SYSTEM_AGENT))
+    return {"status": "archived", "project_id": project_id, "tasks_cancelled": total_cancelled}
 
 
 @router.patch("/api/projects/{project_id}/name")

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -310,6 +310,13 @@ async def project_progress_watchdog() -> list | None:
         if not project_id:
             continue
 
+        # Skip archived projects
+        from onemancompany.core.project_archive import load_named_project, PROJECT_STATUS_ARCHIVED
+        named_pid = project_id.split("/")[0] if "/" in project_id else project_id
+        named_proj = load_named_project(named_pid)
+        if named_proj and named_proj.get("status") == PROJECT_STATUS_ARCHIVED:
+            continue
+
         # Skip projects we've already nudged (waiting for EA to pick it up)
         if project_id in _watchdog_nudged:
             continue


### PR DESCRIPTION
## Summary
1. **Archive 自动 cancel**: archive endpoint 先调 `abort_project()` cancel 所有 running/pending 任务，再标记 archived
2. **看门狗跳过 archived**: `project_progress_watchdog` 检查 project.yaml status，archived 的项目不再 nudge EA

## Test plan
- [x] 全量单元测试通过 (2080 passed)
- [ ] 验证 archive 后所有任务被 cancel
- [ ] 验证 archived 项目不再触发看门狗 nudge

🤖 Generated with [Claude Code](https://claude.com/claude-code)