### PR TITLE
fix: holding timeout skips hiring, watchdog cooldown, default model

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -127,6 +127,8 @@ class AppController {
         this._renderHistoricalActivityLog(activity_log);
       }
       this._refreshCeoInbox();
+      // Restore pending candidate shortlist modal if HR submitted candidates
+      this._restorePendingCandidates();
       // Restore onboarding progress modal if there's an active onboarding
       this._restoreOnboardingProgress();
 
@@ -3263,6 +3265,28 @@ class AppController {
   }
 
   // ===== Candidate Selection (Boss Online) =====
+
+  async _restorePendingCandidates() {
+    try {
+      const resp = await fetch('/api/candidates/pending');
+      const data = await resp.json();
+      const batches = data.batches || {};
+      for (const [batchId, batch] of Object.entries(batches)) {
+        const candidates = batch.candidates || [];
+        if (candidates.length > 0) {
+          this.showCandidateSelection({
+            batch_id: batchId,
+            candidates,
+            roles: batch.roles || [],
+          });
+          break;  // Show one batch at a time
+        }
+      }
+    } catch (e) {
+      console.debug('[bootstrap] No pending candidates:', e);
+    }
+  }
+
   showCandidateSelection(payload) {
     this._candidateBatchId = payload.batch_id;
     this._candidateList = payload.candidates || [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.625",
+  "version": "0.2.626",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.620",
+  "version": "0.2.625",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.620"
+version = "0.2.625"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.625"
+version = "0.2.626"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -895,7 +895,7 @@ async def execute_hire(
     if not llm_model:
         from onemancompany.core.config import load_app_config
         _settings = load_app_config()
-        llm_model = _settings.default_llm_model if hasattr(_settings, 'default_llm_model') else ""
+        llm_model = _settings.get("default_llm_model", "") if isinstance(_settings, dict) else getattr(_settings, "default_llm_model", "")
 
     # Salary
     salary = compute_salary(llm_model) if llm_model else 0.0

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -891,6 +891,12 @@ async def execute_hire(
         department, DEFAULT_TOOL_PERMISSIONS_FALLBACK
     ))
 
+    # Default model from settings if not specified
+    if not llm_model:
+        from onemancompany.core.config import load_app_config
+        _settings = load_app_config()
+        llm_model = _settings.default_llm_model if hasattr(_settings, 'default_llm_model') else ""
+
     # Salary
     salary = compute_salary(llm_model) if llm_model else 0.0
 

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -3829,6 +3829,24 @@ async def decide_hiring_request(request_id: str, body: dict) -> dict:
 
 # ===== Candidate Selection =====
 
+@router.get("/api/candidates/pending")
+async def get_pending_candidates() -> dict:
+    """Return any pending candidate batches awaiting CEO selection.
+
+    Used by bootstrap to restore the shortlist modal after page refresh.
+    """
+    from onemancompany.agents.recruitment import pending_candidates
+    if not pending_candidates:
+        return {"batches": {}}
+    result = {}
+    for batch_id, candidates in pending_candidates.items():
+        result[batch_id] = {
+            "candidates": candidates,
+            "roles": [],  # roles info not persisted, frontend handles gracefully
+        }
+    return {"batches": result}
+
+
 @router.post("/api/candidates/hire")
 async def hire_candidate(body: HireRequest) -> dict:
     """CEO selects a candidate to hire from the shortlist.

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -501,7 +501,7 @@ class Settings(BaseSettings):
     minimax_api_key: str = ""
 
     # Default model
-    default_llm_model: str = "moonshotai/kimi-k2.5"
+    default_llm_model: str = "google/gemini-3.1-flash-lite-preview"
 
     # FastSkills MCP
     skillsmp_api_key: str = ""

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -264,7 +264,7 @@ system_cron_manager = SystemCronManager()
 # Handler implementations
 # ---------------------------------------------------------------------------
 
-@system_cron("heartbeat", interval="1m", description="员工 API 连接检测")
+@system_cron("heartbeat", interval="1m", description="Employee API connection check")
 async def heartbeat_check() -> list | None:
     from onemancompany.core.heartbeat import run_heartbeat_cycle
     from onemancompany.core.events import CompanyEvent
@@ -275,7 +275,7 @@ async def heartbeat_check() -> list | None:
     return None
 
 
-@system_cron("review_reminder", interval="5m", description="审批超时提醒")
+@system_cron("review_reminder", interval="5m", description="Review timeout reminder")
 async def review_reminder_check() -> list | None:
     from onemancompany.core.vessel import scan_overdue_reviews
     from onemancompany.core.events import CompanyEvent
@@ -290,7 +290,7 @@ async def review_reminder_check() -> list | None:
     return None
 
 
-@system_cron("config_reload", interval="30s", description="磁盘配置定期重载")
+@system_cron("config_reload", interval="30s", description="Disk config periodic reload")
 async def config_reload_check() -> list | None:
     from onemancompany.core.state import is_idle, reload_all_from_disk
 
@@ -308,7 +308,7 @@ async def config_reload_check() -> list | None:
 # ---------------------------------------------------------------------------
 
 
-@system_cron("talent_market_keepalive", interval="15s", description="Talent Market MCP 连接保活")
+@system_cron("talent_market_keepalive", interval="15s", description="Talent Market MCP keepalive")
 async def talent_market_keepalive() -> list | None:
     """Ping the Talent Market MCP server; reconnect if the session is dead."""
     from onemancompany.agents.recruitment import talent_market, start_talent_market
@@ -337,7 +337,7 @@ async def talent_market_keepalive() -> list | None:
 _watchdog_nudged: set[str] = set()
 
 
-@system_cron("project_progress_watchdog", interval="1m", description="项目进度看门狗 — 防止项目卡死")
+@system_cron("project_progress_watchdog", interval="10m", description="Project progress watchdog — prevent stuck projects")
 async def project_progress_watchdog() -> list | None:
     """Scan active projects; nudge EA to continue any that are stuck.
 
@@ -395,26 +395,31 @@ async def project_progress_watchdog() -> list | None:
             continue
 
         # Skip if there are still unfinished watchdog nudge subtrees
-        # (previous nudge spawned tasks that haven't completed yet)
-        has_active_nudge = any(
-            n.node_type == NodeType.WATCHDOG_NUDGE
-            and TaskPhase(n.status) not in RESOLVED
-            for n in active_nodes
-        )
-        if not has_active_nudge:
-            # Also check children of finished nudge nodes — they may have
-            # dispatched tasks that are still pending/processing
-            for n in active_nodes:
-                if n.node_type == NodeType.WATCHDOG_NUDGE:
-                    nudge_children = [
-                        tree.get_node(cid) for cid in n.children_ids
-                        if cid in tree._nodes
-                    ]
-                    if any(c and TaskPhase(c.status) not in RESOLVED for c in nudge_children):
-                        has_active_nudge = True
+        # OR if a nudge was recently completed (cooldown: 10 min)
+        from datetime import datetime as _dt
+        skip_nudge = False
+        for n in active_nodes:
+            if n.node_type != NodeType.WATCHDOG_NUDGE:
+                continue
+            # Unfinished nudge or its children
+            if TaskPhase(n.status) not in RESOLVED:
+                skip_nudge = True
+                break
+            nudge_children = [tree.get_node(cid) for cid in n.children_ids if cid in tree._nodes]
+            if any(c and TaskPhase(c.status) not in RESOLVED for c in nudge_children):
+                skip_nudge = True
+                break
+            # Recently finished nudge — cooldown to avoid spam
+            if n.completed_at:
+                try:
+                    completed = _dt.fromisoformat(n.completed_at)
+                    if (_dt.now() - completed).total_seconds() < 600:
+                        skip_nudge = True
                         break
-        if has_active_nudge:
-            logger.debug("[watchdog] Skipping {} — previous nudge subtree still active", project_id)
+                except (ValueError, TypeError) as _e:
+                    logger.debug("[watchdog] Invalid completed_at for nudge {}: {}", n.id, _e)
+        if skip_nudge:
+            logger.debug("[watchdog] Skipping {} — recent or active nudge", project_id)
             continue
 
         # Skip if all active nodes are resolved (project is done)

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -412,7 +412,7 @@ async def project_progress_watchdog() -> list | None:
             # Recently finished nudge — cooldown to avoid spam
             if n.completed_at:
                 try:
-                    completed = _dt.fromisoformat(n.completed_at)
+                    completed = _dt.fromisoformat(n.completed_at).replace(tzinfo=None)
                     if (_dt.now() - completed).total_seconds() < 600:
                         skip_nudge = True
                         break

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1563,6 +1563,11 @@ class EmployeeManager:
         if not node.hold_started_at:
             return False
 
+        # Skip timeout for holds that require human action (CEO/hiring)
+        hold_reason = node.hold_reason or ""
+        if "no_watchdog" in hold_reason or "batch_id" in hold_reason:
+            return False
+
         try:
             started = datetime.fromisoformat(node.hold_started_at)
         except (ValueError, TypeError):

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -597,7 +597,22 @@ def _step_execute(
         if tm_key:
             console.print("  [green]\u2714[/green] Talent Market API key saved")
 
-    # 4. Assign random default avatars to founding employees
+    # 4. Sync founding employees' llm_model to user-selected default
+    import yaml as _yaml
+    from onemancompany.core.config import FOUNDING_IDS, EMPLOYEES_DIR
+    _synced = 0
+    for _fid in FOUNDING_IDS:
+        _profile = EMPLOYEES_DIR / _fid / "profile.yaml"
+        if _profile.exists():
+            _pdata = _yaml.safe_load(_profile.read_text(encoding=ENCODING_UTF8)) or {}
+            if _pdata.get("llm_model") != model:
+                _pdata["llm_model"] = model
+                _profile.write_text(_yaml.dump(_pdata, default_flow_style=False, allow_unicode=True), encoding=ENCODING_UTF8)
+                _synced += 1
+    if _synced:
+        console.print(f"  [green]\u2714[/green] Founding employees model set to {model}")
+
+    # 5. Assign random default avatars to founding employees
     _assign_default_avatars(console)
 
     # 5. Generate MCP configs for founding employees


### PR DESCRIPTION
## Summary

**1. Holding timeout skip for human-action holds**
- `_check_holding_timeout` skips nodes where `hold_reason` contains `no_watchdog` (CEO requests) or `batch_id` (HR hiring awaiting CEO candidate selection)
- Previously these were auto-failed after 30 min even though they require CEO UI action

**2. Watchdog interval + cooldown**
- `project_progress_watchdog` interval changed from 1m to 10m
- Added 10-min cooldown after a nudge finishes before re-nudging
- All system cron descriptions translated to English

**3. Default model google/gemini-3.1-flash-lite-preview**
- Founding employees profile.yaml updated
- Config `default_llm_model` updated
- Onboarding init (`_step_execute`): patches all founding employees' `llm_model` to user-selected model during first install
- `execute_hire()`: falls back to `default_llm_model` for new hires when not specified

**4. Restore pending candidates on bootstrap**
- New `GET /api/candidates/pending` endpoint
- Frontend `_restorePendingCandidates()` auto-shows shortlist modal if HR submitted candidates before page refresh

## Test plan
- [x] 2135 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)