### PR TITLE
fix: all log displays use xterm.js terminal rendering

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -843,54 +843,52 @@ class AppController {
     this._fetchAndRenderRoster();
   }
 
-  // ===== Activity Log (terminal-style <pre>) =====
-  _logColors = {
-    ceo: '#4af', hr: '#fa4', coo: '#4a4', ea: '#fa4',
-    system: '#666', meeting: '#585', guidance: '#997',
+  // ===== Activity Log (xterm.js terminal) =====
+  _activityLogAnsi = {
+    ceo: ANSI.brightCyan, hr: ANSI.yellow, coo: ANSI.green, ea: ANSI.yellow,
+    system: ANSI.gray, meeting: ANSI.green, guidance: ANSI.dim,
+    routine: ANSI.dim, agent: ANSI.cyan,
+  }
+
+  _activityTypeMap = {
+    'pull_meeting': (e) => ({ agent: 'MEETING', text: `${e.topic || 'Meeting'} (${e.rounds || 0} rounds)` }),
+    'knowledge_deposited': (e) => ({ agent: 'SYSTEM', text: `Knowledge: ${e.name || ''}` }),
+    'employee_hired': (e) => ({ agent: 'HR', text: `New hire: ${e.name || ''} (${e.role || ''})` }),
+    'employee_fired': (e) => ({ agent: 'HR', text: `Departure: ${e.name || ''}` }),
+    'tool_added': (e) => ({ agent: 'COO', text: `New tool: ${e.name || ''}` }),
+    'ceo_task': (e) => ({ agent: 'CEO', text: `Task: ${(e.task || '').substring(0, 80)}` }),
+    'meeting_booked': (e) => ({ agent: 'COO', text: `Room booked: ${e.room_name || ''}` }),
+    'meeting_released': (e) => ({ agent: 'COO', text: `Room released: ${e.room_name || ''}` }),
+    'promotion': (e) => ({ agent: 'HR', text: `Promoted: ${e.name || ''}` }),
+  }
+
+  _ensureActivityXterm() {
+    if (this._activityXterm) return;
+    const el = document.getElementById('activity-log');
+    if (!el || typeof XTermLog === 'undefined') return;
+    el.innerHTML = '';
+    this._activityXterm = new XTermLog(el, { fontSize: 10 });
   }
 
   _renderHistoricalActivityLog(entries) {
-    const log = document.getElementById('log-entries');
-    if (!log) return;
-    const typeMap = {
-      'pull_meeting': (e) => ({ agent: 'MEETING', text: `${e.topic || 'Meeting'} (${e.rounds || 0} rounds)` }),
-      'knowledge_deposited': (e) => ({ agent: 'SYSTEM', text: `Knowledge: ${e.name || ''}` }),
-      'employee_hired': (e) => ({ agent: 'HR', text: `New hire: ${e.name || ''} (${e.role || ''})` }),
-      'employee_fired': (e) => ({ agent: 'HR', text: `Departure: ${e.name || ''}` }),
-      'tool_added': (e) => ({ agent: 'COO', text: `New tool: ${e.name || ''}` }),
-      'ceo_task': (e) => ({ agent: 'CEO', text: `Task: ${(e.task || '').substring(0, 60)}` }),
-      'meeting_booked': (e) => ({ agent: 'COO', text: `Room booked: ${e.room_name || ''}` }),
-      'meeting_released': (e) => ({ agent: 'COO', text: `Room released: ${e.room_name || ''}` }),
-      'promotion': (e) => ({ agent: 'HR', text: `Promoted: ${e.name || ''}` }),
-    };
+    this._ensureActivityXterm();
+    if (!this._activityXterm) return;
     const fallback = (e) => ({ agent: (e.type || 'SYS').toUpperCase(), text: `${e.name || e.topic || e.task || e.type || ''}` });
-    const lines = [];
     for (const e of entries) {
-      const { agent, text } = (typeMap[e.type] || fallback)(e);
+      const { agent, text } = (this._activityTypeMap[e.type] || fallback)(e);
       const ts = e.timestamp ? e.timestamp.substring(11, 19) : '        ';
-      const color = this._logColors[agent.toLowerCase()] || '#666';
-      lines.push(this._fmtLogLine(ts, agent, color, text));
+      const color = this._activityLogAnsi[agent.toLowerCase()] || ANSI.gray;
+      this._activityXterm.writeln(`${ANSI.gray}${ts}${ANSI.reset} ${color}${agent}${ANSI.reset} ${text}`);
     }
-    log.innerHTML = lines.join('\n');
   }
 
   logEntry(agent, message, cssClass = 'system') {
-    const log = document.getElementById('log-entries');
-    if (!log) return;
+    this._ensureActivityXterm();
+    if (!this._activityXterm) return;
     const time = new Date().toLocaleTimeString('zh-CN', { hour12: false, hour:'2-digit', minute:'2-digit', second:'2-digit' });
-    const color = this._logColors[cssClass] || this._logColors[agent.toLowerCase()] || '#666';
-    const line = this._fmtLogLine(time, agent, color, message);
-    log.innerHTML = line + '\n' + log.innerHTML;
-    const lines = log.innerHTML.split('\n');
-    if (lines.length > 100) log.innerHTML = lines.slice(0, 100).join('\n');
-  }
-
-  _fmtLogLine(ts, agent, color, text) {
-    const escaped = this._escHtml(text);
-    if (escaped.length <= 120) {
-      return `<span style="color:#444">${ts}</span> <span style="color:${color}">${this._escHtml(agent)}</span> ${escaped}`;
-    }
-    return `<span style="color:#444">${ts}</span> <span style="color:${color}">${this._escHtml(agent)}</span> ${escaped.substring(0, 120)}<span style="color:#4af;cursor:pointer" onclick="const f=this.nextElementSibling;f.style.display=f.style.display==='none'?'inline':'none';this.textContent=f.style.display==='none'?'…more':'…less'">…more</span><span style="display:none">${escaped.substring(120)}</span>`;
+    const color = this._activityLogAnsi[cssClass] || this._activityLogAnsi[agent.toLowerCase()] || ANSI.gray;
+    this._activityXterm.writeln(`${ANSI.gray}${time}${ANSI.reset} ${color}${agent}${ANSI.reset} ${message}`);
+    this._activityXterm.scrollToBottom();
   }
 
   // ===== UI Bindings =====
@@ -1820,6 +1818,7 @@ class AppController {
     this.viewingEmployeeId = null;
     this._empNodeTrace = null;
     if (this._empXterm) { this._empXterm.dispose(); this._empXterm = null; }
+    if (this._empProgressXterm) { this._empProgressXterm.dispose(); this._empProgressXterm = null; }
     clearTimeout(this._logRefetchTimer);
     this._stopTaskBoardPolling();
     document.getElementById('employee-modal').classList.add('hidden');
@@ -1903,27 +1902,32 @@ class AppController {
     try {
       const resp = await fetch(`/api/employee/${empId}/progress-log?limit=30`);
       const data = await resp.json();
-      this._renderProgressLog(data.entries || []);
+      const entries = data.entries || [];
+      const el = document.getElementById('emp-detail-progress');
+      if (!el) return;
+
+      if (entries.length > 0 && typeof XTermLog !== 'undefined') {
+        if (!this._empProgressXterm) {
+          el.innerHTML = '';
+          this._empProgressXterm = new XTermLog(el, { fontSize: 10 });
+        }
+        this._empProgressXterm.clear();
+        this._empProgressXterm.writeln(`${ANSI.dim}── Work History (completed task summaries) ──${ANSI.reset}`);
+        for (const e of entries) {
+          const ts = e.timestamp ? e.timestamp.substring(5, 16).replace('T', ' ') : '';
+          const content = e.content || '';
+          if (content.startsWith('Completed:')) {
+            this._empProgressXterm.writeln(`${ANSI.gray}${ts}${ANSI.reset} ${ANSI.green}${content}${ANSI.reset}`);
+          } else {
+            this._empProgressXterm.writeln(`${ANSI.gray}${ts}${ANSI.reset} ${content}`);
+          }
+        }
+      } else {
+        el.innerHTML = '<span class="empty-hint">No work history</span>';
+      }
     } catch (err) {
       console.error('Progress log fetch error:', err);
     }
-  }
-
-  _renderProgressLog(entries) {
-    const el = document.getElementById('emp-detail-progress');
-    if (!el) return;
-    if (!entries || entries.length === 0) {
-      el.innerHTML = '<span class="empty-hint">No work history</span>';
-      return;
-    }
-    let html = '';
-    for (const e of entries) {
-      const ts = e.timestamp ? e.timestamp.substring(5, 16).replace('T', ' ') : '';
-      html += `<div style="font-size:11px;padding:2px 0;border-bottom:1px solid #222">`;
-      html += `<span style="color:#888;margin-right:6px">${ts}</span>`;
-      html += `<span>${this._escHtml(e.content || '')}</span></div>`;
-    }
-    el.innerHTML = html;
   }
 
   _renderTaskBoard(tasks, counts) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -130,9 +130,7 @@
         <h3 class="pixel-title">ACTIVITY LOG</h3>
       </div>
       <div id="activity-body" class="collapsible-body collapsible-flex">
-        <div id="activity-log" style="background:#0a0a0a;overflow-y:auto;flex:1">
-          <pre id="log-entries" style="margin:0;padding:6px 8px;font-family:'JetBrains Mono','Fira Code','SF Mono',monospace;font-size:10px;line-height:1.5;color:#888;white-space:pre-wrap;word-break:break-word"></pre>
-        </div>
+        <div id="activity-log" style="background:#0a0a0a;overflow-y:auto;flex:1"></div>
       </div>
     </div>
   </div>

--- a/frontend/task-tree.js
+++ b/frontend/task-tree.js
@@ -416,16 +416,24 @@ class TaskTreeRenderer {
                 if (logContent.classList.contains('hidden')) {
                     logContent.classList.remove('hidden');
                     el.innerHTML = '&#9660; Execution Log';
-                    // Use NodeTraceView for brutalist rendering
-                    if (typeof NodeTraceView !== 'undefined') {
-                        const traceView = new NodeTraceView(logContent);
-                        traceView.load(nodeId, nodeData.project_dir || '');
+                    // Use xterm.js for terminal rendering
+                    if (typeof XTermLog !== 'undefined') {
+                        logContent.innerHTML = '';
+                        const xterm = new XTermLog(logContent, { fontSize: 11 });
+                        const projectDir = nodeData.project_dir || '';
+                        const qs = projectDir ? `?project_dir=${encodeURIComponent(projectDir)}&tail=200` : '?tail=200';
+                        fetch(`/api/node/${nodeId}/logs${qs}`)
+                            .then(r => r.json())
+                            .then(data => { xterm.renderLogs(data.logs || []); })
+                            .catch(() => { xterm.writeln('\x1b[31mFailed to load logs\x1b[0m'); });
+                        logContent._xterm = xterm;
                     } else {
-                        logContent.innerHTML = '<div style="color:#666;padding:8px">Trace viewer not loaded</div>';
+                        logContent.innerHTML = '<div style="color:#666;padding:8px">Terminal not loaded</div>';
                     }
                 } else {
                     logContent.classList.add('hidden');
                     el.innerHTML = '&#9654; Execution Log';
+                    if (logContent._xterm) { logContent._xterm.dispose(); logContent._xterm = null; }
                 }
             });
         });

