### PR TITLE
fix: EA auto-reply no longer auto-enabled on conversation open

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.589",
+  "version": "0.2.590",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.589"
+version = "0.2.590"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -5764,11 +5764,9 @@ async def open_ceo_conversation(node_id: str):
         broadcast_fn=ws_manager.broadcast,
     )
     register_session(session)
-    # Auto-enable EA auto-reply — EXCEPT for HR hiring requests (CEO must select candidates)
-    from onemancompany.core.config import HR_ID
-    is_hiring_request = employee_id == HR_ID
-    if not is_hiring_request:
-        session.set_ea_auto_reply(True, node.description or node.description_preview or "")
+    # EA auto-reply is OFF by default — CEO enables it via the sidebar checkbox
+    # (POST /api/ceo/inbox/{node_id}/ea-auto-reply). This prevents unwanted
+    # auto-replies when conversations are opened by schedule_auto_open_inbox().
 
     # Start conversation loop as background task
     spawn_background(_run_conversation_loop(session, node, tree, project_dir))


### PR DESCRIPTION
## Summary
- `open_ceo_conversation()` previously called `set_ea_auto_reply(True)` unconditionally for all non-HR requests
- Combined with `schedule_auto_open_inbox()` (PR #114), every CEO_REQUEST triggered EA auto-reply without CEO consent
- Now EA auto-reply is OFF by default — CEO must enable via sidebar checkbox

## Test plan
- [x] 2140 tests pass, 0 regressions
- [ ] Manual: create CEO_REQUEST, verify EA does NOT auto-reply until checkbox is toggled

🤖 Generated with [Claude Code](https://claude.com/claude-code)