### PR TITLE
fix: CEO_PROMPT根节点confirm后推进到FINISHED

### DIFF
--- a/src/onemancompany/core/task_tree.py
+++ b/src/onemancompany/core/task_tree.py
@@ -174,7 +174,7 @@ class TaskNode:
             "employee_id": self.employee_id,
             "description_preview": self._description_preview,
             "acceptance_criteria": list(self.acceptance_criteria),
-            "node_type": str(self.node_type),
+            "node_type": self.node_type.value if hasattr(self.node_type, 'value') else str(self.node_type),
             "model_used": self.model_used,
             "project_dir": self.project_dir,
             "status": self.status,
@@ -207,6 +207,11 @@ class TaskNode:
         filtered = {k: v for k, v in d.items() if k in cls.__dataclass_fields__ and k not in _skip}
         if "status" in filtered:
             filtered["status"] = _STATUS_MIGRATION.get(filtered["status"], filtered["status"])
+        # Migrate "NodeType.XXX" → "xxx" (old bug serialized enum repr instead of value)
+        if "node_type" in filtered:
+            nt = filtered["node_type"]
+            if isinstance(nt, str) and nt.startswith("NodeType."):
+                filtered["node_type"] = nt.split(".", 1)[1].lower()
 
         if old_format:
             # Old format: description/result inline — set them on the node

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2537,6 +2537,24 @@ class EmployeeManager:
 
         ctx = pending["cleanup_ctx"]
         logger.info("[ceo_report] confirmed project={}", project_id)
