### PR TITLE
fix: remove erroneous await on sync _check_holding_timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.594",
+  "version": "0.2.595",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.594"
+version = "0.2.595"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -486,7 +486,7 @@ async def holding_timeout_sweep() -> list | None:
     timed_out: list[str] = []
     for emp_id, entries in list(employee_manager._schedule.items()):
         for entry in list(entries):
-            result = await employee_manager._check_holding_timeout(entry.tree_path, entry.node_id)
+            result = employee_manager._check_holding_timeout(entry.tree_path, entry.node_id)
             if result:
                 timed_out.append(entry.node_id)
                 employee_manager.unschedule(emp_id, entry.node_id)


### PR DESCRIPTION
## Summary
`holding_timeout_sweep` used `await` on `_check_holding_timeout()` which is a sync method returning `bool`. This caused the entire cron to fail with `"object bool can't be used in 'await' expression"`, making the HOLDING timeout sweep non-functional.

**Fix:** Remove the `await` keyword.

## Test plan
- [x] 2140 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)