### PR TITLE
fix: persist meeting agenda to disk and restore on startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.595",
+  "version": "0.2.596",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.595"
+version = "0.2.596"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -823,6 +823,8 @@ async def pull_meeting(
                 "completed": completed,
             }
             room.agenda = agenda_data
+            from onemancompany.core.store import save_room
+            await save_room(room.id, {"agenda": agenda_data})
             await _publish("meeting_agenda_update", agenda_data)
 
         await _update_agenda(agenda_items, 0, [])
@@ -971,6 +973,7 @@ async def pull_meeting(
             "is_booked": False,
             "booked_by": "",
             "participants": [],
+            "agenda": {},
         })
         await _publish("meeting_released", {
             "room_id": room.id, "room_name": room.name,

--- a/src/onemancompany/agents/coo_agent.py
+++ b/src/onemancompany/agents/coo_agent.py
@@ -69,6 +69,7 @@ def _load_assets_from_disk() -> None:
                 capacity=data.get("capacity", 6),
                 position=tuple(data.get("position", [1, 8])),
                 sprite=data.get("sprite", "meeting_room"),
+                agenda=data.get("agenda", {}),
             )
 
 


### PR DESCRIPTION
## Summary
Meeting agenda was only persisted in memory (`company_state`), not written to room YAML on disk. Server restart during an active meeting would lose agenda state.

**Fix:**
- `_update_agenda()` now calls `save_room(room_id, {"agenda": ...})` on every update
- Meeting end `save_room()` includes `"agenda": {}` to clear on disk
- `_load_assets_from_disk()` restores `agenda` from room YAML data on startup

## Test plan
- [x] 2140 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)