### PR TITLE
fix: TalentMarket auto-reconnect on disconnected session

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.590",
+  "version": "0.2.591",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.590"
+version = "0.2.591"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/recruitment.py
+++ b/src/onemancompany/agents/recruitment.py
@@ -349,7 +349,11 @@ class TalentMarketClient:
     async def _call(self, tool_name: str, _retry: bool = True, **kwargs) -> dict:
         """Invoke an MCP tool, auto-injecting the API key. Auto-reconnects on connection error."""
         if not self._session:
-            raise RuntimeError("Not connected to Talent Market")
+            if self._url and self._api_key and _retry:
+                logger.info("[TalentMarket] Not connected, auto-connecting before call...")
+                await self._reconnect()
+            if not self._session:
+                raise RuntimeError("Not connected to Talent Market")
         kwargs["api_key"] = self._api_key
         logger.debug("[TalentMarket] calling tool={} args={}", tool_name,
                      {k: v[:30] + "..." if isinstance(v, str) and len(v) > 30 else v for k, v in kwargs.items() if k != "api_key"})


### PR DESCRIPTION
## Summary
`TalentMarketClient._call()` immediately raised `RuntimeError("Not connected to Talent Market")` when `_session` was None, even though it had saved URL + API key from a previous connection. This caused `cv_hire` to fail when the MCP SSE connection dropped between keepalive pings.

**Fix:** If `_session` is None but credentials exist, attempt `_reconnect()` before raising. Only raises if reconnection also fails.

## Test plan
- [x] 2140 tests pass, 0 regressions
- [ ] Manual: disconnect Talent Market, attempt hire, verify auto-reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)