### PR TITLE
fix: restore HOLDING nodes to schedule on restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.572",
+  "version": "0.2.573",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.572"
+version = "0.2.573"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/task_persistence.py
+++ b/src/onemancompany/core/task_persistence.py
@@ -65,6 +65,12 @@ def recover_schedule_from_trees(
                     employee_manager.schedule_node(
                         node.employee_id, node.id, str(tree_path),
                     )
+                elif node.status == TaskPhase.HOLDING.value:
+                    # HOLDING nodes must be in schedule so resume_held_task()
+                    # can find them after restart (watchdog or CEO inbox resume).
+                    employee_manager.schedule_node(
+                        node.employee_id, node.id, str(tree_path),
+                    )
 
     # 2. Scan system task trees
     if employees_dir.exists():

--- a/tests/unit/core/test_task_persistence.py
+++ b/tests/unit/core/test_task_persistence.py
@@ -101,13 +101,14 @@ class TestRecoverScheduleFromTrees:
 
         assert len(em.scheduled) == 0
 
-    def test_holding_nodes_left_as_is(self, tmp_path):
-        """HOLDING nodes should not be reset or scheduled."""
+    def test_holding_nodes_scheduled_for_resume(self, tmp_path):
+        """HOLDING nodes should remain holding but be scheduled so resume_held_task can find them."""
         from onemancompany.core.task_tree import TaskTree
 
         tree = TaskTree("proj1")
         root = tree.create_root("emp1", "root")
         root.status = "holding"
+        root.hold_reason = "ceo_request=abc123,no_watchdog=1"
         proj_dir = tmp_path / "projects" / "proj1"
         tree_path = proj_dir / "task_tree.yaml"
         tree.save(tree_path)
@@ -117,7 +118,9 @@ class TestRecoverScheduleFromTrees:
 
         loaded = TaskTree.load(tree_path)
         assert loaded.get_node(root.id).status == "holding"
-        assert len(em.scheduled) == 0
+        # HOLDING nodes must be in schedule so resume_held_task() works after restart
+        assert len(em.scheduled) == 1
+        assert em.scheduled[0][1] == root.id
 
     def test_pending_with_unresolved_deps_not_scheduled(self, tmp_path):
         """PENDING nodes whose deps are not yet resolved should NOT be scheduled."""


### PR DESCRIPTION
## Summary
- `recover_schedule_from_trees()` only restored PENDING nodes after restart, skipping HOLDING ones
- This caused `resume_held_task()` to silently fail (return False) when CEO responded to inbox items post-restart
- HR tasks waiting for CEO hire approval would remain stuck in HOLDING forever after any restart

## Root cause
When HR dispatches `request_hiring()`, it creates a CEO_REQUEST child and enters HOLDING with `hold_reason=ceo_request=<id>,no_watchdog=1`. On restart, `recover_schedule_from_trees` only schedules PENDING nodes. The HOLDING node is lost from `_schedule`, so when CEO later responds via inbox, `resume_held_task` can't find the entry.

## Fix
Also schedule HOLDING nodes during recovery so they remain findable by `resume_held_task()` and watchdog pollers.

## Test plan
- [x] Updated `test_holding_nodes_left_as_is` → `test_holding_nodes_scheduled_for_resume`
- [x] All 2078 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)