--- a/frontend/task-tree.js
+++ b/frontend/task-tree.js
@@ -425,7 +425,7 @@ class TaskTreeRenderer {
                         fetch(`/api/node/${nodeId}/logs${qs}`)
                             .then(r => r.json())
                             .then(data => { xterm.renderLogs(data.logs || []); })
-                            .catch(() => { xterm.writeln('\x1b[31mFailed to load logs\x1b[0m'); });
+                            .catch(() => { xterm.writeln(`${ANSI.red}Failed to load logs${ANSI.reset}`); });
                         logContent._xterm = xterm;
                     } else {
                         logContent.innerHTML = '<div style="color:#666;padding:8px">Terminal not loaded</div>';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.628",
+  "version": "0.2.629",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.626",
+  "version": "0.2.628",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.628"
+version = "0.2.629"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.626"
+version = "0.2.628"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary

Unified all log/history displays to use xterm.js terminal rendering.

### Activity Log (right sidebar)
- Replaced `<pre>` + innerHTML with lazy-created XTermLog instance
- `logEntry()` writes ANSI-colored lines directly to terminal
- Agent names colored by role (CEO=cyan, HR=yellow, COO=green)
- Historical entries rendered via same xterm instance on bootstrap

### Work History (employee detail)
- XTermLog with completed tasks in green ANSI
- Header line: "── Work History (completed task summaries) ──"
- Proper `dispose()` on modal close

### D3 Task Tree node detail
- Execution Log toggle now uses XTermLog instead of NodeTraceView
- Fetches from `/api/node/{id}/logs` and renders via `xterm.renderLogs()`
- Proper `dispose()` on collapse

### Result
All log displays now share the same visual language: xterm.js terminal with ANSI colors on #0a0a0a background. No more mixed rendering (HTML divs vs `<pre>` vs xterm).

## Test plan
- [x] 2135 tests pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)