### PR TITLE
feat: add Claude model selector for self-hosted employees

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2654,6 +2654,11 @@ class AppController {
     const hasActive = sessions.some(s => s.status === 'running');
     const statusColor = hasActive ? 'var(--pixel-green)' : 'var(--pixel-yellow)';
     const statusText = hasActive ? 'Active' : (sessions.length > 0 ? 'Idle' : 'No sessions');
+    const currentModel = empData.llm_model || 'opus';
+    const claudeModels = [
+      { id: 'opus', label: 'Claude Opus' },
+      { id: 'sonnet', label: 'Claude Sonnet' },
+    ];
 
     const section = document.createElement('div');
     section.className = 'emp-detail-section-content';
@@ -2664,8 +2669,10 @@ class AppController {
         <span style="font-size:6px;color:var(--pixel-cyan);">Self-hosted (Claude Code)</span>
       </div>
       <div style="display:flex;align-items:center;gap:4px;">
-        <span style="font-size:6px;color:var(--pixel-yellow);min-width:55px;">Auth</span>
-        <span style="font-size:6px;color:var(--text-main);">${this._escHtml(empData.auth_method || 'cli')}</span>
+        <span style="font-size:6px;color:var(--pixel-yellow);min-width:55px;">Model</span>
+        <select id="emp-self-hosted-model" class="emp-model-select" style="flex:1;">
+          ${claudeModels.map(m => `<option value="${m.id}" ${m.id === currentModel ? 'selected' : ''}>${m.label}</option>`).join('')}
+        </select>
       </div>
       <div style="display:flex;align-items:center;gap:4px;">
         <span style="font-size:6px;color:var(--pixel-yellow);min-width:55px;">Status</span>
@@ -2674,6 +2681,24 @@ class AppController {
       ${sessions.length > 0 ? `<div style="font-size:5px;color:var(--text-dim);margin-top:2px;">${sessions.length} session(s)</div>` : ''}
     `;
     container.appendChild(section);
+
+    const modelSelect = section.querySelector('#emp-self-hosted-model');
+    modelSelect.addEventListener('change', async () => {
+      const newModel = modelSelect.value;
+      modelSelect.disabled = true;
+      try {
+        await fetch(`/api/employee/${empId}/model`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ model: newModel }),
+        });
+        this.logEntry('CEO', `Updated self-hosted employee #${empId} model to ${newModel}`, 'ceo');
+      } catch (e) {
+        console.error('Failed to save model:', e);
+      } finally {
+        modelSelect.disabled = false;
+      }
+    });
   }
 
   _renderFallbackModelSection(empId, empData, container) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.571",
+  "version": "0.2.572",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.571"
+version = "0.2.572"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -1543,14 +1543,15 @@ async def update_employee_model(employee_id: str, body: dict) -> dict:
 
     emp = _require_employee(employee_id)
 
-    # Compute new salary — skip OpenRouter pricing for non-openrouter providers
+    # Compute new salary — skip OpenRouter pricing for self-hosted or non-openrouter providers
     cfg = employee_configs.get(employee_id)
+    hosting = cfg.hosting if cfg else emp.get("hosting", "company")
     api_provider = cfg.api_provider if cfg else "openrouter"
-    if api_provider == "openrouter":
+    if hosting == "self" or api_provider != "openrouter":
+        new_salary = cfg.salary_per_1m_tokens if cfg else 0.0
+    else:
         from onemancompany.core.model_costs import compute_salary
         new_salary = compute_salary(model_id)
-    else:
-        new_salary = cfg.salary_per_1m_tokens if cfg else 0.0
 
     # Update in-memory config
     if cfg:

--- a/tests/unit/scripts/test_swe_bench_runner.py
+++ b/tests/unit/scripts/test_swe_bench_runner.py
@@ -104,6 +104,16 @@ class TestPredictionsIO:
 
 
 class TestGitOps:
+    @pytest.fixture(autouse=True)
+    def _isolate_git_env(self, monkeypatch):
+        """Isolate from project git env (pre-commit sets GIT_DIR/GIT_INDEX_FILE)."""
+        monkeypatch.delenv("GIT_DIR", raising=False)
+        monkeypatch.delenv("GIT_WORK_TREE", raising=False)
+        monkeypatch.delenv("GIT_INDEX_FILE", raising=False)
+        monkeypatch.setenv("GIT_CONFIG_VALUE_0", "/dev/null")
+        monkeypatch.setenv("GIT_CONFIG_KEY_0", "core.hooksPath")
+        monkeypatch.setenv("GIT_CONFIG_COUNT", "1")
+
     def test_clone_repo(self, tmp_path):
         from swe_bench_runner import clone_repo
 


### PR DESCRIPTION
## Summary
- Add model dropdown (sonnet/opus, default opus) to self-hosted employee detail panel
- Fix `update_employee_model` to skip OpenRouter salary computation for self-hosted employees
- Fix `TestGitOps` to isolate from project git hooks/env during pre-commit runs

## Test plan
- [x] All 2077 unit tests pass
- [ ] Open self-hosted employee detail panel → verify model dropdown appears
- [ ] Change model → verify profile.yaml updated with new llm_model value
- [ ] Verify next Claude session picks up the new model via `--model` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)