### PR TITLE
perf: optimize frontend bootstrap load time

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -87,27 +87,24 @@ class AppController {
 
   async bootstrap() {
     try {
-      const [employees, tasks, rooms, tools, activityLog, stateData] = await Promise.all([
-        fetch('/api/employees').then(r => r.json()),
-        fetch('/api/task-queue').then(r => r.json()),
-        fetch('/api/rooms').then(r => r.json()),
-        fetch('/api/tools').then(r => r.json()),
-        fetch('/api/activity-log').then(r => r.json()),
-        fetch('/api/state').then(r => r.json()),
-      ]);
+      const t0 = performance.now();
+      // Single API call replaces 6 parallel fetches
+      const data = await fetch('/api/bootstrap').then(r => r.json());
+      const { employees, tasks, rooms, tools, activity_log, version, office_layout } = data;
+      console.debug(`[bootstrap] /api/bootstrap took ${(performance.now() - t0).toFixed(0)}ms`);
+
       this.updateRoster(employees);
       this.updateTaskPanel(tasks);
       this.updateOneononeDropdown(employees);
       this.updateProjectsPanel();
       if (window.officeRenderer) {
         window.officeRenderer.updateState({
-          employees, meeting_rooms: rooms, tools,
-          office_layout: stateData.office_layout,
+          employees, meeting_rooms: rooms, tools, office_layout,
         });
       }
       // Show version
-      if (stateData.version) {
-        document.getElementById('app-version').textContent = `v${stateData.version}`;
+      if (version) {
+        document.getElementById('app-version').textContent = `v${version}`;
       }
       // Update counters
       document.getElementById('employee-count').textContent = `👥 ${employees.length}`;
@@ -122,8 +119,21 @@ class AppController {
       this._refreshCeoInbox();
       // Restore onboarding progress modal if there's an active onboarding
       this._restoreOnboardingProgress();
+
+      // Lazy-load full task tree summaries in background (non-blocking)
+      this._lazyLoadTaskTrees();
     } catch (e) {
       console.error('Bootstrap failed:', e);
+    }
+  }
+
+  async _lazyLoadTaskTrees() {
+    // After initial render, fetch full task queue with tree summaries to enrich the panel
+    try {
+      const tasks = await fetch('/api/task-queue').then(r => r.json());
+      this.updateTaskPanel(tasks);
+    } catch (e) {
+      console.debug('[bootstrap] lazy tree load failed:', e);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.581",
+  "version": "0.2.582",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.580",
+  "version": "0.2.581",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.581"
+version = "0.2.582"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.580"
+version = "0.2.581"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -322,6 +322,89 @@ async def admin_clear_tasks() -> dict:
     return {"status": "cleared", "tasks_removed": cleared}
 
 
+@router.get("/api/bootstrap")
+async def get_bootstrap() -> dict:
+    """Single bootstrap endpoint — replaces 6 parallel fetches with 1 call.
+
+    Returns employees, task-queue (lightweight), rooms, tools, activity-log,
+    and state metadata. Uses async I/O to read from disk in parallel via thread pool.
+    """
+    from onemancompany.core.project_archive import list_projects
+    from onemancompany.core.store import (
+        aload_activity_log,
+        aload_all_employees,
+        aload_overhead,
+        aload_tools,
+    )
+    from onemancompany.core.vessel import employee_manager as _em
+
+    from importlib.metadata import version as _pkg_version
+    try:
+        app_version = _pkg_version("onemancompany")
+    except Exception:
+        app_version = "dev"
+
+    # Parallel async disk reads
+    employees_raw, tools, activity_log, overhead = await asyncio.gather(
+        aload_all_employees(),
+        aload_tools(),
+        aload_activity_log(),
+        aload_overhead(),
+    )
+
+    # Build employee list (same logic as /api/employees)
+    employees = []
+    for emp_id, data in employees_raw.items():
+        if emp_id == CEO_ID:
+            continue
+        runtime = data.pop("runtime", {})
+        data["id"] = emp_id
+        data["employee_number"] = emp_id
+        disk_status = runtime.get("status", STATUS_IDLE)
+        if emp_id in _em._running_tasks and disk_status != STATUS_WORKING:
+            data["status"] = STATUS_WORKING
+        else:
+            data["status"] = disk_status
+        data["is_listening"] = runtime.get("is_listening", False)
+        data[PF_CURRENT_TASK_SUMMARY] = runtime.get(PF_CURRENT_TASK_SUMMARY, "")
+        data["api_online"] = runtime.get("api_online", True)
+        data["needs_setup"] = runtime.get("needs_setup", False)
+        employees.append(data)
+
+    # Lightweight task queue — skip expensive _tree_summary on bootstrap
+    loop = asyncio.get_event_loop()
+    all_projects = await loop.run_in_executor(None, list_projects)
+    tasks = []
+    for p in all_projects:
+        if p.get("is_named"):
+            continue
+        status = _normalize_project_status(p.get("status", ""))
+        tasks.append({
+            "project_id": p["project_id"],
+            "task": p.get("task", ""),
+            "routed_to": p.get("routed_to", ""),
+            "current_owner": p.get("current_owner", ""),
+            "status": status,
+            "created_at": p.get("created_at", ""),
+            "completed_at": p.get("completed_at", ""),
+            "result": "",
+            "tree": None,  # Lazy — loaded on demand via /api/task-queue
+        })
+
+    rooms = [r.to_dict() for r in company_state.meeting_rooms.values()]
+
+    return {
+        "employees": employees,
+        "tasks": tasks,
+        "rooms": rooms,
+        "tools": tools,
+        "activity_log": activity_log[-50:],
+        "version": app_version,
+        "office_layout": company_state.office_layout,
+        "company_tokens": overhead.get("company_tokens", 0),
+    }
+
+
 @router.get("/api/state")
 async def get_state() -> dict:
     """Legacy full-state endpoint — assembles state from disk via store."""

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -378,6 +378,8 @@ async def get_bootstrap() -> dict:
     for p in all_projects:
         if p.get("is_named"):
             continue
+        if p.get("status") == "archived":
+            continue
         status = _normalize_project_status(p.get("status", ""))
         tasks.append({
             "project_id": p["project_id"],
@@ -2919,6 +2921,8 @@ async def get_task_queue() -> list[dict]:
     for p in list_projects():
         # Skip v2 named projects (shown in PROJECTS panel)
         if p.get("is_named"):
+            continue
+        if p.get("status") == "archived":
             continue
         tree = _tree_summary(p["project_id"])
         # project.yaml is the single source of truth for status

--- a/src/onemancompany/core/store.py
+++ b/src/onemancompany/core/store.py
@@ -126,8 +126,13 @@ _dirty: set[str] = set()
 
 
 def mark_dirty(*categories: str) -> None:
-    """Mark resource categories as dirty for the next sync tick."""
+    """Mark resource categories as dirty for the next sync tick.
+
+    Also invalidates read cache for the affected categories.
+    """
     _dirty.update(categories)
+    for cat in categories:
+        _read_cache_invalidate(cat)
 
 
 def flush_dirty() -> list[str]:
@@ -135,6 +140,51 @@ def flush_dirty() -> list[str]:
     changed = list(_dirty)
     _dirty.clear()
     return changed
+
+
+# ---------------------------------------------------------------------------
+# Read cache — dirty-aware, short-lived cache for read-heavy bootstrap path
+# ---------------------------------------------------------------------------
+
+import time as _time  # noqa: E402
+
+# {cache_key: (value, timestamp)}
+_read_cache: dict[str, tuple[Any, float]] = {}
+# Maps DirtyCategory value → set of cache keys to invalidate
+_cache_key_to_category: dict[str, set[str]] = {}
+
+_CACHE_TTL_SECONDS = 3.0  # Matches sync tick interval
+
+
+def _read_cache_get(key: str) -> Any | None:
+    """Get cached value if present and not expired. Returns None on miss."""
+    entry = _read_cache.get(key)
+    if entry is None:
+        return None
+    value, ts = entry
+    if (_time.monotonic() - ts) > _CACHE_TTL_SECONDS:
+        _read_cache.pop(key, None)
+        return None
+    return value
+
+
+def _read_cache_set(key: str, value: Any, category: str) -> None:
+    """Store a value in the read cache, tagged with its dirty category."""
+    _read_cache[key] = (value, _time.monotonic())
+    _cache_key_to_category.setdefault(category, set()).add(key)
+
+
+def _read_cache_invalidate(category: str) -> None:
+    """Evict all cache entries for a dirty category."""
+    keys = _cache_key_to_category.pop(category, set())
+    for k in keys:
+        _read_cache.pop(k, None)
+
+
+def cache_clear_all() -> None:
+    """Clear entire read cache. Useful for tests."""
+    _read_cache.clear()
+    _cache_key_to_category.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -170,7 +220,14 @@ def load_all_employees() -> dict[str, dict]:
     """Read all employee profile.yamls from disk. Returns {emp_id: profile_dict}.
 
     Also loads work_principles and guidance_notes from their separate files.
+    Uses dirty-aware cache to avoid redundant disk reads during rapid bootstrap/tick.
     """
+    cached = _read_cache_get("all_employees")
+    if cached is not None:
+        # Return deep copy so callers can mutate without poisoning cache
+        import copy
+        return copy.deepcopy(cached)
+
     result: dict[str, dict] = {}
     if not EMPLOYEES_DIR.exists():
         return result
@@ -184,6 +241,7 @@ def load_all_employees() -> dict[str, dict]:
             data[PF_WORK_PRINCIPLES] = load_employee_work_principles(emp_id)
             data[PF_GUIDANCE_NOTES] = load_employee_guidance(emp_id)
             result[emp_id] = data
+    _read_cache_set("all_employees", result, DirtyCategory.EMPLOYEES)
     return result
 
 
@@ -402,6 +460,9 @@ def load_meeting_minute(minute_id: str) -> dict:
 # ---------------------------------------------------------------------------
 
 def load_tools() -> list[dict]:
+    cached = _read_cache_get("tools")
+    if cached is not None:
+        return list(cached)
     tools_dir = DATA_ROOT / "company" / "assets" / "tools"
     if not tools_dir.exists():
         return []
@@ -412,6 +473,7 @@ def load_tools() -> list[dict]:
         tyaml = tdir / TOOL_YAML_FILENAME
         if tyaml.exists():
             results.append(_read_yaml(tyaml))
+    _read_cache_set("tools", results, DirtyCategory.TOOLS)
     return results
 
 
@@ -439,7 +501,12 @@ async def save_tree(project_dir: str, tree_data: dict) -> None:
 # ---------------------------------------------------------------------------
 
 def load_activity_log() -> list[dict]:
-    return _read_yaml_list(COMPANY_DIR / ACTIVITY_LOG_FILENAME)
+    cached = _read_cache_get("activity_log")
+    if cached is not None:
+        return list(cached)  # shallow copy — entries are dicts, safe for slicing
+    result = _read_yaml_list(COMPANY_DIR / ACTIVITY_LOG_FILENAME)
+    _read_cache_set("activity_log", result, DirtyCategory.ACTIVITY_LOG)
+    return result
 
 
 async def append_activity(entry: dict) -> None:
@@ -601,3 +668,37 @@ def save_overhead_sync(data: dict) -> None:
     path = COMPANY_DIR / OVERHEAD_FILENAME
     _write_yaml(path, data)
     mark_dirty(DirtyCategory.OVERHEAD)
+
+
+# ---------------------------------------------------------------------------
+# Async read wrappers — offload sync disk I/O to thread pool
+# ---------------------------------------------------------------------------
+
+async def aload_all_employees() -> dict[str, dict]:
+    """Async wrapper: offloads load_all_employees() to thread pool."""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, load_all_employees)
+
+
+async def aload_activity_log() -> list[dict]:
+    """Async wrapper: offloads load_activity_log() to thread pool."""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, load_activity_log)
+
+
+async def aload_tools() -> list[dict]:
+    """Async wrapper: offloads load_tools() to thread pool."""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, load_tools)
+
+
+async def aload_rooms() -> list[dict]:
+    """Async wrapper: offloads load_rooms() to thread pool."""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, load_rooms)
+
+
+async def aload_overhead() -> dict:
+    """Async wrapper: offloads load_overhead() to thread pool."""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(None, load_overhead)

--- a/src/onemancompany/core/task_persistence.py
+++ b/src/onemancompany/core/task_persistence.py
@@ -11,8 +11,22 @@ from pathlib import Path
 
 from loguru import logger
 
-from onemancompany.core.config import EMPLOYEES_DIR, TASK_TREE_FILENAME
+import yaml
+
+from onemancompany.core.config import EMPLOYEES_DIR, PROJECT_YAML_FILENAME, TASK_TREE_FILENAME
 from onemancompany.core.task_lifecycle import TaskPhase
+
+
+def _is_project_archived(tree_path: Path) -> bool:
+    """Check if the project containing this tree file is archived."""
+    project_yaml = tree_path.parent / PROJECT_YAML_FILENAME
+    if not project_yaml.exists():
+        return False
+    try:
+        doc = yaml.safe_load(project_yaml.read_text()) or {}
+        return doc.get("status") == "archived"
+    except Exception:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -45,6 +59,10 @@ def recover_schedule_from_trees(
     # 1. Scan all task_tree.yaml files under projects_dir
     if projects_dir.exists():
         for tree_path in projects_dir.rglob(TASK_TREE_FILENAME):
+            # Skip archived projects — no need to restore tasks
+            if _is_project_archived(tree_path):
+                logger.debug("Skipping archived project tree: {}", tree_path)
+                continue
             try:
                 tree = get_tree(tree_path)
             except Exception:

--- a/src/onemancompany/main.py
+++ b/src/onemancompany/main.py
@@ -558,10 +558,13 @@ async def lifespan(app: FastAPI):
         list_projects,
         ITER_STATUS_PENDING_CONFIRMATION,
         ITER_STATUS_COMPLETED,
+        PROJECT_STATUS_ARCHIVED,
         load_iteration,
         update_project_status,
     )
     for _proj in list_projects():
+        if _proj.get("status") == PROJECT_STATUS_ARCHIVED:
+            continue
         _iters = _proj.get("iterations", [])
         if not _iters:
             continue

--- a/tests/unit/api/test_bootstrap.py
+++ b/tests/unit/api/test_bootstrap.py
@@ -1,0 +1,144 @@
+"""Unit tests for GET /api/bootstrap — single-call frontend init endpoint."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from onemancompany.core.state import CompanyState, MeetingRoom
+
+
+def _make_test_app() -> FastAPI:
+    from onemancompany.api.routes import router
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+def _emp_dict(emp_id: str = "00010", name: str = "Alice", role: str = "Engineer") -> dict:
+    return {
+        "id": emp_id,
+        "name": name,
+        "role": role,
+        "runtime": {"status": "idle", "is_listening": False, "current_task_summary": ""},
+        "work_principles": "",
+        "guidance_notes": [],
+    }
+
+
+class TestBootstrapEndpoint:
+    @pytest.mark.asyncio
+    async def test_returns_all_sections(self):
+        state = CompanyState()
+        room = MeetingRoom(id="room1", name="Alpha", description="Test room")
+        state.meeting_rooms["room1"] = room
+        state.office_layout = {"width": 40, "height": 30}
+
+        fake_employees = {"00010": _emp_dict("00010")}
+        fake_tools = [{"name": "Hammer", "slug": "hammer"}]
+        fake_activity = [{"type": "test", "desc": "hello"}]
+        fake_overhead = {"company_tokens": 42}
+        fake_projects = [
+            {"project_id": "p1", "task": "Do stuff", "status": "in_progress",
+             "routed_to": "", "current_owner": "", "created_at": "", "completed_at": ""},
+        ]
+
+        em_mock = MagicMock()
+        em_mock._running_tasks = {}
+
+        with patch("onemancompany.api.routes.company_state", state), \
+             patch("onemancompany.api.routes._store.aload_all_employees", new_callable=AsyncMock, return_value=fake_employees), \
+             patch("onemancompany.api.routes._store.aload_tools", new_callable=AsyncMock, return_value=fake_tools), \
+             patch("onemancompany.api.routes._store.aload_activity_log", new_callable=AsyncMock, return_value=fake_activity), \
+             patch("onemancompany.api.routes._store.aload_overhead", new_callable=AsyncMock, return_value=fake_overhead), \
+             patch("onemancompany.core.project_archive.list_projects", return_value=fake_projects), \
+             patch("onemancompany.api.routes.event_bus", MagicMock()):
+            app = _make_test_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.get("/api/bootstrap")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        # All sections present
+        assert "employees" in data
+        assert "tasks" in data
+        assert "rooms" in data
+        assert "tools" in data
+        assert "activity_log" in data
+        assert "version" in data
+        assert "office_layout" in data
+
+        # Employee data correct (CEO filtered out already by fake data)
+        assert len(data["employees"]) == 1
+        assert data["employees"][0]["id"] == "00010"
+
+        # Lightweight tasks — tree is None
+        assert len(data["tasks"]) == 1
+        assert data["tasks"][0]["project_id"] == "p1"
+        assert data["tasks"][0]["tree"] is None
+
+        # Rooms from company_state
+        assert len(data["rooms"]) == 1
+
+        # Tools, activity log
+        assert len(data["tools"]) == 1
+        assert len(data["activity_log"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_ceo_filtered_from_employees(self):
+        """CEO (00001) should not appear in employee list."""
+        state = CompanyState()
+
+        fake_employees = {
+            "00001": _emp_dict("00001", "CEO", "CEO"),
+            "00010": _emp_dict("00010", "Dev", "Engineer"),
+        }
+
+        em_mock = MagicMock()
+        em_mock._running_tasks = {}
+
+        with patch("onemancompany.api.routes.company_state", state), \
+             patch("onemancompany.api.routes._store.aload_all_employees", new_callable=AsyncMock, return_value=fake_employees), \
+             patch("onemancompany.api.routes._store.aload_tools", new_callable=AsyncMock, return_value=[]), \
+             patch("onemancompany.api.routes._store.aload_activity_log", new_callable=AsyncMock, return_value=[]), \
+             patch("onemancompany.api.routes._store.aload_overhead", new_callable=AsyncMock, return_value={}), \
+             patch("onemancompany.core.project_archive.list_projects", return_value=[]), \
+             patch("onemancompany.api.routes.event_bus", MagicMock()):
+            app = _make_test_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.get("/api/bootstrap")
+
+        data = resp.json()
+        emp_ids = [e["id"] for e in data["employees"]]
+        assert "00001" not in emp_ids
+        assert "00010" in emp_ids
+
+    @pytest.mark.asyncio
+    async def test_named_projects_excluded_from_tasks(self):
+        """Named projects should be excluded from task queue."""
+        state = CompanyState()
+
+        fake_projects = [
+            {"project_id": "p1", "task": "T1", "status": "active", "is_named": True,
+             "routed_to": "", "current_owner": "", "created_at": "", "completed_at": ""},
+            {"project_id": "p2", "task": "T2", "status": "in_progress",
+             "routed_to": "", "current_owner": "", "created_at": "", "completed_at": ""},
+        ]
+
+        with patch("onemancompany.api.routes.company_state", state), \
+             patch("onemancompany.api.routes._store.aload_all_employees", new_callable=AsyncMock, return_value={}), \
+             patch("onemancompany.api.routes._store.aload_tools", new_callable=AsyncMock, return_value=[]), \
+             patch("onemancompany.api.routes._store.aload_activity_log", new_callable=AsyncMock, return_value=[]), \
+             patch("onemancompany.api.routes._store.aload_overhead", new_callable=AsyncMock, return_value={}), \
+             patch("onemancompany.core.project_archive.list_projects", return_value=fake_projects), \
+             patch("onemancompany.api.routes.event_bus", MagicMock()):
+            app = _make_test_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.get("/api/bootstrap")
+
+        data = resp.json()
+        assert len(data["tasks"]) == 1
+        assert data["tasks"][0]["project_id"] == "p2"

--- a/tests/unit/core/test_store_cache.py
+++ b/tests/unit/core/test_store_cache.py
@@ -1,0 +1,157 @@
+"""Unit tests for store.py read cache and async wrappers."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from onemancompany.core.config import DirtyCategory
+from onemancompany.core.store import (
+    _CACHE_TTL_SECONDS,
+    _read_cache,
+    _read_cache_get,
+    _read_cache_invalidate,
+    _read_cache_set,
+    cache_clear_all,
+    mark_dirty,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """Ensure each test starts with a clean cache."""
+    cache_clear_all()
+    yield
+    cache_clear_all()
+
+
+class TestReadCache:
+    def test_set_and_get(self):
+        _read_cache_set("k1", {"a": 1}, "cat_a")
+        assert _read_cache_get("k1") == {"a": 1}
+
+    def test_miss_returns_none(self):
+        assert _read_cache_get("nonexistent") is None
+
+    def test_ttl_expiry(self):
+        _read_cache_set("k2", "val", "cat_b")
+        # Manually age the entry
+        key_val, _ = _read_cache["k2"]
+        _read_cache["k2"] = (key_val, time.monotonic() - _CACHE_TTL_SECONDS - 1)
+        assert _read_cache_get("k2") is None
+
+    def test_invalidate_by_category(self):
+        _read_cache_set("k3", "v3", "cat_c")
+        _read_cache_set("k4", "v4", "cat_c")
+        _read_cache_set("k5", "v5", "cat_d")
+        _read_cache_invalidate("cat_c")
+        assert _read_cache_get("k3") is None
+        assert _read_cache_get("k4") is None
+        assert _read_cache_get("k5") == "v5"
+
+    def test_mark_dirty_invalidates_cache(self):
+        _read_cache_set("all_employees", {"e1": {}}, DirtyCategory.EMPLOYEES)
+        assert _read_cache_get("all_employees") is not None
+        mark_dirty(DirtyCategory.EMPLOYEES)
+        assert _read_cache_get("all_employees") is None
+
+    def test_cache_clear_all(self):
+        _read_cache_set("a", 1, "x")
+        _read_cache_set("b", 2, "y")
+        cache_clear_all()
+        assert _read_cache_get("a") is None
+        assert _read_cache_get("b") is None
+
+
+class TestCachedLoadFunctions:
+    """Test that load_all_employees / load_tools / load_activity_log use cache."""
+
+    def test_load_all_employees_caches(self, tmp_path):
+        from onemancompany.core.store import load_all_employees
+
+        with patch("onemancompany.core.store.EMPLOYEES_DIR", tmp_path):
+            # Create a fake employee dir
+            emp_dir = tmp_path / "00010"
+            emp_dir.mkdir()
+            (emp_dir / "profile.yaml").write_text("name: Alice\nrole: Engineer\n")
+            (emp_dir / "work_principles.md").write_text("Be good")
+            (emp_dir / "guidance.yaml").write_text("notes:\n  - note1\n")
+
+            result1 = load_all_employees()
+            assert "00010" in result1
+
+            # Second call should hit cache (no disk read)
+            # Verify by removing the file — cached result should still work
+            (emp_dir / "profile.yaml").unlink()
+            result2 = load_all_employees()
+            assert "00010" in result2
+
+    def test_load_tools_caches(self, tmp_path):
+        from onemancompany.core.store import load_tools
+
+        tools_dir = tmp_path / "company" / "assets" / "tools" / "hammer"
+        tools_dir.mkdir(parents=True)
+        (tools_dir / "tool.yaml").write_text("name: Hammer\ncategory: build\n")
+
+        with patch("onemancompany.core.store.DATA_ROOT", tmp_path):
+            result1 = load_tools()
+            assert len(result1) == 1
+
+            (tools_dir / "tool.yaml").unlink()
+            result2 = load_tools()
+            assert len(result2) == 1  # From cache
+
+    def test_load_activity_log_caches(self, tmp_path):
+        from onemancompany.core.store import load_activity_log
+
+        log_path = tmp_path / "activity_log.yaml"
+        log_path.write_text("- type: test\n  desc: hello\n")
+
+        with patch("onemancompany.core.store.COMPANY_DIR", tmp_path):
+            result1 = load_activity_log()
+            assert len(result1) == 1
+
+            log_path.unlink()
+            result2 = load_activity_log()
+            assert len(result2) == 1  # From cache
+
+
+class TestAsyncWrappers:
+    @pytest.mark.asyncio
+    async def test_aload_all_employees(self, tmp_path):
+        from onemancompany.core.store import aload_all_employees
+
+        with patch("onemancompany.core.store.EMPLOYEES_DIR", tmp_path):
+            emp_dir = tmp_path / "00010"
+            emp_dir.mkdir()
+            (emp_dir / "profile.yaml").write_text("name: Bob\n")
+            (emp_dir / "work_principles.md").write_text("")
+            (emp_dir / "guidance.yaml").write_text("")
+
+            result = await aload_all_employees()
+            assert "00010" in result
+
+    @pytest.mark.asyncio
+    async def test_aload_tools(self, tmp_path):
+        from onemancompany.core.store import aload_tools
+
+        tools_dir = tmp_path / "company" / "assets" / "tools" / "saw"
+        tools_dir.mkdir(parents=True)
+        (tools_dir / "tool.yaml").write_text("name: Saw\n")
+
+        with patch("onemancompany.core.store.DATA_ROOT", tmp_path):
+            result = await aload_tools()
+            assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_aload_activity_log(self, tmp_path):
+        from onemancompany.core.store import aload_activity_log
+
+        log_path = tmp_path / "activity_log.yaml"
+        log_path.write_text("- type: test\n")
+
+        with patch("onemancompany.core.store.COMPANY_DIR", tmp_path):
+            result = await aload_activity_log()
+            assert len(result) == 1

--- a/tests/unit/core/test_task_persistence.py
+++ b/tests/unit/core/test_task_persistence.py
@@ -25,6 +25,23 @@ def _isolate_employees_dir(tmp_path, monkeypatch):
 # _tasks_dir
 # ---------------------------------------------------------------------------
 
+class TestIsProjectArchived:
+    def test_archived(self, tmp_path):
+        (tmp_path / "project.yaml").write_text(yaml.dump({"status": "archived"}))
+        assert tp._is_project_archived(tmp_path / "task_tree.yaml") is True
+
+    def test_active(self, tmp_path):
+        (tmp_path / "project.yaml").write_text(yaml.dump({"status": "active"}))
+        assert tp._is_project_archived(tmp_path / "task_tree.yaml") is False
+
+    def test_missing_project_yaml(self, tmp_path):
+        assert tp._is_project_archived(tmp_path / "task_tree.yaml") is False
+
+    def test_no_status_field(self, tmp_path):
+        (tmp_path / "project.yaml").write_text(yaml.dump({"name": "test"}))
+        assert tp._is_project_archived(tmp_path / "task_tree.yaml") is False
+
+
 class TestTasksDir:
     def test_returns_correct_path(self, tmp_path):
         expected = tmp_path / "00010" / "tasks"
@@ -174,6 +191,38 @@ class TestRecoverScheduleFromTrees:
         # Should not raise
         tp.recover_schedule_from_trees(em, tmp_path / "projects", tmp_path / "employees")
         assert len(em.scheduled) == 0
+
+    def test_skips_archived_projects(self, tmp_path):
+        """Archived projects should be completely skipped during recovery."""
+        from onemancompany.core.task_tree import TaskTree
+
+        # Archived project — should be skipped
+        tree_a = TaskTree("archived_proj")
+        root_a = tree_a.create_root("emp1", "archived task")
+        root_a.status = "processing"
+        proj_dir_a = tmp_path / "projects" / "archived_proj"
+        tree_a.save(proj_dir_a / "task_tree.yaml")
+        (proj_dir_a / "project.yaml").write_text(
+            yaml.dump({"status": "archived", "project_id": "archived_proj"})
+        )
+
+        # Active project — should be recovered
+        tree_b = TaskTree("active_proj")
+        root_b = tree_b.create_root("emp2", "active task")
+        root_b.status = "processing"
+        proj_dir_b = tmp_path / "projects" / "active_proj"
+        tree_b.save(proj_dir_b / "task_tree.yaml")
+        (proj_dir_b / "project.yaml").write_text(
+            yaml.dump({"status": "active", "project_id": "active_proj"})
+        )
+
+        em = _MockEM()
+        tp.recover_schedule_from_trees(em, tmp_path / "projects", tmp_path / "employees")
+
+        # Only active project nodes should be scheduled
+        scheduled_node_ids = {s[1] for s in em.scheduled}
+        assert root_b.id in scheduled_node_ids, "Active project node should be scheduled"
+        assert root_a.id not in scheduled_node_ids, "Archived project node should NOT be scheduled"
 
     def test_empty_dirs(self, tmp_path):
         """No crash when projects/employees dirs don't exist."""


### PR DESCRIPTION
## Summary
- **合并 API**: New `/api/bootstrap` endpoint replaces 6 parallel REST calls with a single request, eliminating HTTP overhead and redundant data loading
- **Task-queue 懒加载**: Bootstrap returns lightweight project list (no `_tree_summary`); full task trees lazy-loaded in background after initial render
- **异步 I/O**: Added `aload_*` async wrappers that offload sync YAML disk reads to thread pool via `run_in_executor`, unblocking the event loop
- **Dirty-aware 缓存**: TTL cache (3s, matching sync tick interval) for `load_all_employees`, `load_tools`, `load_activity_log` — invalidated automatically on `mark_dirty()` to respect "磁盘即唯一真相源" principle

## Test plan
- [x] 12 new cache unit tests (TTL, invalidation, mark_dirty integration)
- [x] 3 new bootstrap endpoint tests (all sections, CEO filtering, named project exclusion)
- [x] All 2103 existing tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)