### PR TITLE
fix: full-content activity log with more/less expand

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -861,13 +861,13 @@ class AppController {
       'meeting_released': (e) => ({ agent: 'COO', text: `Room released: ${e.room_name || ''}` }),
       'promotion': (e) => ({ agent: 'HR', text: `Promoted: ${e.name || ''}` }),
     };
-    const fallback = (e) => ({ agent: (e.type || 'SYS').toUpperCase(), text: `${(e.name || e.topic || e.task || e.type || '').substring(0, 60)}` });
+    const fallback = (e) => ({ agent: (e.type || 'SYS').toUpperCase(), text: `${e.name || e.topic || e.task || e.type || ''}` });
     const lines = [];
     for (const e of entries) {
       const { agent, text } = (typeMap[e.type] || fallback)(e);
       const ts = e.timestamp ? e.timestamp.substring(11, 19) : '        ';
       const color = this._logColors[agent.toLowerCase()] || '#666';
-      lines.push(`<span style="color:#444">${ts}</span> <span style="color:${color}">${this._escHtml(agent)}</span> ${this._escHtml(text)}`);
+      lines.push(this._fmtLogLine(ts, agent, color, text));
     }
     log.innerHTML = lines.join('\n');
   }
@@ -877,12 +877,18 @@ class AppController {
     if (!log) return;
     const time = new Date().toLocaleTimeString('zh-CN', { hour12: false, hour:'2-digit', minute:'2-digit', second:'2-digit' });
     const color = this._logColors[cssClass] || this._logColors[agent.toLowerCase()] || '#666';
-    const line = `<span style="color:#444">${time}</span> <span style="color:${color}">${this._escHtml(agent)}</span> ${this._escHtml(message)}`;
-    // Prepend new line (newest first)
+    const line = this._fmtLogLine(time, agent, color, message);
     log.innerHTML = line + '\n' + log.innerHTML;
-    // Keep manageable
     const lines = log.innerHTML.split('\n');
     if (lines.length > 100) log.innerHTML = lines.slice(0, 100).join('\n');
+  }
+
+  _fmtLogLine(ts, agent, color, text) {
+    const escaped = this._escHtml(text);
+    if (escaped.length <= 120) {
+      return `<span style="color:#444">${ts}</span> <span style="color:${color}">${this._escHtml(agent)}</span> ${escaped}`;
+    }
+    return `<span style="color:#444">${ts}</span> <span style="color:${color}">${this._escHtml(agent)}</span> ${escaped.substring(0, 120)}<span style="color:#4af;cursor:pointer" onclick="const f=this.nextElementSibling;f.style.display=f.style.display==='none'?'inline':'none';this.textContent=f.style.display==='none'?'…more':'…less'">…more</span><span style="display:none">${escaped.substring(120)}</span>`;
   }
 
   // ===== UI Bindings =====

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.617",
+  "version": "0.2.618",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.617"
+version = "0.2.618"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -543,7 +543,7 @@ class BaseAgentRunner:
         from langchain_core.messages import HumanMessage, SystemMessage
 
         self._set_status(STATUS_WORKING)
-        await self._publish("agent_thinking", {"message": f"{self.role} analyzing: {task[:80]}"})
+        await self._publish("agent_thinking", {"message": f"{self.role} analyzing: {task}"})
 
         prompt = self._build_full_prompt()
         messages_input = {
@@ -1138,7 +1138,7 @@ class EmployeeAgent(BaseAgentRunner):
 
     async def run(self, task: str) -> str:
         self._set_status(STATUS_WORKING)
-        await self._publish("agent_thinking", {"message": f"{self.role} analyzing: {task[:80]}"})
+        await self._publish("agent_thinking", {"message": f"{self.role} analyzing: {task}"})
 
         initial_msgs = [
             SystemMessage(content=self._build_full_prompt()),

--- a/src/onemancompany/agents/coo_agent.py
+++ b/src/onemancompany/agents/coo_agent.py
@@ -888,7 +888,7 @@ class COOAgent(BaseAgentRunner):
 
     async def run(self, task: str) -> str:
         self._set_status(STATUS_WORKING)
-        await self._publish("agent_thinking", {"message": f"COO analyzing: {task[:80]}"})
+        await self._publish("agent_thinking", {"message": f"COO analyzing: {task}"})
 
         result = await self._agent.ainvoke(
             {"messages": [

--- a/src/onemancompany/agents/cso_agent.py
+++ b/src/onemancompany/agents/cso_agent.py
@@ -256,7 +256,7 @@ class CSOAgent(BaseAgentRunner):
 
     async def run(self, task: str) -> str:
         self._set_status(STATUS_WORKING)
-        await self._publish("agent_thinking", {"message": f"CSO analyzing: {task[:80]}"})
+        await self._publish("agent_thinking", {"message": f"CSO analyzing: {task}"})
 
         result = await self._agent.ainvoke(
             {"messages": [

--- a/src/onemancompany/agents/ea_agent.py
+++ b/src/onemancompany/agents/ea_agent.py
@@ -40,7 +40,7 @@ class EAAgent(BaseAgentRunner):
 
     async def run(self, task: str) -> str:
         self._set_status(STATUS_WORKING)
-        await self._publish("agent_thinking", {"message": f"EA analyzing: {task[:80]}"})
+        await self._publish("agent_thinking", {"message": f"EA analyzing: {task}"})
 
         result = await self._agent.ainvoke(
             {"messages": [


### PR DESCRIPTION
## Summary
- Removed `[:80]` truncation from all `agent_thinking` event payloads (5 files)
- Activity log entries >120 chars now show clickable …more/…less toggle
- Extracted `_fmtLogLine()` helper shared by `logEntry()` and `_renderHistoricalActivityLog()`

## Test plan
- [x] 2135 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)