### PR TITLE
fix: inbox complete fallback, report confirm path, remove content truncation

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4091,7 +4091,7 @@ class AppController {
             html += `<span style="color:var(--pixel-green);">${entry.employee_id}</span> `;
             html += `<span style="color:var(--pixel-yellow);">${entry.action}</span>`;
             if (entry.detail) {
-              html += `<div style="color:var(--pixel-white);margin-top:1px;">${entry.detail.substring(0, 200)}${entry.detail.length > 200 ? '...' : ''}</div>`;
+              html += `<div style="color:var(--pixel-white);margin-top:1px;">${this._escHtml(entry.detail)}</div>`;
             }
             html += `</div>`;
           }
@@ -6540,7 +6540,7 @@ class AppController {
           detailHtml += `<div class="task-result-report md-rendered">${this._renderMarkdown(taskResult)}</div>`;
         } else if (doc.output) {
           detailHtml += `<div style="font-size:7px;color:var(--pixel-cyan);margin:8px 0 3px;">Output</div>`;
-          detailHtml += `<div style="font-size:5px;color:var(--pixel-white);background:var(--bg-dark);padding:4px;border:1px solid var(--border);max-height:80px;overflow-y:auto;">${this._escHtml(doc.output).substring(0, 500)}</div>`;
+          detailHtml += `<div style="font-size:5px;color:var(--pixel-white);background:var(--bg-dark);padding:4px;border:1px solid var(--border);max-height:80px;overflow-y:auto;">${this._escHtml(doc.output)}</div>`;
         }
 
         const timeline = doc.timeline || [];
