### PR TITLE
fix: show company equipment tools in employee system prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.589",
+  "version": "0.2.590",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.589"
+version = "0.2.590"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -488,6 +488,17 @@ def get_employee_tools_prompt(employee_id: str) -> str:
                             content = f"[binary, {fpath.stat().st_size} bytes]"
                         parts.append(f"  - {fname}:\n```\n{content}\n```")
 
+    # List company equipment (template tools) accessible via use_tool()
+    # These are NOT langchain tools — employees call use_tool("tool_name") to access them.
+    equipment_tools = [
+        t for t in company_state.tools.values()
+        if not t.allowed_users or employee_id in t.allowed_users
+    ]
+    if equipment_tools:
+        parts.append("\n## Company Equipment (use via `use_tool(tool_name)`):")
+        for t in equipment_tools:
+            parts.append(f"- **{t.name}** ({t.id}): {t.description[:100] if t.description else 'No description'}")
+
     parts.append("\n### Tool Usage Rules — Internal vs External")
     parts.append(
         "- **Internal task dispatch**: Use dispatch_child() to assign work to employees. "


### PR DESCRIPTION
## Summary
Template tools (gmail, web_search, image_generation, etc.) from `company_state.tools` were not listed in the employee system prompt. Employees had `use_tool()` available as a LangChain function but didn't know what company tools existed to call it with.

**Root cause:** `get_employee_tools_prompt()` only listed `tool_registry` tools (langchain_module type). Template tools are company equipment accessed via `use_tool("tool_name")` but were invisible in the prompt.

**Fix:** Added a "Company Equipment" section to the prompt listing all template tools from `company_state.tools` that the employee is authorized to use, with name, ID, and description.

## Test plan
- [x] 2140 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)