### PR TITLE
fix: auto-opened inbox conversations enable EA auto-reply

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.599",
+  "version": "0.2.600",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.599"
+version = "0.2.600"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -122,8 +122,15 @@ def schedule_auto_open_inbox(node_id: str) -> None:
     async def _auto_open(nid: str):
         try:
             from onemancompany.api.routes import open_ceo_conversation
-            await open_ceo_conversation(nid)
+            result = await open_ceo_conversation(nid)
             logger.info("[auto_open_inbox] Opened CEO conversation for {}", nid)
+            # Auto-enable EA reply so the request is handled without CEO intervention
+            from onemancompany.core.ceo_conversation import get_session
+            session = get_session(nid)
+            if session:
+                description = result.get("description", "") if isinstance(result, dict) else ""
+                session.set_ea_auto_reply(True, description)
+                logger.info("[auto_open_inbox] EA auto-reply enabled for {}", nid)
         except Exception as _e:
             logger.warning("[auto_open_inbox] Failed for {}: {}", nid, _e)
 


### PR DESCRIPTION
## Summary
PR #115 correctly disabled EA auto-reply in `open_ceo_conversation()` (for manual CEO clicks). But `schedule_auto_open_inbox()` is the automated path that runs when a CEO_REQUEST is created — it should enable EA auto-reply so requests are handled without CEO intervention.

**Root cause:** `schedule_auto_open_inbox` → `open_ceo_conversation` (opens session) → EA auto-reply OFF → session hangs waiting for CEO who never clicks.

**Fix:** `_auto_open()` now calls `session.set_ea_auto_reply(True, description)` after opening the conversation, enabling the 2-second EA auto-reply timer.

**Result:**
- Auto-opened conversations (from dispatch_child/standalone/circuit breaker): EA auto-replies ✅
- Manually opened conversations (CEO clicks inbox item): EA auto-reply OFF by default, CEO toggles checkbox ✅

## Test plan
- [x] 2140 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)