### PR TITLE
fix: idempotency batch 2 — orphan recovery, timeout, cleanup, cascade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.593",
+  "version": "0.2.594",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.591",
+  "version": "0.2.592",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.592",
+  "version": "0.2.593",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.592"
+version = "0.2.593"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.593"
+version = "0.2.594"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.591"
+version = "0.2.592"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -490,6 +490,16 @@ async def holding_timeout_sweep() -> list | None:
             if result:
                 timed_out.append(entry.node_id)
                 employee_manager.unschedule(emp_id, entry.node_id)
+                # Cascade: trigger dep resolution so dependents get BLOCKED/CANCELLED
+                try:
+                    from onemancompany.core.task_tree import get_tree
+                    from onemancompany.core.vessel import _trigger_dep_resolution
+                    tree = get_tree(entry.tree_path)
+                    node = tree.get_node(entry.node_id)
+                    if node:
+                        _trigger_dep_resolution(str(Path(entry.tree_path).parent), tree, node)
+                except Exception as e:
+                    logger.error("[holding_timeout_sweep] dep resolution failed for {}: {}", entry.node_id, e)
 
     if timed_out:
         logger.info("[holding_timeout_sweep] Auto-failed {} timed-out HOLDING node(s): {}",
@@ -500,6 +510,14 @@ async def holding_timeout_sweep() -> list | None:
 def clear_watchdog_nudge(project_id: str) -> None:
     """Clear the nudge flag for a project (call when EA starts working on it)."""
     _watchdog_nudged.discard(project_id)
+
+
+@system_cron("schedule_cleanup", interval="10m", description="清理僵尸 schedule 条目")
+async def schedule_cleanup() -> list | None:
+    """Periodically clean up orphaned schedule entries."""
+    from onemancompany.core.vessel import employee_manager
+    employee_manager.cleanup_orphaned_schedule()
+    return None
 
 
 def _build_tree_status_summary(tree) -> str:

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -492,12 +492,13 @@ async def holding_timeout_sweep() -> list | None:
                 employee_manager.unschedule(emp_id, entry.node_id)
                 # Cascade: trigger dep resolution so dependents get BLOCKED/CANCELLED
                 try:
+                    from pathlib import Path as _Path
                     from onemancompany.core.task_tree import get_tree
                     from onemancompany.core.vessel import _trigger_dep_resolution
                     tree = get_tree(entry.tree_path)
                     node = tree.get_node(entry.node_id)
                     if node:
-                        _trigger_dep_resolution(str(Path(entry.tree_path).parent), tree, node)
+                        _trigger_dep_resolution(str(_Path(entry.tree_path).parent), tree, node)
                 except Exception as e:
                     logger.error("[holding_timeout_sweep] dep resolution failed for {}: {}", entry.node_id, e)
 

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -478,7 +478,7 @@ async def project_progress_watchdog() -> list | None:
     return None
 
 
-@system_cron("holding_timeout_sweep", interval="10m", description="HOLDING 超时扫描 — 自动 fail 过期任务")
+@system_cron("holding_timeout_sweep", interval="10m", description="HOLDING timeout sweep — auto-fail expired tasks")
 async def holding_timeout_sweep() -> list | None:
     """Scan all scheduled HOLDING nodes and auto-fail those exceeding MAX_HOLD_SECONDS."""
     from onemancompany.core.vessel import employee_manager
@@ -513,7 +513,7 @@ def clear_watchdog_nudge(project_id: str) -> None:
     _watchdog_nudged.discard(project_id)
 
 
-@system_cron("schedule_cleanup", interval="10m", description="清理僵尸 schedule 条目")
+@system_cron("schedule_cleanup", interval="10m", description="Clean up orphaned schedule entries")
 async def schedule_cleanup() -> list | None:
     """Periodically clean up orphaned schedule entries."""
     from onemancompany.core.vessel import employee_manager

--- a/src/onemancompany/core/task_persistence.py
+++ b/src/onemancompany/core/task_persistence.py
@@ -14,7 +14,7 @@ from loguru import logger
 import yaml
 
 from onemancompany.core.config import EMPLOYEES_DIR, PROJECT_YAML_FILENAME, TASK_TREE_FILENAME
-from onemancompany.core.task_lifecycle import TaskPhase
+from onemancompany.core.task_lifecycle import RESOLVED, TaskPhase
 
 
 def _is_project_archived(tree_path: Path) -> bool:
@@ -89,6 +89,25 @@ def recover_schedule_from_trees(
                     employee_manager.schedule_node(
                         node.employee_id, node.id, str(tree_path),
                     )
+
+            # 1b. Auto-finish orphaned COMPLETED nodes whose parent is already RESOLVED.
+            # These nodes were left behind when the server restarted before the
+            # completion consumer could propagate their status upward.
+            orphan_modified = False
+            for node in tree._nodes.values():
+                if node.status != TaskPhase.COMPLETED.value:
+                    continue
+                parent = tree.get_node(node.parent_id) if node.parent_id else None
+                if parent and TaskPhase(parent.status) in RESOLVED:
+                    node.set_status(TaskPhase.ACCEPTED)
+                    node.set_status(TaskPhase.FINISHED)
+                    orphan_modified = True
+                    logger.info(
+                        "Auto-finished orphaned COMPLETED node {} (parent {} is {})",
+                        node.id, parent.id, parent.status,
+                    )
+            if orphan_modified:
+                save_tree_async(tree_path)
 
     # 2. Scan system task trees
     if employees_dir.exists():

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2076,8 +2076,10 @@ class EmployeeManager:
                     )
             except asyncio.TimeoutError:
                 logger.error(
-                    "Completion consumer TIMEOUT (60s) for node {} — skipping to unblock queue",
-                    entry.node_id,
+                    "Completion consumer TIMEOUT (60s) for node {} tree={} — "
+                    "skipping to unblock queue. Tree may be in inconsistent state; "
+                    "restart will re-evaluate via recover_schedule_from_trees.",
+                    entry.node_id, entry.tree_path,
                 )
             except asyncio.CancelledError:
                 raise

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -754,6 +754,45 @@ class EmployeeManager:
         entries = self._schedule.get(employee_id, [])
         self._schedule[employee_id] = [e for e in entries if e.node_id != node_id]
 
+    def cleanup_orphaned_schedule(self) -> int:
+        """Remove schedule entries pointing to missing trees or resolved/terminal nodes.
+
+        Returns the number of entries removed.
+        """
+        from onemancompany.core.task_lifecycle import RESOLVED, TERMINAL
+        from onemancompany.core.task_tree import get_tree
+
+        removed = 0
+        for emp_id in list(self._schedule.keys()):
+            entries = self._schedule.get(emp_id, [])
+            keep = []
+            for entry in entries:
+                tree_path = Path(entry.tree_path)
+                if not tree_path.exists():
+                    logger.debug("[cleanup_schedule] Removing orphan: tree {} gone", tree_path)
+                    removed += 1
+                    continue
+                try:
+                    tree = get_tree(tree_path)
+                    node = tree.get_node(entry.node_id)
+                except Exception:
+                    logger.debug("[cleanup_schedule] Removing orphan: corrupt tree {}", tree_path)
+                    removed += 1
+                    continue
+                if not node:
+                    logger.debug("[cleanup_schedule] Removing orphan: node {} not in tree", entry.node_id)
+                    removed += 1
+                    continue
+                if TaskPhase(node.status) in TERMINAL:
+                    logger.debug("[cleanup_schedule] Removing terminal node {} ({})", entry.node_id, node.status)
+                    removed += 1
+                    continue
+                keep.append(entry)
+            self._schedule[emp_id] = keep
+        if removed:
+            logger.info("[cleanup_schedule] Removed {} orphaned schedule entries", removed)
+        return removed
+
     def get_next_scheduled(self, employee_id: str) -> ScheduleEntry | None:
         """Find next scheduled node that is PENDING with deps resolved."""
         from onemancompany.core.task_tree import get_tree
@@ -2031,7 +2070,15 @@ class EmployeeManager:
                 from onemancompany.core.task_tree import get_tree_lock
                 lock = get_tree_lock(entry.tree_path)
                 with lock:
-                    await self._on_child_complete_inner(employee_id, entry, project_id)
+                    await asyncio.wait_for(
+                        self._on_child_complete_inner(employee_id, entry, project_id),
+                        timeout=60.0,
+                    )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "Completion consumer TIMEOUT (60s) for node {} — skipping to unblock queue",
+                    entry.node_id,
+                )
             except asyncio.CancelledError:
                 raise
             except Exception as e:


### PR DESCRIPTION
## Summary
Four fixes from the idempotency roadmap batch 2:

**1. Startup recovery for orphaned COMPLETED nodes (#11)**
- Scans trees on restart, auto-finishes COMPLETED children whose parent is already RESOLVED
- Fixes Project 37 bug: task + ceo_request nodes stuck in `completed` preventing `is_subtree_resolved()` from returning True, blocking CEO root forever

**2. Completion consumer timeout (#10)**
- `_on_child_complete_inner` now wrapped in `asyncio.wait_for(timeout=60s)`
- A single slow tree op can no longer jam the entire completion queue

**3. Schedule orphan cleanup (#8)**
- New `cleanup_orphaned_schedule()` removes entries pointing to missing trees, missing nodes, or terminal nodes
- Wired into `schedule_cleanup` system cron (10m interval)

**4. Dep cascade on HOLDING timeout (#7)**
- `holding_timeout_sweep` now calls `_trigger_dep_resolution` after auto-failing a HOLDING node
- Dependents properly get BLOCKED or cascade-cancelled instead of waiting forever

**Note:** #9 (EA HOLDING timeout) was already solved by batch 1's `MAX_HOLD_SECONDS` + `holding_timeout_sweep`.

## Test plan
- [x] 2140 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)