@@ -6554,7 +6554,7 @@ class AppController {
             detailHtml += `<span style="color:var(--pixel-green);">${entry.employee_id}</span> `;
             detailHtml += `<span style="color:var(--pixel-yellow);">${entry.action}</span>`;
             if (entry.detail) {
-              detailHtml += `<div style="color:var(--pixel-white);margin-top:1px;">${this._escHtml(entry.detail.substring(0, 150))}${entry.detail.length > 150 ? '...' : ''}</div>`;
+              detailHtml += `<div style="color:var(--pixel-white);margin-top:1px;">${this._escHtml(entry.detail)}</div>`;
             }
             detailHtml += `</div>`;
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.633",
+  "version": "0.2.634",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.635",
+  "version": "0.2.636",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.634",
+  "version": "0.2.635",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.634"
+version = "0.2.635"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.633"
+version = "0.2.634"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.635"
+version = "0.2.636"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -6072,11 +6072,19 @@ async def upload_ceo_attachment(node_id: str, file: UploadFile):
 async def complete_ceo_conversation(node_id: str):
     """CEO marks conversation as complete."""
     session = get_session(node_id)
-    if not session:
-        raise HTTPException(status_code=404, detail="No active conversation")
+    if session:
+        await session.complete()
+        return {"status": "completing", "node_id": node_id}
 
-    await session.complete()
-    return {"status": "completing", "node_id": node_id}
+    # No active session — complete the node directly (CEO never opened
+    # a conversation, or session was already cleaned up).
+    node, tree, project_dir = _find_ceo_node(node_id)
+    await _complete_ceo_request(
+        node, tree, project_dir,
+        target_status=TaskPhase.ACCEPTED,
+        notes="CEO completed (no active session)",
+    )
+    return {"status": "completed", "node_id": node_id}
 
 
 @router.post("/api/ceo/inbox/{node_id}/confirm")
@@ -6138,7 +6146,7 @@ async def toggle_ea_auto_reply(node_id: str, body: dict):
     return {"status": "ok", "ea_auto_reply": enabled}
 
 
-@router.post("/api/ceo/report/{project_id}/confirm")
+@router.post("/api/ceo/report/{project_id:path}/confirm")
 async def confirm_ceo_report(project_id: str):
     """CEO confirms a pending project completion report (early confirmation)."""
     from onemancompany.core.vessel import employee_manager

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -6079,6 +6079,8 @@ async def complete_ceo_conversation(node_id: str):
     # No active session — complete the node directly (CEO never opened
     # a conversation, or session was already cleaned up).
     node, tree, project_dir = _find_ceo_node(node_id)
+    if node.status in (TaskPhase.ACCEPTED.value, TaskPhase.FINISHED.value, TaskPhase.CANCELLED.value):
+        raise HTTPException(status_code=409, detail=f"Node already {node.status}")
     await _complete_ceo_request(
         node, tree, project_dir,
         target_status=TaskPhase.ACCEPTED,

--- a/tests/unit/api/test_ceo_inbox_routes.py
+++ b/tests/unit/api/test_ceo_inbox_routes.py
@@ -70,7 +70,28 @@ class TestCompleteConversation:
     """POST /api/ceo/inbox/{node_id}/complete"""
 
     @patch("onemancompany.api.routes.get_session")
-    def test_rejects_if_no_session(self, mock_get):
+    def test_completes_via_session(self, mock_get):
+        from starlette.testclient import TestClient
+        from onemancompany.api.routes import router
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        mock_session = MagicMock()
+        mock_session.complete = AsyncMock()
+        mock_get.return_value = mock_session
+
+        resp = client.post("/api/ceo/inbox/xyz/complete")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "completing"
+        mock_session.complete.assert_awaited_once()
+
+    @patch("onemancompany.api.routes._complete_ceo_request", new_callable=AsyncMock)
+    @patch("onemancompany.api.routes._find_ceo_node")
+    @patch("onemancompany.api.routes.get_session")
+    def test_fallback_completes_node_directly_when_no_session(self, mock_get, mock_find, mock_complete):
         from starlette.testclient import TestClient
         from onemancompany.api.routes import router
         from fastapi import FastAPI
@@ -80,5 +101,31 @@ class TestCompleteConversation:
         client = TestClient(app)
 
         mock_get.return_value = None
-        resp = client.post("/api/ceo/inbox/xyz/complete")
-        assert resp.status_code == 404
+        mock_node = MagicMock()
+        mock_node.status = "processing"
+        mock_find.return_value = (mock_node, MagicMock(), "/tmp/proj")
+
+        resp = client.post("/api/ceo/inbox/node123/complete")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "completed"
+        mock_complete.assert_awaited_once()
+
+    @patch("onemancompany.api.routes._find_ceo_node")
+    @patch("onemancompany.api.routes.get_session")
+    def test_rejects_already_finished_node(self, mock_get, mock_find):
+        from starlette.testclient import TestClient
+        from onemancompany.api.routes import router
+        from fastapi import FastAPI
+
+        app = FastAPI()
+        app.include_router(router)
+        client = TestClient(app)
+
+        mock_get.return_value = None
+        mock_node = MagicMock()
+        mock_node.status = "finished"
+        mock_find.return_value = (mock_node, MagicMock(), "/tmp/proj")
+
+        resp = client.post("/api/ceo/inbox/node123/complete")
+        assert resp.status_code == 409
+        assert "already finished" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

- **Inbox complete 404 fix**: `/api/ceo/inbox/{node_id}/complete` now falls back to `_complete_ceo_request()` when no active conversation session exists, instead of returning 404. Handles cases where CEO never opened the chat or session was already cleaned up.

- **Report confirm 405 fix**: `/api/ceo/report/{project_id}/confirm` uses `{project_id:path}` parameter type to handle project IDs containing slashes (e.g. `iter_001/confirm` was being parsed as path segments, causing 405 Method Not Allowed).

- **Content truncation removed**: CEO report output (was 500 chars), timeline entry details (was 150/200 chars) now display in full without truncation.

## Changes

- `src/onemancompany/api/routes.py`: `complete_ceo_conversation()` fallback to direct node completion; `confirm_ceo_report()` path parameter type fix
- `frontend/app.js`: Remove `.substring(0, N)` truncation on `doc.output` (500), `entry.detail` (150/200); add missing `_escHtml()` call

## Test plan

- [ ] Click "Complete" on a CEO inbox item that was never opened — should succeed (not 404)
- [ ] Confirm a project report with slash-containing project ID — should succeed (not 405)
- [ ] Verify CEO report and timeline entries show full content without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)