+
+        # Advance CEO_PROMPT root node: COMPLETED → ACCEPTED → FINISHED
+        # The node in cleanup_ctx is the EA node; its parent is the CEO_PROMPT root.
+        ea_node = ctx["node"]
+        tree_dir = ea_node.project_dir or ""
+        if tree_dir:
+            from onemancompany.core.task_tree import get_tree, save_tree_async
+            tree_path = Path(tree_dir) / TASK_TREE_FILENAME
+            if tree_path.exists():
+                tree = get_tree(tree_path)
+                ceo_root = tree.get_node(ea_node.parent_id) if ea_node.parent_id else None
+                if ceo_root and ceo_root.is_ceo_node and ceo_root.status == TaskPhase.COMPLETED.value:
+                    ceo_root.set_status(TaskPhase.ACCEPTED)
+                    ceo_root.acceptance_result = {"passed": True, "notes": "CEO confirmed project completion."}
+                    ceo_root.set_status(TaskPhase.FINISHED)
+                    logger.info("[ceo_report] CEO root {} → ACCEPTED → FINISHED", ceo_root.id)
+                    save_tree_async(tree_path)
+
         await self._full_cleanup(
             ctx["employee_id"], ctx["node"], agent_error=False,
             project_id=project_id,

--- a/tests/unit/core/test_ceo_prompt_finish.py
+++ b/tests/unit/core/test_ceo_prompt_finish.py
@@ -1,0 +1,167 @@
+"""Tests for CEO_PROMPT root node advancing to FINISHED after CEO confirmation.
+
+Covers the bug where _confirm_ceo_report completes cleanup but leaves
+the CEO_PROMPT root node stuck at 'completed' instead of 'finished'.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from onemancompany.core.task_lifecycle import NodeType, TaskPhase
+
+
+def _make_tree_yaml(root_status: str = "completed") -> str:
+    """Create a minimal task tree YAML with CEO_PROMPT root + EA child."""
+    return f"""\
+project_id: test-project/iter_001
+root_id: root_001
+current_branch: 0
+mode: standard
+nodes:
+- id: root_001
+  parent_id: ''
+  children_ids:
+  - ea_001
+  employee_id: '00001'
+  description_preview: Test project
+  acceptance_criteria: []
+  node_type: {NodeType.CEO_PROMPT.value}
+  model_used: ''
+  project_dir: ''
+  status: {root_status}
+  acceptance_result: null
+  project_id: test-project/iter_001
+  created_at: '2026-03-24T12:00:00'
+  completed_at: ''
+  cost_usd: 0.0
+  input_tokens: 0
+  output_tokens: 0
+  timeout_seconds: 3600
+  branch: 0
+  branch_active: true
+  depends_on: []
+  hold_reason: ''
+  directives_count: 0
+- id: ea_001
+  parent_id: root_001
+  children_ids: []
+  employee_id: '00004'
+  description_preview: EA dispatched task
+  acceptance_criteria: []
+  node_type: task
+  model_used: ''
+  project_dir: ''
+  status: finished
+  acceptance_result:
+    passed: true
+    notes: All done.
+  project_id: test-project/iter_001
+  created_at: '2026-03-24T12:00:01'
+  completed_at: '2026-03-24T12:30:00'
+  cost_usd: 0.0
+  input_tokens: 0
+  output_tokens: 0
+  timeout_seconds: 3600
+  branch: 0
+  branch_active: true
+  depends_on: []
+  hold_reason: ''
+  directives_count: 0
+"""
+
+
+@pytest.mark.asyncio
+async def test_confirm_ceo_report_advances_root_to_finished():
+    """After CEO confirms, the CEO_PROMPT root should be ACCEPTED → FINISHED."""
+    from onemancompany.core.task_tree import TaskTree
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tree_path = Path(tmpdir) / "task_tree.yaml"
+        tree_path.write_text(_make_tree_yaml("completed"))
+
+        tree = TaskTree.load(tree_path)
+        ea_node = tree.get_node("ea_001")
+        # Set project_dir so _confirm_ceo_report can find the tree
+        ea_node.project_dir = tmpdir
+
+        root = tree.get_node("root_001")
+        assert root.status == TaskPhase.COMPLETED.value
+
+        # Build the pending report structure that _confirm_ceo_report expects
+        from onemancompany.core.vessel import EmployeeManager
+
+        em = EmployeeManager.__new__(EmployeeManager)
+        em._pending_ceo_reports = {}
+        em._running_tasks = {}
+        em._schedule = {}
+        em._restart_pending = False
+
+        em._pending_ceo_reports["test-project/iter_001"] = {
+            "timer_task": None,
+            "cleanup_ctx": {
+                "employee_id": "00004",
+                "node": ea_node,
+                "project_id": "test-project/iter_001",
+                "run_retrospective": False,
+            },
+        }
+
+        # Mock _full_cleanup to avoid side effects
+        em._full_cleanup = AsyncMock()
+
+        result = await em._confirm_ceo_report("test-project/iter_001")
+        assert result is True
+
+        # Reload tree from disk (save_tree_async writes synchronously in test)
+        tree2 = TaskTree.load(tree_path)
+        root2 = tree2.get_node("root_001")
+        assert root2.status == TaskPhase.FINISHED.value
+        assert root2.acceptance_result["passed"] is True
+
+
+@pytest.mark.asyncio
+async def test_confirm_ceo_report_no_double_finish():
+    """If root is already FINISHED, _confirm_ceo_report should not error."""
+    from onemancompany.core.task_tree import TaskTree
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tree_path = Path(tmpdir) / "task_tree.yaml"
+        tree_path.write_text(_make_tree_yaml("finished"))
+
+        tree = TaskTree.load(tree_path)
+        ea_node = tree.get_node("ea_001")
+        ea_node.project_dir = tmpdir
+
+        from onemancompany.core.vessel import EmployeeManager
+
+        em = EmployeeManager.__new__(EmployeeManager)
+        em._pending_ceo_reports = {}
+        em._running_tasks = {}
+        em._schedule = {}
+        em._restart_pending = False
+
+        em._pending_ceo_reports["test-project/iter_001"] = {
+            "timer_task": None,
+            "cleanup_ctx": {
+                "employee_id": "00004",
+                "node": ea_node,
+                "project_id": "test-project/iter_001",
+                "run_retrospective": False,
+            },
+        }
+
+        em._full_cleanup = AsyncMock()
+
+        result = await em._confirm_ceo_report("test-project/iter_001")
+        assert result is True
+
+        # Root should stay finished, no error
+        tree2 = TaskTree.load(tree_path)
+        root2 = tree2.get_node("root_001")
+        assert root2.status == TaskPhase.FINISHED.value

--- a/tests/unit/core/test_node_type_serialization.py
+++ b/tests/unit/core/test_node_type_serialization.py
@@ -1,0 +1,66 @@
+"""Tests for TaskNode node_type serialization/deserialization.
+
+Covers the bug where node_type was serialized as 'NodeType.CEO_REQUEST'
+(enum repr) instead of 'ceo_request' (enum value), causing comparisons
+to fail after deserialization.
+"""
+
+from __future__ import annotations
+
+from onemancompany.core.task_lifecycle import NodeType
+from onemancompany.core.task_tree import TaskNode
+
+
+class TestNodeTypeSerialization:
+    """Ensure node_type round-trips correctly through to_dict/from_dict."""
+
+    def test_to_dict_with_enum_member(self):
+        """to_dict should serialize enum member as its value string."""
+        node = TaskNode(id="n1", node_type=NodeType.CEO_REQUEST)
+        d = node.to_dict()
+        assert d["node_type"] == "ceo_request"
+
+    def test_to_dict_with_string_value(self):
+        """to_dict should pass through plain strings unchanged."""
+        node = TaskNode(id="n1", node_type="task")
+        d = node.to_dict()
+        assert d["node_type"] == "task"
+
+    def test_from_dict_migrates_old_enum_repr(self):
+        """from_dict should migrate 'NodeType.CEO_REQUEST' → 'ceo_request'."""
+        d = {
+            "id": "n1",
+            "node_type": "NodeType.CEO_REQUEST",
+            "description_preview": "test",
+        }
+        node = TaskNode.from_dict(d)
+        assert node.node_type == "ceo_request"
+        assert node.node_type == NodeType.CEO_REQUEST
+
+    def test_from_dict_migrates_watchdog_nudge(self):
+        d = {
+            "id": "n1",
+            "node_type": "NodeType.WATCHDOG_NUDGE",
+            "description_preview": "test",
+        }
+        node = TaskNode.from_dict(d)
+        assert node.node_type == "watchdog_nudge"
+        assert node.node_type == NodeType.WATCHDOG_NUDGE
+
+    def test_from_dict_normal_value_unchanged(self):
+        """Normal value strings should not be affected by migration."""
+        d = {
+            "id": "n1",
+            "node_type": "task",
+            "description_preview": "test",
+        }
+        node = TaskNode.from_dict(d)
+        assert node.node_type == "task"
+
+    def test_roundtrip_preserves_value(self):
+        """Serialize → deserialize should preserve node_type correctly."""
+        node = TaskNode(id="n1", node_type=NodeType.CEO_PROMPT)
+        d = node.to_dict()
+        node2 = TaskNode.from_dict(d)
+        assert node2.node_type == NodeType.CEO_PROMPT
+        assert d["node_type"] == "ceo_prompt"


### PR DESCRIPTION
## Summary
- **Bug 1**: `_confirm_ceo_report` 完成 cleanup 但遗漏了将 CEO_PROMPT 根节点从 `completed` 推进到 `accepted` → `finished`，导致项目完成后根节点永远卡在 completed 状态，前端无法显示为绿色
- **Bug 2**: `to_dict()` 用 `str(NodeType.CEO_REQUEST)` 序列化得到 `"NodeType.CEO_REQUEST"` 而非 `"ceo_request"`，反序列化后与 NodeType 枚举比较失败，导致 CEO_REQUEST 节点在 inbox 扫描时被跳过（HR 提交的招聘审批 CEO 看不到）

## Changes
- `vessel.py`: `_confirm_ceo_report` 在 cleanup 前推进 CEO_PROMPT 根节点到 FINISHED
- `task_tree.py`: `to_dict()` 用 `.value` 序列化 node_type；`from_dict()` 增加 `"NodeType.XXX"` → `"xxx"` 迁移

## Test plan
- [x] `test_confirm_ceo_report_advances_root_to_finished` — 验证根节点状态推进
- [x] `test_confirm_ceo_report_no_double_finish` — 验证已完成的不会报错
- [x] `test_to_dict_with_enum_member` — 验证序列化输出正确
- [x] `test_from_dict_migrates_old_enum_repr` — 验证旧数据迁移
- [x] `test_roundtrip_preserves_value` — 验证序列化反序列化一致
- [x] 2052 existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)