### PR TITLE
fix: persist meeting agenda across page refresh

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -111,6 +111,12 @@ class AppController {
       document.getElementById('tool-count').textContent = `🔧 ${tools.length}`;
       const freeRooms = rooms.filter(r => !r.is_booked).length;
       document.getElementById('room-count').textContent = `🏢 ${freeRooms}/${rooms.length}`;
+      // Restore meeting agenda cache from room data (survives page refresh)
+      for (const room of rooms) {
+        if (room.agenda && room.agenda.items && room.agenda.items.length > 0) {
+          this._meetingAgendaCache[room.id] = room.agenda;
+        }
+      }
       // Refresh meeting modal if open
       if (this.viewingRoomId) {
         const room = rooms.find(r => r.id === this.viewingRoomId);

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -814,13 +814,18 @@ async def pull_meeting(
         ceo_queue: asyncio.Queue = asyncio.Queue()
         _ceo_meeting_queues[room.id] = ceo_queue
 
-        # Broadcast initial agenda to frontend
-        await _publish("meeting_agenda_update", {
-            "room_id": room.id,
-            "items": agenda_items,
-            "current_index": 0,
-            "completed": [],
-        })
+        # Persist + broadcast agenda to frontend
+        async def _update_agenda(items, current_index, completed):
+            agenda_data = {
+                "room_id": room.id,
+                "items": items,
+                "current_index": current_index,
+                "completed": completed,
+            }
+            room.agenda = agenda_data
+            await _publish("meeting_agenda_update", agenda_data)
+
+        await _update_agenda(agenda_items, 0, [])
 
         rounds_used = 0
 
@@ -829,12 +834,7 @@ async def pull_meeting(
             completed_indices: list[int] = []
             for item_idx, item_text in enumerate(agenda_items):
                 # Broadcast current agenda item
-                await _publish("meeting_agenda_update", {
-                    "room_id": room.id,
-                    "items": agenda_items,
-                    "current_index": item_idx,
-                    "completed": completed_indices,
-                })
+                await _update_agenda(agenda_items, item_idx, completed_indices)
                 await _chat(room.id, MEETING_SYSTEM_SENDER, SYSTEM_SENDER,
                             f"📋 Agenda item {item_idx + 1}/{len(agenda_items)}: {item_text}")
                 chat_history.append({"speaker": MEETING_SYSTEM_SENDER, "message": f"Now discussing: {item_text}"})
@@ -854,12 +854,7 @@ async def pull_meeting(
                 completed_indices.append(item_idx)
 
             # Broadcast all items completed
-            await _publish("meeting_agenda_update", {
-                "room_id": room.id,
-                "items": agenda_items,
-                "current_index": -1,
-                "completed": completed_indices,
-            })
+            await _update_agenda(agenda_items, -1, completed_indices)
             await _chat(room.id, MEETING_SYSTEM_SENDER, SYSTEM_SENDER, "All agenda items have been discussed. Meeting concluded.")
 
         else:
@@ -970,6 +965,7 @@ async def pull_meeting(
         room.is_booked = False
         room.booked_by = ""
         room.participants = []
+        room.agenda = {}  # Clear agenda on meeting end
         from onemancompany.core.store import save_room
         await save_room(room.id, {
             "is_booked": False,

--- a/src/onemancompany/core/state.py
+++ b/src/onemancompany/core/state.py
@@ -123,6 +123,8 @@ class MeetingRoom:
     booked_by: str = ""  # employee_id who booked it
     participants: list[str] = field(default_factory=list)  # employee_ids in the meeting
     is_booked: bool = False
+    # Active agenda (persisted so it survives page refresh)
+    agenda: dict = field(default_factory=dict)  # {items, current_index, completed}
 
     def to_dict(self) -> dict:
         return {
@@ -135,6 +137,7 @@ class MeetingRoom:
             "booked_by": self.booked_by,
             "participants": self.participants,
             "is_booked": self.is_booked,
+            "agenda": self.agenda,
         }
 
 


### PR DESCRIPTION
## Summary
Meeting agenda data was stored only in frontend JS memory (`_meetingAgendaCache`), lost on every page refresh.

**Fix:**
- Added `agenda` dict field to `MeetingRoom` dataclass
- Agenda updates now persist to `room.agenda` in `company_state` (in addition to WS broadcast)
- Frontend `bootstrap()` restores `_meetingAgendaCache` from room data
- Agenda cleared when meeting room is released

## Test plan
- [x] 2140 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)