### PR TITLE
feat: background task system — agent tools + management UI

### DIFF
--- a/docs/google5575e9099405f85b.html
+++ b/docs/google5575e9099405f85b.html
@@ -1,0 +1,1 @@
+google-site-verification: google5575e9099405f85b.html

--- a/docs/superpowers/plans/2026-03-26-background-tasks.md
+++ b/docs/superpowers/plans/2026-03-26-background-tasks.md
@@ -1,0 +1,1431 @@
+# Background Task System Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add agent tools to launch/check/stop long-running background processes, with a global management UI.
+
+**Architecture:** `BackgroundTaskManager` singleton manages async subprocesses with stdout→disk logging. Three agent tools (start/check/stop) registered as base category. Split-panel modal with XTermLog output viewer.
+
+**Tech Stack:** Python asyncio subprocess, YAML persistence, vanilla JS modal, xterm.js
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/onemancompany/core/background_tasks.py` | BackgroundTaskManager singleton + BackgroundTask dataclass |
+| Create | `tests/unit/core/test_background_tasks.py` | Manager unit tests |
+| Create | `tests/unit/api/test_background_task_routes.py` | API route tests |
+| Modify | `src/onemancompany/core/models.py` | Add BACKGROUND_TASK_UPDATE to EventType |
+| Modify | `src/onemancompany/agents/common_tools.py` | 3 new tools + registration |
+| Modify | `src/onemancompany/api/routes.py` | 3 new REST endpoints |
+| Modify | `frontend/index.html` | Modal HTML + toolbar button |
+| Modify | `frontend/app.js` | Modal logic, XTermLog rendering, WebSocket handler |
+| Modify | `frontend/style.css` | Modal styles |
+
+---
+
+### Task 1: BackgroundTaskManager — Data Model + Persistence
+
+**Files:**
+- Create: `src/onemancompany/core/background_tasks.py`
+- Create: `tests/unit/core/test_background_tasks.py`
+
+- [ ] **Step 1: Write failing tests for data model and persistence**
+
+```python
+# tests/unit/core/test_background_tasks.py
+"""Tests for BackgroundTaskManager."""
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+import yaml
+
+
+class TestBackgroundTaskDataModel:
+    """BackgroundTask dataclass + YAML serialization."""
+
+    def test_create_task(self):
+        from onemancompany.core.background_tasks import BackgroundTask
+        task = BackgroundTask(
+            id="abc12345",
+            command="npm run dev",
+            description="Dev server",
+            working_dir="/tmp",
+            started_by="emp001",
+        )
+        assert task.id == "abc12345"
+        assert task.status == "running"
+        assert task.pid is None
+        assert task.port is None
+
+    def test_to_dict(self):
+        from onemancompany.core.background_tasks import BackgroundTask
+        task = BackgroundTask(
+            id="abc12345",
+            command="npm run dev",
+            description="Dev server",
+            working_dir="/tmp",
+            started_by="emp001",
+        )
+        d = task.to_dict()
+        assert d["id"] == "abc12345"
+        assert d["command"] == "npm run dev"
+        assert d["status"] == "running"
+
+    def test_from_dict(self):
+        from onemancompany.core.background_tasks import BackgroundTask
+        d = {
+            "id": "abc12345",
+            "command": "npm run dev",
+            "description": "Dev server",
+            "working_dir": "/tmp",
+            "started_by": "emp001",
+            "started_at": "2026-03-26T14:00:00",
+            "status": "completed",
+            "pid": 12345,
+            "returncode": 0,
+            "ended_at": "2026-03-26T14:05:00",
+            "port": 3000,
+            "address": "http://localhost:3000",
+        }
+        task = BackgroundTask.from_dict(d)
+        assert task.id == "abc12345"
+        assert task.status == "completed"
+        assert task.port == 3000
+
+
+class TestPortDetection:
+    """Port extraction from command and output."""
+
+    def test_detect_port_from_command_long_flag(self):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+        assert BackgroundTaskManager._detect_port_from_command("npm run dev --port 3000") == 3000
+
+    def test_detect_port_from_command_short_flag(self):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+        assert BackgroundTaskManager._detect_port_from_command("python -m http.server -p 8080") == 8080
+
+    def test_detect_port_from_command_equals(self):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+        assert BackgroundTaskManager._detect_port_from_command("serve --port=4200") == 4200
+
+    def test_detect_port_from_command_none(self):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+        assert BackgroundTaskManager._detect_port_from_command("echo hello") is None
+
+
+class TestBackgroundTaskManagerPersistence:
+    """YAML save/load."""
+
+    def test_save_and_load(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager, BackgroundTask
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        task = BackgroundTask(
+            id="t1", command="echo hi", description="test",
+            working_dir="/tmp", started_by="emp001",
+        )
+        task.pid = 999
+        mgr._tasks["t1"] = task
+        mgr._save()
+
+        mgr2 = BackgroundTaskManager(data_dir=tmp_path)
+        mgr2._load()
+        assert "t1" in mgr2._tasks
+        assert mgr2._tasks["t1"].command == "echo hi"
+
+    def test_load_marks_stale_running_as_stopped(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager, BackgroundTask
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        task = BackgroundTask(
+            id="t1", command="sleep 999", description="stale",
+            working_dir="/tmp", started_by="emp001",
+        )
+        task.status = "running"
+        task.pid = 999999  # non-existent PID
+        mgr._tasks["t1"] = task
+        mgr._save()
+
+        mgr2 = BackgroundTaskManager(data_dir=tmp_path)
+        mgr2._load()
+        assert mgr2._tasks["t1"].status == "stopped"
+
+
+class TestConcurrencyLimit:
+    """Max 5 concurrent tasks."""
+
+    def test_running_count(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager, BackgroundTask
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        for i in range(5):
+            t = BackgroundTask(id=f"t{i}", command=f"cmd{i}", description="",
+                               working_dir="/tmp", started_by="emp001")
+            t.status = "running"
+            mgr._tasks[t.id] = t
+        assert mgr.running_count == 5
+        assert mgr.can_launch is False
+
+    def test_completed_tasks_dont_count(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager, BackgroundTask
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        t = BackgroundTask(id="t1", command="cmd", description="",
+                           working_dir="/tmp", started_by="emp001")
+        t.status = "completed"
+        mgr._tasks["t1"] = t
+        assert mgr.running_count == 0
+        assert mgr.can_launch is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/unit/core/test_background_tasks.py -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement BackgroundTask dataclass + BackgroundTaskManager persistence**
+
+```python
+# src/onemancompany/core/background_tasks.py
+"""Background task manager — launch and manage long-running processes.
+
+Singleton `background_task_manager` manages async subprocesses.
+State persisted to company/background_tasks.yaml.
+Output logs at company/background_tasks/{task_id}/output.log.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+from loguru import logger
+
+MAX_CONCURRENT = 5
+_TASKS_FILENAME = "background_tasks.yaml"
+
+
+@dataclass
+class BackgroundTask:
+    id: str
+    command: str
+    description: str
+    working_dir: str
+    started_by: str
+    started_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    status: str = "running"  # running | completed | failed | stopped
+    pid: int | None = None
+    returncode: int | None = None
+    ended_at: str | None = None
+    port: int | None = None
+    address: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "command": self.command,
+            "description": self.description,
+            "working_dir": self.working_dir,
+            "started_by": self.started_by,
+            "started_at": self.started_at,
+            "status": self.status,
+            "pid": self.pid,
+            "returncode": self.returncode,
+            "ended_at": self.ended_at,
+            "port": self.port,
+            "address": self.address,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> BackgroundTask:
+        return cls(
+            id=d["id"],
+            command=d["command"],
+            description=d.get("description", ""),
+            working_dir=d.get("working_dir", ""),
+            started_by=d.get("started_by", ""),
+            started_at=d.get("started_at", ""),
+            status=d.get("status", "running"),
+            pid=d.get("pid"),
+            returncode=d.get("returncode"),
+            ended_at=d.get("ended_at"),
+            port=d.get("port"),
+            address=d.get("address"),
+        )
+
+
+class BackgroundTaskManager:
+    """Manages long-running background processes."""
+
+    def __init__(self, data_dir: Path | None = None):
+        if data_dir is None:
+            from onemancompany.core.config import COMPANY_DIR
+            data_dir = COMPANY_DIR
+        self._data_dir = Path(data_dir)
+        self._tasks: dict[str, BackgroundTask] = {}
+        self._processes: dict[str, "asyncio.subprocess.Process"] = {}
+        self._monitors: dict[str, "asyncio.Task"] = {}
+
+    @property
+    def running_count(self) -> int:
+        return sum(1 for t in self._tasks.values() if t.status == "running")
+
+    @property
+    def can_launch(self) -> bool:
+        return self.running_count < MAX_CONCURRENT
+
+    def get_task(self, task_id: str) -> BackgroundTask | None:
+        return self._tasks.get(task_id)
+
+    def get_all(self) -> list[BackgroundTask]:
+        return sorted(self._tasks.values(), key=lambda t: t.started_at, reverse=True)
+
+    def output_log_path(self, task_id: str) -> Path:
+        return self._data_dir / "background_tasks" / task_id / "output.log"
+
+    def _yaml_path(self) -> Path:
+        return self._data_dir / _TASKS_FILENAME
+
+    def _save(self) -> None:
+        """Atomic save to YAML."""
+        import tempfile
+        path = self._yaml_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = {"tasks": [t.to_dict() for t in self._tasks.values()]}
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".yaml")
+        try:
+            with os.fdopen(fd, "w") as f:
+                yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+            os.replace(tmp, str(path))
+        except Exception:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
+
+    def _load(self) -> None:
+        """Load tasks from YAML. Mark stale running tasks as stopped."""
+        path = self._yaml_path()
+        if not path.exists():
+            return
+        try:
+            with open(path) as f:
+                data = yaml.safe_load(f) or {}
+        except Exception as e:
+            logger.warning("Failed to load background tasks: {}", e)
+            return
+        for d in data.get("tasks", []):
+            task = BackgroundTask.from_dict(d)
+            if task.status == "running":
+                # Process can't survive restart — mark as stopped
+                if not self._is_pid_alive(task.pid):
+                    task.status = "stopped"
+                    task.ended_at = datetime.now(timezone.utc).isoformat()
+                    logger.info("[bg_tasks] Marked stale task {} as stopped (PID {} gone)",
+                                task.id, task.pid)
+            self._tasks[task.id] = task
+        self._save()
+
+    @staticmethod
+    def _is_pid_alive(pid: int | None) -> bool:
+        if pid is None:
+            return False
+        try:
+            os.kill(pid, 0)
+            return True
+        except (OSError, ProcessLookupError):
+            return False
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/core/test_background_tasks.py -v`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/onemancompany/core/background_tasks.py tests/unit/core/test_background_tasks.py
+git commit -m "feat: BackgroundTaskManager data model + YAML persistence"
+```
+
+---
+
+### Task 2: BackgroundTaskManager — Process Launch + Monitor + Terminate
+
+**Files:**
+- Modify: `src/onemancompany/core/background_tasks.py`
+- Modify: `src/onemancompany/core/models.py`
+- Modify: `tests/unit/core/test_background_tasks.py`
+
+- [ ] **Step 1: Add BACKGROUND_TASK_UPDATE to EventType**
+
+In `src/onemancompany/core/models.py`, add to the `EventType` enum:
+
+```python
+    BACKGROUND_TASK_UPDATE = "background_task_update"
+```
+
+- [ ] **Step 2: Write failing tests for launch + terminate**
+
+Append to `tests/unit/core/test_background_tasks.py`:
+
+```python
+import asyncio
+
+
+class TestLaunchTask:
+    """BackgroundTaskManager.launch()."""
+
+    @pytest.mark.asyncio
+    async def test_launch_returns_task(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        task = await mgr.launch(
+            command="echo hello",
+            description="test echo",
+            working_dir=str(tmp_path),
+            started_by="emp001",
+        )
+        assert task.status == "running"
+        assert task.pid is not None
+        assert task.id in mgr._tasks
+        # Wait for process to finish
+        await asyncio.sleep(0.5)
+        assert mgr._tasks[task.id].status == "completed"
+        assert mgr._tasks[task.id].returncode == 0
+
+    @pytest.mark.asyncio
+    async def test_launch_writes_output_log(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        task = await mgr.launch(
+            command="echo hello_world",
+            description="test output",
+            working_dir=str(tmp_path),
+            started_by="emp001",
+        )
+        await asyncio.sleep(0.5)
+        log_path = mgr.output_log_path(task.id)
+        assert log_path.exists()
+        content = log_path.read_text()
+        assert "hello_world" in content
+
+    @pytest.mark.asyncio
+    async def test_launch_rejects_when_at_limit(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager, BackgroundTask
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        # Fill up slots with fake running tasks
+        for i in range(5):
+            t = BackgroundTask(id=f"fake{i}", command="x", description="",
+                               working_dir="/tmp", started_by="emp001")
+            t.status = "running"
+            mgr._tasks[t.id] = t
+
+        with pytest.raises(RuntimeError, match="limit"):
+            await mgr.launch(
+                command="echo nope",
+                description="over limit",
+                working_dir=str(tmp_path),
+                started_by="emp001",
+            )
+
+
+class TestTerminateTask:
+    """BackgroundTaskManager.terminate()."""
+
+    @pytest.mark.asyncio
+    async def test_terminate_running_task(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        task = await mgr.launch(
+            command="sleep 60",
+            description="long running",
+            working_dir=str(tmp_path),
+            started_by="emp001",
+        )
+        assert task.status == "running"
+        result = await mgr.terminate(task.id)
+        assert result is True
+        assert mgr._tasks[task.id].status == "stopped"
+
+    @pytest.mark.asyncio
+    async def test_terminate_nonexistent_task(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        result = await mgr.terminate("nope")
+        assert result is False
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/unit/core/test_background_tasks.py::TestLaunchTask -v`
+Expected: FAIL — launch method not found
+
+- [ ] **Step 4: Implement launch + monitor + terminate + port detection**
+
+Add to `BackgroundTaskManager` in `src/onemancompany/core/background_tasks.py`:
+
+```python
+    import asyncio
+    import re
+    import uuid
+
+    async def launch(
+        self,
+        command: str,
+        description: str,
+        working_dir: str,
+        started_by: str,
+    ) -> BackgroundTask:
+        """Launch a background process. Raises RuntimeError if at limit."""
+        if not self.can_launch:
+            raise RuntimeError(
+                f"Background task limit reached ({MAX_CONCURRENT} max). "
+                f"Stop a running task first."
+            )
+
+        task_id = uuid.uuid4().hex[:8]
+        task = BackgroundTask(
+            id=task_id,
+            command=command,
+            description=description,
+            working_dir=working_dir or str(self._data_dir),
+            started_by=started_by,
+        )
+
+        # Prepare output log directory
+        log_path = self.output_log_path(task_id)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_fd = open(log_path, "w")
+
+        proc = await asyncio.create_subprocess_shell(
+            command,
+            stdout=log_fd,
+            stderr=asyncio.subprocess.STDOUT,
+            cwd=working_dir or None,
+        )
+        task.pid = proc.pid
+        self._tasks[task_id] = task
+        self._processes[task_id] = proc
+        self._save()
+
+        # Port detection from command args
+        task.port = self._detect_port_from_command(command)
+        if task.port:
+            task.address = f"http://localhost:{task.port}"
+
+        # Start monitor coroutine
+        monitor = asyncio.create_task(self._monitor(task_id, proc, log_fd))
+        self._monitors[task_id] = monitor
+
+        logger.info("[bg_tasks] Launched {} (PID {}): {}", task_id, proc.pid, command[:80])
+        self._broadcast_update(task)
+        return task
+
+    async def _monitor(self, task_id: str, proc, log_fd) -> None:
+        """Wait for process to exit, detect port from output, update status."""
+        task = self._tasks.get(task_id)
+        if not task:
+            return
+
+        try:
+            # Port detection from output (first 30s)
+            if not task.port:
+                from onemancompany.core.async_utils import spawn_background
+                spawn_background(self._detect_port_from_output(task_id))
+
+            returncode = await proc.wait()
+            task.returncode = returncode
+            task.status = "completed" if returncode == 0 else "failed"
+            task.ended_at = datetime.now(timezone.utc).isoformat()
+            logger.info("[bg_tasks] Task {} finished: exit {}", task_id, returncode)
+        except asyncio.CancelledError:
+            raise  # Must re-raise per project rules
+        finally:
+            log_fd.close()
+            self._processes.pop(task_id, None)
+            self._monitors.pop(task_id, None)
+            self._save()
+            self._broadcast_update(task)
+
+    async def _detect_port_from_output(self, task_id: str) -> None:
+        """Scan output log for port patterns during the first 30 seconds."""
+        import re
+        port_re = re.compile(
+            r"(?:https?://[\w.-]+:|localhost:|0\.0\.0\.0:|127\.0\.0\.1:)(\d{2,5})"
+        )
+        deadline = asyncio.get_event_loop().time() + 30
+        while asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(2)
+            task = self._tasks.get(task_id)
+            if not task or task.status != "running" or task.port:
+                return
+            log_path = self.output_log_path(task_id)
+            if not log_path.exists():
+                continue
+            try:
+                text = log_path.read_text()
+                match = port_re.search(text)
+                if match:
+                    task.port = int(match.group(1))
+                    task.address = f"http://localhost:{task.port}"
+                    self._save()
+                    self._broadcast_update(task)
+                    logger.info("[bg_tasks] Detected port {} for task {}", task.port, task_id)
+                    return
+            except Exception as e:
+                logger.debug("[bg_tasks] Port detection read error for {}: {}", task_id, e)
+
+    async def terminate(self, task_id: str) -> bool:
+        """Terminate a running task. Returns True if terminated, False if not found."""
+        task = self._tasks.get(task_id)
+        if not task or task.status != "running":
+            return False
+
+        proc = self._processes.get(task_id)
+        if proc:
+            try:
+                proc.terminate()
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=10)
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    await proc.wait()
+            except ProcessLookupError:
+                pass
+
+        # Cancel monitor
+        monitor = self._monitors.pop(task_id, None)
+        if monitor:
+            monitor.cancel()
+
+        task.status = "stopped"
+        task.ended_at = datetime.now(timezone.utc).isoformat()
+        task.returncode = proc.returncode if proc else None
+        self._processes.pop(task_id, None)
+        self._save()
+        self._broadcast_update(task)
+        logger.info("[bg_tasks] Terminated task {}", task_id)
+        return True
+
+    async def stop_all(self) -> None:
+        """Terminate all running tasks. Called on shutdown."""
+        for task_id in list(self._processes.keys()):
+            await self.terminate(task_id)
+
+    def start(self) -> None:
+        """Load persisted state on startup."""
+        self._load()
+        logger.info("[bg_tasks] Loaded {} tasks ({} were running)",
+                    len(self._tasks), sum(1 for t in self._tasks.values() if t.status == "stopped"))
+
+    @staticmethod
+    def _detect_port_from_command(command: str) -> int | None:
+        """Extract port from command arguments like --port 3000 or -p 8080."""
+        import re
+        m = re.search(r"(?:--port|--PORT|-p)[= ](\d{2,5})", command)
+        return int(m.group(1)) if m else None
+
+    def _broadcast_update(self, task: BackgroundTask) -> None:
+        """Publish event via EventBus (fire-and-forget)."""
+        try:
+            from onemancompany.core.events import event_bus, CompanyEvent
+            from onemancompany.core.models import EventType
+            from onemancompany.core.async_utils import spawn_background
+            spawn_background(event_bus.publish(CompanyEvent(
+                type=EventType.BACKGROUND_TASK_UPDATE,
+                payload=task.to_dict(),
+                agent="SYSTEM",
+            )))
+        except Exception as e:
+            logger.debug("[bg_tasks] Broadcast failed (no event loop?): {}", e)
+
+    def read_output_tail(self, task_id: str, lines: int = 50) -> str:
+        """Read last N lines of a task's output log."""
+        log_path = self.output_log_path(task_id)
+        if not log_path.exists():
+            return ""
+        try:
+            all_lines = log_path.read_text().splitlines()
+            return "\n".join(all_lines[-lines:])
+        except Exception:
+            return ""
+
+
+# Singleton — import-time creation, call start() during app startup
+background_task_manager = BackgroundTaskManager()
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/core/test_background_tasks.py -v`
+Expected: All 11 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/onemancompany/core/background_tasks.py src/onemancompany/core/models.py tests/unit/core/test_background_tasks.py
+git commit -m "feat: BackgroundTaskManager launch/monitor/terminate + port detection"
+```
+
+---
+
+### Task 3: Agent Tools — start/check/stop_background_task
+
+**Files:**
+- Modify: `src/onemancompany/agents/common_tools.py`
+- Create: `tests/unit/agents/test_background_task_tools.py`
+
+- [ ] **Step 1: Write failing tests for agent tools**
+
+```python
+# tests/unit/agents/test_background_task_tools.py
+"""Tests for background task agent tools."""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+class TestStartBackgroundTask:
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.agents.common_tools.background_task_manager")
+    async def test_start_returns_task_id(self, mock_mgr):
+        from onemancompany.agents.common_tools import start_background_task
+
+        mock_task = MagicMock()
+        mock_task.id = "abc12345"
+        mock_task.pid = 999
+        mock_mgr.launch = AsyncMock(return_value=mock_task)
+
+        result = await start_background_task.ainvoke({
+            "command": "npm run dev",
+            "description": "Dev server",
+            "employee_id": "emp001",
+        })
+        assert result["status"] == "ok"
+        assert result["task_id"] == "abc12345"
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.agents.common_tools.background_task_manager")
+    async def test_start_returns_error_at_limit(self, mock_mgr):
+        from onemancompany.agents.common_tools import start_background_task
+
+        mock_mgr.launch = AsyncMock(side_effect=RuntimeError("limit reached"))
+        result = await start_background_task.ainvoke({
+            "command": "npm run dev",
+            "description": "Dev server",
+            "employee_id": "emp001",
+        })
+        assert result["status"] == "error"
+        assert "limit" in result["message"]
+
+
+class TestCheckBackgroundTask:
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.agents.common_tools.background_task_manager")
+    async def test_check_returns_status(self, mock_mgr):
+        from onemancompany.agents.common_tools import check_background_task
+
+        mock_task = MagicMock()
+        mock_task.status = "running"
+        mock_task.port = 3000
+        mock_task.address = "http://localhost:3000"
+        mock_task.returncode = None
+        mock_task.started_at = "2026-03-26T14:00:00"
+        mock_mgr.get_task.return_value = mock_task
+        mock_mgr.read_output_tail.return_value = "server started"
+
+        result = await check_background_task.ainvoke({
+            "task_id": "abc12345",
+            "employee_id": "emp001",
+        })
+        assert result["status"] == "running"
+        assert result["port"] == 3000
+        assert "server started" in result["output_tail"]
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.agents.common_tools.background_task_manager")
+    async def test_check_not_found(self, mock_mgr):
+        from onemancompany.agents.common_tools import check_background_task
+
+        mock_mgr.get_task.return_value = None
+        result = await check_background_task.ainvoke({
+            "task_id": "nope",
+            "employee_id": "emp001",
+        })
+        assert result["status"] == "error"
+
+
+class TestStopBackgroundTask:
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.agents.common_tools.background_task_manager")
+    async def test_stop_running_task(self, mock_mgr):
+        from onemancompany.agents.common_tools import stop_background_task
+
+        mock_mgr.terminate = AsyncMock(return_value=True)
+        result = await stop_background_task.ainvoke({
+            "task_id": "abc12345",
+            "employee_id": "emp001",
+        })
+        assert result["status"] == "ok"
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.agents.common_tools.background_task_manager")
+    async def test_stop_not_found(self, mock_mgr):
+        from onemancompany.agents.common_tools import stop_background_task
+
+        mock_mgr.terminate = AsyncMock(return_value=False)
+        result = await stop_background_task.ainvoke({
+            "task_id": "nope",
+            "employee_id": "emp001",
+        })
+        assert result["status"] == "error"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/unit/agents/test_background_task_tools.py -v`
+Expected: FAIL — tools not defined
+
+- [ ] **Step 3: Implement tools and register them**
+
+Add to `src/onemancompany/agents/common_tools.py`, before `_register_all_internal_tools`:
+
+```python
+# ---------------------------------------------------------------------------
+# Background task tools
+# ---------------------------------------------------------------------------
+
+
+@tool
+async def start_background_task(
+    command: str,
+    description: str,
+    working_dir: str = "",
+    employee_id: str = "",
+) -> dict:
+    """Start a long-running background process (deploy, dev server, watcher, build).
+
+    ONLY use for processes that need to keep running after this tool returns.
+    For quick commands (< 2 minutes), use bash() instead.
+    Max 5 concurrent background tasks globally.
+
+    Args:
+        command: Shell command to run.
+        description: Brief description of what this does and why.
+        working_dir: Directory to run in (defaults to project root).
+        employee_id: Your employee ID.
+    """
+    try:
+        from onemancompany.core.config import SOURCE_ROOT
+        from onemancompany.core.background_tasks import background_task_manager
+        wd = working_dir or str(SOURCE_ROOT)
+        task = await background_task_manager.launch(
+            command=command,
+            description=description,
+            working_dir=wd,
+            started_by=employee_id,
+        )
+        return {"status": "ok", "task_id": task.id, "pid": task.pid}
+    except RuntimeError as e:
+        return {"status": "error", "message": str(e)}
+    except Exception as e:
+        return {"status": "error", "message": f"Failed to start: {e}"}
+
+
+@tool
+async def check_background_task(
+    task_id: str,
+    tail: int = 50,
+    employee_id: str = "",
+) -> dict:
+    """Check status and recent output of a background task.
+
+    Args:
+        task_id: The task ID returned by start_background_task.
+        tail: Number of output lines to return (default 50).
+        employee_id: Your employee ID.
+    """
+    from onemancompany.core.background_tasks import background_task_manager
+    task = background_task_manager.get_task(task_id)
+    if not task:
+        return {"status": "error", "message": f"Task {task_id} not found"}
+    output = background_task_manager.read_output_tail(task_id, lines=tail)
+    return {
+        "status": task.status,
+        "returncode": task.returncode,
+        "port": task.port,
+        "address": task.address,
+        "output_tail": output,
+        "started_at": task.started_at,
+        "ended_at": task.ended_at,
+        "pid": task.pid,
+    }
+
+
+@tool
+async def stop_background_task(
+    task_id: str,
+    employee_id: str = "",
+) -> dict:
+    """Stop a running background task. Sends SIGTERM, then SIGKILL after 10s.
+
+    Args:
+        task_id: The task ID to stop.
+        employee_id: Your employee ID.
+    """
+    from onemancompany.core.background_tasks import background_task_manager
+    result = await background_task_manager.terminate(task_id)
+    if result:
+        return {"status": "ok", "task_id": task_id}
+    return {"status": "error", "message": f"Task {task_id} not found or not running"}
+```
+
+Add to the `_base` list in `_register_all_internal_tools`:
+
+```python
+    _base = [
+        # ... existing tools ...
+        start_background_task, check_background_task, stop_background_task,
+    ]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/agents/test_background_task_tools.py -v`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/onemancompany/agents/common_tools.py tests/unit/agents/test_background_task_tools.py
+git commit -m "feat: agent tools — start/check/stop_background_task"
+```
+
+---
+
+### Task 4: API Routes
+
+**Files:**
+- Modify: `src/onemancompany/api/routes.py`
+- Create: `tests/unit/api/test_background_task_routes.py`
+
+- [ ] **Step 1: Write failing tests for API routes**
+
+```python
+# tests/unit/api/test_background_task_routes.py
+"""Tests for background task API endpoints."""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+def _make_client():
+    from starlette.testclient import TestClient
+    from onemancompany.api.routes import router
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+class TestListBackgroundTasks:
+
+    @patch("onemancompany.api.routes.background_task_manager")
+    def test_returns_tasks(self, mock_mgr):
+        client = _make_client()
+        mock_task = MagicMock()
+        mock_task.to_dict.return_value = {
+            "id": "t1", "command": "npm dev", "status": "running",
+        }
+        mock_mgr.get_all.return_value = [mock_task]
+        mock_mgr.running_count = 1
+
+        resp = client.get("/api/background-tasks")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["tasks"]) == 1
+        assert data["running_count"] == 1
+        assert data["max_concurrent"] == 5
+
+
+class TestGetBackgroundTask:
+
+    @patch("onemancompany.api.routes.background_task_manager")
+    def test_returns_task_with_output(self, mock_mgr):
+        client = _make_client()
+        mock_task = MagicMock()
+        mock_task.to_dict.return_value = {"id": "t1", "status": "running"}
+        mock_mgr.get_task.return_value = mock_task
+        mock_mgr.read_output_tail.return_value = "hello world"
+
+        resp = client.get("/api/background-tasks/t1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["task"]["id"] == "t1"
+        assert data["output_tail"] == "hello world"
+
+    @patch("onemancompany.api.routes.background_task_manager")
+    def test_not_found(self, mock_mgr):
+        client = _make_client()
+        mock_mgr.get_task.return_value = None
+
+        resp = client.get("/api/background-tasks/nope")
+        assert resp.status_code == 404
+
+
+class TestStopBackgroundTask:
+
+    @patch("onemancompany.api.routes.background_task_manager")
+    def test_stop_running(self, mock_mgr):
+        client = _make_client()
+        mock_mgr.terminate = AsyncMock(return_value=True)
+
+        resp = client.post("/api/background-tasks/t1/stop")
+        assert resp.status_code == 200
+
+    @patch("onemancompany.api.routes.background_task_manager")
+    def test_stop_not_running(self, mock_mgr):
+        client = _make_client()
+        mock_mgr.terminate = AsyncMock(return_value=False)
+
+        resp = client.post("/api/background-tasks/nope/stop")
+        assert resp.status_code == 409
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/unit/api/test_background_task_routes.py -v`
+Expected: FAIL — routes not defined
+
+- [ ] **Step 3: Implement API routes**
+
+Add to `src/onemancompany/api/routes.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Background Tasks
+# ---------------------------------------------------------------------------
+
+
+@router.get("/api/background-tasks")
+async def list_background_tasks():
+    """List all background tasks."""
+    from onemancompany.core.background_tasks import background_task_manager, MAX_CONCURRENT
+    tasks = background_task_manager.get_all()
+    return {
+        "tasks": [t.to_dict() for t in tasks],
+        "running_count": background_task_manager.running_count,
+        "max_concurrent": MAX_CONCURRENT,
+    }
+
+
+@router.get("/api/background-tasks/{task_id}")
+async def get_background_task(task_id: str, tail: int = 50):
+    """Get background task detail + output tail."""
+    from onemancompany.core.background_tasks import background_task_manager
+    task = background_task_manager.get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+    output = background_task_manager.read_output_tail(task_id, lines=tail)
+    return {"task": task.to_dict(), "output_tail": output}
+
+
+@router.post("/api/background-tasks/{task_id}/stop")
+async def stop_background_task_api(task_id: str):
+    """Stop a running background task."""
+    from onemancompany.core.background_tasks import background_task_manager
+    result = await background_task_manager.terminate(task_id)
+    if not result:
+        raise HTTPException(status_code=409, detail="Task not found or not running")
+    return {"status": "ok", "task_id": task_id}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/api/test_background_task_routes.py -v`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/onemancompany/api/routes.py tests/unit/api/test_background_task_routes.py
+git commit -m "feat: background tasks API — list, detail, stop endpoints"
+```
+
+---
+
+### Task 5: Frontend — Modal HTML + Toolbar Button + Styles
+
+**Files:**
+- Modify: `frontend/index.html`
+- Modify: `frontend/style.css`
+
+- [ ] **Step 1: Add toolbar button to index.html**
+
+In `frontend/index.html`, add after the `dashboard-toolbar-btn` button:
+
+```html
+<button id="bg-tasks-toolbar-btn" class="toolbar-icon-btn" title="Background Tasks">&#9641;</button>
+```
+
+- [ ] **Step 2: Add modal HTML to index.html**
+
+Add before the closing `</body>` tag (near other modals):
+
+```html
+<!-- Background Tasks Modal -->
+<div id="bg-tasks-modal" class="modal-overlay hidden">
+  <div class="modal-content bg-tasks-modal-content">
+    <div class="modal-header">
+      <h3 class="pixel-title">&#9608; BACKGROUND TASKS</h3>
+      <span id="bg-tasks-slots" class="bg-tasks-slots"></span>
+      <button id="bg-tasks-close-btn" class="modal-close">&#10005;</button>
+    </div>
+    <div class="modal-body bg-tasks-body">
+      <div id="bg-tasks-list" class="bg-tasks-list"></div>
+      <div id="bg-tasks-detail" class="bg-tasks-detail">
+        <div class="bg-tasks-detail-empty">Select a task</div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+- [ ] **Step 3: Add styles to style.css**
+
+Append to `frontend/style.css`:
+
+```css
+/* ── Background Tasks Modal ── */
+.bg-tasks-modal-content {
+  width: 90vw;
+  max-width: 900px;
+  height: 70vh;
+  max-height: 600px;
+}
+.bg-tasks-slots {
+  color: #555;
+  font-size: 9px;
+  font-family: var(--font-mono);
+  margin-left: auto;
+  margin-right: 12px;
+}
+.bg-tasks-body {
+  display: flex;
+  gap: 0;
+  height: calc(100% - 40px);
+  overflow: hidden;
+}
+.bg-tasks-list {
+  flex: 0 0 280px;
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  background: #0a0a0a;
+}
+.bg-tasks-detail {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #0a0a0a;
+  padding: 8px;
+}
+.bg-tasks-detail-empty {
+  color: #555;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+/* Task list items */
+.bg-task-item {
+  padding: 6px 8px;
+  border-left: 2px solid #333;
+  margin: 2px 4px;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  transition: background 0.1s;
+}
+.bg-task-item:hover { background: #111; }
+.bg-task-item.selected { background: #111; }
+.bg-task-item.status-running { border-left-color: #44aa44; }
+.bg-task-item.status-completed { border-left-color: #555; opacity: 0.6; }
+.bg-task-item.status-failed { border-left-color: #ff4444; opacity: 0.6; }
+.bg-task-item.status-stopped { border-left-color: #aa4444; opacity: 0.6; }
+.bg-task-item-status { font-size: 9px; }
+.bg-task-item-cmd { color: #44aaff; margin: 2px 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.bg-task-item-port { color: #aa44ff; font-size: 9px; }
+
+/* Detail panel */
+.bg-tasks-detail-header { margin-bottom: 6px; }
+.bg-tasks-detail-cmd { color: #44aaff; font-size: 11px; font-weight: bold; font-family: var(--font-mono); word-break: break-all; }
+.bg-tasks-detail-desc { color: #666; font-size: 10px; font-family: var(--font-mono); margin: 4px 0; }
+.bg-tasks-detail-meta { display: flex; flex-wrap: wrap; gap: 10px; font-size: 9px; font-family: var(--font-mono); margin-bottom: 8px; }
+.bg-tasks-detail-output { flex: 1; min-height: 0; border: 1px solid #222; }
+.bg-tasks-detail-actions { margin-top: 6px; text-align: right; }
+.bg-tasks-stop-btn {
+  color: #ff4444;
+  border: 1px solid #ff4444;
+  background: transparent;
+  padding: 3px 12px;
+  font-size: 10px;
+  font-family: var(--font-mono);
+  cursor: pointer;
+  letter-spacing: 1px;
+}
+.bg-tasks-stop-btn:hover { background: #ff444422; }
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/index.html frontend/style.css
+git commit -m "feat: background tasks modal HTML + CSS (brutalist split panel)"
+```
+
+---
+
+### Task 6: Frontend — JavaScript Logic + XTermLog Rendering
+
+**Files:**
+- Modify: `frontend/app.js`
+
+- [ ] **Step 1: Add event binding in constructor**
+
+In `app.js`, find where toolbar buttons are bound (near `dashboard-toolbar-btn` listener) and add:
+
+```javascript
+document.getElementById('bg-tasks-toolbar-btn').addEventListener('click', () => this.openBackgroundTasks());
+document.getElementById('bg-tasks-close-btn').addEventListener('click', () => this.closeBackgroundTasks());
+document.getElementById('bg-tasks-modal').addEventListener('click', (e) => {
+  if (e.target.id === 'bg-tasks-modal') this.closeBackgroundTasks();
+});
+```
+
+- [ ] **Step 2: Add WebSocket event handler**
+
+In the WebSocket message handler map (where `ceo_inbox_updated`, `background_task_update` etc. are), add:
+
+```javascript
+'background_task_update': (p) => {
+  if (document.getElementById('bg-tasks-modal') && !document.getElementById('bg-tasks-modal').classList.contains('hidden')) {
+    this._fetchBackgroundTasks();
+  }
+  return { text: `BG Task ${p.task_id}: ${p.status}`, cls: 'system', agent: 'SYSTEM' };
+},
+```
+
+- [ ] **Step 3: Implement open/close/render methods**
+
+Add to `AppController`:
+
+```javascript
+  // ===== Background Tasks =====
+
+  openBackgroundTasks() {
+    document.getElementById('bg-tasks-modal').classList.remove('hidden');
+    this._bgTaskSelected = null;
+    this._bgTaskXterm = null;
+    this._fetchBackgroundTasks();
+  }
+
+  closeBackgroundTasks() {
+    document.getElementById('bg-tasks-modal').classList.add('hidden');
+    clearInterval(this._bgTaskPollTimer);
+    this._bgTaskPollTimer = null;
+    if (this._bgTaskXterm) { this._bgTaskXterm.dispose(); this._bgTaskXterm = null; }
+  }
+
+  async _fetchBackgroundTasks() {
+    try {
+      const resp = await fetch('/api/background-tasks');
+      const data = await resp.json();
+      this._renderBgTaskList(data.tasks);
+      document.getElementById('bg-tasks-slots').textContent =
+        `${data.running_count}/${data.max_concurrent} SLOTS`;
+      // If selected task is in the list, refresh detail (re-fetch with output)
+      if (this._bgTaskSelected) {
+        const current = data.tasks.find(t => t.id === this._bgTaskSelected);
+        if (current) this._fetchBgTaskDetail(this._bgTaskSelected);
+      }
+    } catch (e) {
+      console.error('[bg-tasks] fetch error:', e);
+    }
+  }
+
+  _renderBgTaskList(tasks) {
+    const el = document.getElementById('bg-tasks-list');
+    if (!tasks.length) {
+      el.innerHTML = '<div style="color:#555;font-size:10px;padding:12px;font-family:var(--font-mono);">No background tasks</div>';
+      return;
+    }
+    const statusIcon = { running: '\u2588', completed: '\u2591', failed: '\u2573', stopped: '\u2592' };
+    const statusColor = { running: '#44aa44', completed: '#666', failed: '#ff4444', stopped: '#aa4444' };
+    let html = '';
+    for (const t of tasks) {
+      const selected = t.id === this._bgTaskSelected ? ' selected' : '';
+      const dur = this._bgTaskDuration(t);
+      const cmd = this._escHtml(t.command.length > 30 ? t.command.substring(0, 30) + '...' : t.command);
+      html += `<div class="bg-task-item status-${t.status}${selected}" data-id="${t.id}">`;
+      html += `<div class="bg-task-item-status" style="color:${statusColor[t.status] || '#666'}">${statusIcon[t.status] || '\u2591'} ${t.status.toUpperCase()} ${dur}</div>`;
+      html += `<div class="bg-task-item-cmd">${cmd}</div>`;
+      if (t.port) html += `<div class="bg-task-item-port">\u25B6 :${t.port}</div>`;
+      html += '</div>';
+    }
+    el.innerHTML = html;
+    // Bind click events
+    el.querySelectorAll('.bg-task-item').forEach(item => {
+      item.addEventListener('click', () => {
+        this._bgTaskSelected = item.dataset.id;
+        this._fetchBgTaskDetail(item.dataset.id);
+        // Update selected state
+        el.querySelectorAll('.bg-task-item').forEach(i => i.classList.remove('selected'));
+        item.classList.add('selected');
+      });
+    });
+  }
+
+  async _fetchBgTaskDetail(taskId) {
+    try {
+      const resp = await fetch(`/api/background-tasks/${taskId}?tail=200`);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      this._renderBgTaskDetail(data.task, data.output_tail);
+      // Start/stop polling
+      clearInterval(this._bgTaskPollTimer);
+      if (data.task.status === 'running') {
+        this._bgTaskPollTimer = setInterval(() => this._fetchBgTaskDetail(taskId), 3000);
+      }
+    } catch (e) {
+      console.error('[bg-tasks] detail fetch error:', e);
+    }
+  }
+
+  _renderBgTaskDetail(task, outputTail) {
+    const el = document.getElementById('bg-tasks-detail');
+    const statusColor = { running: '#44aa44', completed: '#666', failed: '#ff4444', stopped: '#aa4444' };
+
+    let metaHtml = `<span style="color:${statusColor[task.status] || '#666'}">\u2588 ${task.status.toUpperCase()}</span>`;
+    if (task.port) {
+      const addr = task.address || `http://localhost:${task.port}`;
+      metaHtml += `<span style="color:#aa44ff">\u25B6 <a href="${addr}" target="_blank" style="color:#aa44ff;">${addr}</a></span>`;
+    }
+    if (task.pid) metaHtml += `<span style="color:#555">PID ${task.pid}</span>`;
+    if (task.started_by) metaHtml += `<span style="color:#555">by ${this._escHtml(task.started_by)}</span>`;
+    const dur = this._bgTaskDuration(task);
+    if (dur) metaHtml += `<span style="color:#555">${dur}</span>`;
+
+    el.innerHTML = `
+      <div class="bg-tasks-detail-header">
+        <div class="bg-tasks-detail-cmd">${this._escHtml(task.command)}</div>
+        <div class="bg-tasks-detail-desc">${this._escHtml(task.description)}</div>
+        <div class="bg-tasks-detail-meta">${metaHtml}</div>
+      </div>
+      <div class="bg-tasks-detail-output" id="bg-tasks-output"></div>
+      ${task.status === 'running' ? '<div class="bg-tasks-detail-actions"><button class="bg-tasks-stop-btn" id="bg-tasks-stop-btn">\u25A0 STOP</button></div>' : ''}
+    `;
+
+    // Render output in xterm
+    const outputEl = document.getElementById('bg-tasks-output');
+    if (this._bgTaskXterm) { this._bgTaskXterm.dispose(); }
+    this._bgTaskXterm = new XTermLog(outputEl, { fontSize: 11 });
+    if (outputTail) {
+      for (const line of outputTail.split('\n')) {
+        this._bgTaskXterm.writeln(line);
+      }
+    } else {
+      this._bgTaskXterm.writeln(`${ANSI.gray}No output yet${ANSI.reset}`);
+    }
+
+    // Stop button
+    const stopBtn = document.getElementById('bg-tasks-stop-btn');
+    if (stopBtn) {
+      stopBtn.addEventListener('click', async () => {
+        stopBtn.disabled = true;
+        stopBtn.textContent = 'STOPPING...';
+        try {
+          await fetch(`/api/background-tasks/${task.id}/stop`, { method: 'POST' });
+          this._fetchBackgroundTasks();
+        } catch (e) {
+          console.error('[bg-tasks] stop error:', e);
+        }
+      });
+    }
+  }
+
+  _bgTaskDuration(task) {
+    if (!task.started_at) return '';
+    const start = new Date(task.started_at);
+    const end = task.ended_at ? new Date(task.ended_at) : new Date();
+    const s = Math.floor((end - start) / 1000);
+    if (s < 60) return `${s}s`;
+    if (s < 3600) return `${Math.floor(s / 60)}m${s % 60}s`;
+    return `${Math.floor(s / 3600)}h${Math.floor((s % 3600) / 60)}m`;
+  }
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/app.js
+git commit -m "feat: background tasks modal JS — list, detail, XTermLog output, stop"
+```
+
+---
+
+### Task 7: Integration — Startup/Shutdown Hooks + Full Test
+
+**Files:**
+- Modify: `src/onemancompany/api/routes.py` (or main app entry point)
+
+- [ ] **Step 1: Wire BackgroundTaskManager into app lifecycle**
+
+Find where the app starts (where `system_cron_manager.start_all()` is called) and add:
+
+```python
+from onemancompany.core.background_tasks import background_task_manager
+background_task_manager.start()
+```
+
+Find the shutdown handler and add:
+
+```python
+await background_task_manager.stop_all()
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `.venv/bin/python -m pytest tests/ -v --timeout=30`
+Expected: All tests PASS (existing + new)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/onemancompany/api/routes.py  # or wherever lifecycle hooks are
+git commit -m "feat: wire background task manager into app startup/shutdown"
+```
+
+> **Note:** MCP bridge registration for self-hosted employees is deferred to a follow-up PR.
+
+- [ ] **Step 4: Create PR**
+
+```bash
+git push -u origin feat/background-tasks
+gh pr create --title "feat: background task system — agent tools + management UI" --body "..."
+```

--- a/docs/superpowers/specs/2026-03-26-background-tasks-design.md
+++ b/docs/superpowers/specs/2026-03-26-background-tasks-design.md
@@ -1,0 +1,295 @@
+# Background Task System Design
+
+## Goal
+
+Add a system tool that allows agents to launch long-running bash processes (deployments, dev servers, watchers, etc.) in the background, with a global management UI for the CEO to monitor and control them.
+
+## Architecture
+
+### Overview
+
+```
+Agent Tool (start/check/stop)
+        │
+        ▼
+BackgroundTaskManager (singleton)
+  ├── asyncio.create_subprocess_exec
+  ├── stdout/stderr → disk log
+  ├── metadata → YAML persistence
+  └── WebSocket event broadcast
+        │
+        ▼
+Frontend Split Panel Modal
+  ├── Left: task list (status-colored borders)
+  └── Right: detail + XTermLog output viewer
+```
+
+### Components
+
+1. **`src/onemancompany/core/background_tasks.py`** — `BackgroundTaskManager` singleton
+2. **Agent tools** in `src/onemancompany/agents/common_tools.py` — 3 new tools
+3. **API routes** in `src/onemancompany/api/routes.py` — REST endpoints
+4. **Frontend modal** in `frontend/index.html` + `frontend/app.js`
+
+## Data Model
+
+```python
+@dataclass
+class BackgroundTask:
+    id: str                    # 8-char hex from uuid4
+    command: str               # shell command
+    description: str           # agent's description of purpose
+    working_dir: str           # execution directory
+    started_by: str            # employee_id
+    started_at: str            # ISO 8601 timestamp
+    status: str                # running | completed | failed | stopped
+    pid: int                   # OS process ID
+    returncode: int | None     # exit code (None while running)
+    ended_at: str | None       # ISO 8601 timestamp
+    port: int | None           # auto-detected port
+    address: str | None        # auto-detected address (e.g. http://localhost:3000)
+```
+
+### Persistence
+
+- **Metadata**: `company/background_tasks.yaml` — list of all tasks (YAML, atomic write via tempfile + os.replace)
+- **Output logs**: `company/background_tasks/{task_id}/output.log` — combined stdout+stderr
+- **On startup recovery**: Tasks with `status: running` are marked as `stopped` (process no longer exists after restart)
+
+## Concurrency Limit
+
+- Global maximum: **5 concurrent running tasks**
+- Exceeding the limit returns an error to the agent tool
+- Completed/failed/stopped tasks do not count toward the limit
+
+## Port & Address Detection
+
+Two detection strategies, applied in order:
+
+1. **Command argument scan**: regex match `--port[= ](\d+)`, `-p[= ](\d+)` from the command string
+2. **Output scan**: regex match `https?://[\w.-]+:(\d+)`, `localhost:(\d+)`, `0\.0\.0\.0:(\d+)` from the first 50 lines of output
+
+Detection runs once at startup (command scan) and periodically for the first 30 seconds (output scan, every 2s). Once a port is found, scanning stops.
+
+## Agent Tools
+
+Registered as **base** category (available to all employees). Tool descriptions emphasize "only use when necessary for long-running processes."
+
+### `start_background_task`
+
+```python
+@tool
+async def start_background_task(
+    command: str,
+    description: str,
+    working_dir: str = "",
+    employee_id: str = "",
+) -> dict:
+    """Start a long-running background process (e.g. deploy, dev server, watcher).
+
+    ONLY use this for processes that need to keep running. For quick commands, use bash() instead.
+    Returns task_id to check status or stop later. Max 5 concurrent tasks globally.
+    """
+```
+
+Returns: `{"status": "ok", "task_id": "a1b2c3d4", "pid": 12345}` or `{"status": "error", "message": "..."}`
+
+### `check_background_task`
+
+```python
+@tool
+async def check_background_task(
+    task_id: str,
+    tail: int = 50,
+    employee_id: str = "",
+) -> dict:
+    """Check status and recent output of a background task."""
+```
+
+Returns: `{"status": "running|completed|failed|stopped", "returncode": ..., "port": ..., "address": ..., "output_tail": "last N lines", "uptime_seconds": ...}`
+
+### `stop_background_task`
+
+```python
+@tool
+async def stop_background_task(
+    task_id: str,
+    employee_id: str = "",
+) -> dict:
+    """Stop a running background task. Sends SIGTERM, then SIGKILL after 10s."""
+```
+
+Returns: `{"status": "ok", "task_id": "..."}` or `{"status": "error", "message": "..."}`
+
+## BackgroundTaskManager
+
+### Singleton lifecycle
+
+- Created at import time (like `tool_registry`)
+- `start()` called at app startup — recovers state from YAML, marks stale `running` tasks as `stopped`
+- `stop_all()` called at shutdown — terminates all running processes gracefully
+
+### Process management
+
+```python
+async def launch(self, command, description, working_dir, started_by) -> BackgroundTask:
+    # 1. Check concurrency limit
+    # 2. Create task metadata
+    # 3. Open output log file
+    # 4. Start subprocess: asyncio.create_subprocess_shell(
+    #        command, stdout=log_fd, stderr=STDOUT, cwd=working_dir)
+    # 5. Save metadata to YAML
+    # 6. Start monitor coroutine (_monitor_task)
+    # 7. Broadcast event
+    # 8. Return task
+
+async def _monitor_task(self, task):
+    # 1. Run port detection (first 30s)
+    # 2. await process.wait()
+    # 3. Update status (completed/failed based on returncode)
+    # 4. Save metadata
+    # 5. Broadcast event
+
+async def terminate(self, task_id) -> bool:
+    # 1. Send SIGTERM
+    # 2. Wait 10s
+    # 3. Send SIGKILL if still alive
+    # 4. Update status to stopped
+    # 5. Save metadata, broadcast event
+```
+
+### State persistence
+
+```yaml
+# company/background_tasks.yaml
+tasks:
+  - id: a1b2c3d4
+    command: "npm run dev --port 3000"
+    description: "Deploy frontend dev server"
+    working_dir: "/path/to/project"
+    started_by: "f7c3f7"
+    started_at: "2026-03-26T14:30:00"
+    status: running
+    pid: 42831
+    returncode: null
+    ended_at: null
+    port: 3000
+    address: "http://localhost:3000"
+```
+
+## API Routes
+
+### `GET /api/background-tasks`
+
+Returns list of all tasks (newest first).
+
+Response: `{"tasks": [BackgroundTask, ...], "running_count": 2, "max_concurrent": 5}`
+
+### `GET /api/background-tasks/{task_id}`
+
+Returns task detail + tail of output log.
+
+Query params: `?tail=100` (default 50)
+
+Response: `{"task": BackgroundTask, "output_tail": "..."}`
+
+### `POST /api/background-tasks/{task_id}/stop`
+
+Terminates a running task. Returns 409 if task is not running.
+
+Response: `{"status": "ok", "task_id": "..."}`
+
+## WebSocket Events
+
+New event type: `BACKGROUND_TASK_UPDATE`
+
+Payload:
+```json
+{
+  "type": "background_task_update",
+  "payload": {
+    "task_id": "a1b2c3d4",
+    "status": "running",
+    "port": 3000,
+    "address": "http://localhost:3000"
+  }
+}
+```
+
+Triggered on: task start, port detected, task complete/fail/stop.
+
+Frontend handler: refresh task list on any `background_task_update` event.
+
+## Frontend UI
+
+### Toolbar Button
+
+New button in the toolbar row: `&#9654;` (or terminal icon) labeled "Tasks".
+
+### Modal: Split Panel Layout
+
+Brutalist + xterm + pixel cyberpunk aesthetic (consistent with trace viewer, activity log).
+
+**Structure**:
+```
+┌──────────────────────────────────────────────┐
+│ ██ BACKGROUND TASKS              2/5 SLOTS   │
+├──────────────────┬───────────────────────────┤
+│ Task List        │ Detail Panel              │
+│                  │                           │
+│ ██ RUNNING 2m34s │ npm run dev --port 3000   │
+│ npm run dev      │ Deploy frontend dev server│
+│ ▶ :3000          │                           │
+│                  │ ██ RUNNING  ▶ :3000       │
+│ ██ RUNNING 18m   │ PID 42831  by f7c3f7     │
+│ pytest --watch   │                           │
+│                  │ ┌─────────────────────┐   │
+│ ░ COMPLETED      │ │ xterm.js output     │   │
+│ docker build     │ │ (read-only terminal)│   │
+│                  │ │                     │   │
+│ ╳ FAILED exit 1  │ │                     │   │
+│ deploy.sh prod   │ └─────────────────────┘   │
+│                  │                           │
+│                  │              [■ STOP]      │
+└──────────────────┴───────────────────────────┘
+```
+
+**Left panel** (task list):
+- Each task: status-colored left border (green=running, gray=completed, red=failed/stopped)
+- Shows: status + uptime/exit code, command (truncated), port if detected
+- Click to select → loads detail in right panel
+- Running tasks sorted first, then by started_at desc
+
+**Right panel** (detail):
+- Full command, description
+- Status badge, port/address (clickable link if address detected), PID, started_by employee
+- XTermLog instance rendering output.log (read-only, auto-scroll)
+- STOP button (only for running tasks, red border, confirms on click)
+- Auto-refresh output every 3 seconds while task is running
+
+### Auto-refresh
+
+- Output tail: poll `GET /api/background-tasks/{id}?tail=200` every 3 seconds for the selected running task
+- Task list: re-fetch on `background_task_update` WebSocket event
+- Stop polling when modal is closed or task is not running
+
+## Testing
+
+- Unit tests for `BackgroundTaskManager`: launch, terminate, concurrency limit, port detection, YAML persistence, startup recovery
+- Unit tests for API routes: list, detail, stop, 409 on stop non-running
+- Unit tests for agent tools: start, check, stop
+- Mock subprocess for all tests (no real processes)
+
+## Files to Create/Modify
+
+| Action | File | Purpose |
+|--------|------|---------|
+| Create | `src/onemancompany/core/background_tasks.py` | BackgroundTaskManager + BackgroundTask dataclass |
+| Modify | `src/onemancompany/agents/common_tools.py` | 3 new tools: start/check/stop_background_task |
+| Modify | `src/onemancompany/core/models.py` | Add BACKGROUND_TASK_UPDATE to EventType |
+| Modify | `src/onemancompany/api/routes.py` | 3 new API endpoints |
+| Modify | `frontend/index.html` | Modal HTML + toolbar button |
+| Modify | `frontend/app.js` | Modal logic, XTermLog rendering, WebSocket handler |
+| Modify | `frontend/style.css` | Modal styles (brutalist theme) |
+| Create | `tests/unit/core/test_background_tasks.py` | Manager unit tests |
+| Create | `tests/unit/api/test_background_task_routes.py` | API route tests |

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -442,6 +442,12 @@ class AppController {
         this._showProjectReportModal(p);
         return { text: `📊 Project Report: ${p.subject}`, cls: 'ceo', agent: 'SYSTEM' };
       },
+      'background_task_update': (p) => {
+        if (document.getElementById('bg-tasks-modal') && !document.getElementById('bg-tasks-modal').classList.contains('hidden')) {
+          this._fetchBackgroundTasks();
+        }
+        return { text: `BG Task ${p.task_id}: ${p.status}`, cls: 'system', agent: 'SYSTEM' };
+      },
       'review_reminder': (p) => {
         const nodes = p.overdue_nodes || [];
         if (!nodes.length) return null;
@@ -1122,6 +1128,13 @@ class AppController {
     document.getElementById('dashboard-close-btn').addEventListener('click', () => this.closeDashboard());
     document.getElementById('dashboard-modal').addEventListener('click', (e) => {
       if (e.target.id === 'dashboard-modal') this.closeDashboard();
+    });
+
+    // Background Tasks modal bindings
+    document.getElementById('bg-tasks-toolbar-btn').addEventListener('click', () => this.openBackgroundTasks());
+    document.getElementById('bg-tasks-close-btn').addEventListener('click', () => this.closeBackgroundTasks());
+    document.getElementById('bg-tasks-modal').addEventListener('click', (e) => {
+      if (e.target.id === 'bg-tasks-modal') this.closeBackgroundTasks();
     });
 
     // Candidate selection modal bindings
@@ -6950,6 +6963,144 @@ class AppController {
       `;
       list.appendChild(card);
     }
+  }
+
+  // ===== Background Tasks =====
+
+  openBackgroundTasks() {
+    document.getElementById('bg-tasks-modal').classList.remove('hidden');
+    this._bgTaskSelected = null;
+    this._bgTaskXterm = null;
+    this._fetchBackgroundTasks();
+  }
+
+  closeBackgroundTasks() {
+    document.getElementById('bg-tasks-modal').classList.add('hidden');
+    clearInterval(this._bgTaskPollTimer);
+    this._bgTaskPollTimer = null;
+    if (this._bgTaskXterm) { this._bgTaskXterm.dispose(); this._bgTaskXterm = null; }
+  }
+
+  async _fetchBackgroundTasks() {
+    try {
+      const resp = await fetch('/api/background-tasks');
+      const data = await resp.json();
+      this._renderBgTaskList(data.tasks);
+      document.getElementById('bg-tasks-slots').textContent =
+        `${data.running_count}/${data.max_concurrent} SLOTS`;
+      // If selected task is in the list, refresh detail (re-fetch with output)
+      if (this._bgTaskSelected) {
+        const current = data.tasks.find(t => t.id === this._bgTaskSelected);
+        if (current) this._fetchBgTaskDetail(this._bgTaskSelected);
+      }
+    } catch (e) {
+      console.error('[bg-tasks] fetch error:', e);
+    }
+  }
+
+  _renderBgTaskList(tasks) {
+    const el = document.getElementById('bg-tasks-list');
+    if (!tasks.length) {
+      el.innerHTML = '<div style="color:#555;font-size:10px;padding:12px;font-family:var(--font-mono);">No background tasks</div>';
+      return;
+    }
+    const statusIcon = { running: '\u2588', completed: '\u2591', failed: '\u2573', stopped: '\u2592' };
+    const statusColor = { running: '#44aa44', completed: '#666', failed: '#ff4444', stopped: '#aa4444' };
+    let html = '';
+    for (const t of tasks) {
+      const selected = t.id === this._bgTaskSelected ? ' selected' : '';
+      const dur = this._bgTaskDuration(t);
+      const cmd = this._escHtml(t.command.length > 30 ? t.command.substring(0, 30) + '...' : t.command);
+      html += `<div class="bg-task-item status-${t.status}${selected}" data-id="${t.id}">`;
+      html += `<div class="bg-task-item-status" style="color:${statusColor[t.status] || '#666'}">${statusIcon[t.status] || '\u2591'} ${t.status.toUpperCase()} ${dur}</div>`;
+      html += `<div class="bg-task-item-cmd">${cmd}</div>`;
+      if (t.port) html += `<div class="bg-task-item-port">\u25B6 :${t.port}</div>`;
+      html += '</div>';
+    }
+    el.innerHTML = html;
+    el.querySelectorAll('.bg-task-item').forEach(item => {
+      item.addEventListener('click', () => {
+        this._bgTaskSelected = item.dataset.id;
+        this._fetchBgTaskDetail(item.dataset.id);
+        el.querySelectorAll('.bg-task-item').forEach(i => i.classList.remove('selected'));
+        item.classList.add('selected');
+      });
+    });
+  }
+
+  async _fetchBgTaskDetail(taskId) {
+    try {
+      const resp = await fetch(`/api/background-tasks/${taskId}?tail=200`);
+      if (!resp.ok) return;
+      const data = await resp.json();
+      this._renderBgTaskDetail(data.task, data.output_tail);
+      clearInterval(this._bgTaskPollTimer);
+      if (data.task.status === 'running') {
+        this._bgTaskPollTimer = setInterval(() => this._fetchBgTaskDetail(taskId), 3000);
+      }
+    } catch (e) {
+      console.error('[bg-tasks] detail fetch error:', e);
+    }
+  }
+
+  _renderBgTaskDetail(task, outputTail) {
+    const el = document.getElementById('bg-tasks-detail');
+    const statusColor = { running: '#44aa44', completed: '#666', failed: '#ff4444', stopped: '#aa4444' };
+
+    let metaHtml = `<span style="color:${statusColor[task.status] || '#666'}">\u2588 ${task.status.toUpperCase()}</span>`;
+    if (task.port) {
+      const addr = task.address || `http://localhost:${task.port}`;
+      metaHtml += `<span style="color:#aa44ff">\u25B6 <a href="${addr}" target="_blank" style="color:#aa44ff;">${addr}</a></span>`;
+    }
+    if (task.pid) metaHtml += `<span style="color:#555">PID ${task.pid}</span>`;
+    if (task.started_by) metaHtml += `<span style="color:#555">by ${this._escHtml(task.started_by)}</span>`;
+    const dur = this._bgTaskDuration(task);
+    if (dur) metaHtml += `<span style="color:#555">${dur}</span>`;
+
+    el.innerHTML = `
+      <div class="bg-tasks-detail-header">
+        <div class="bg-tasks-detail-cmd">${this._escHtml(task.command)}</div>
+        <div class="bg-tasks-detail-desc">${this._escHtml(task.description)}</div>
+        <div class="bg-tasks-detail-meta">${metaHtml}</div>
+      </div>
+      <div class="bg-tasks-detail-output" id="bg-tasks-output"></div>
+      ${task.status === 'running' ? '<div class="bg-tasks-detail-actions"><button class="bg-tasks-stop-btn" id="bg-tasks-stop-btn">\u25A0 STOP</button></div>' : ''}
+    `;
+
+    const outputEl = document.getElementById('bg-tasks-output');
+    if (this._bgTaskXterm) { this._bgTaskXterm.dispose(); }
+    this._bgTaskXterm = new XTermLog(outputEl, { fontSize: 11 });
+    if (outputTail) {
+      for (const line of outputTail.split('\n')) {
+        this._bgTaskXterm.writeln(line);
+      }
+    } else {
+      this._bgTaskXterm.writeln(`${ANSI.gray}No output yet${ANSI.reset}`);
+    }
+
+    const stopBtn = document.getElementById('bg-tasks-stop-btn');
+    if (stopBtn) {
+      stopBtn.addEventListener('click', async () => {
+        stopBtn.disabled = true;
+        stopBtn.textContent = 'STOPPING...';
+        try {
+          await fetch(`/api/background-tasks/${task.id}/stop`, { method: 'POST' });
+          this._fetchBackgroundTasks();
+        } catch (e) {
+          console.error('[bg-tasks] stop error:', e);
+        }
+      });
+    }
+  }
+
+  _bgTaskDuration(task) {
+    if (!task.started_at) return '';
+    const start = new Date(task.started_at);
+    const end = task.ended_at ? new Date(task.ended_at) : new Date();
+    const s = Math.floor((end - start) / 1000);
+    if (s < 60) return `${s}s`;
+    if (s < 3600) return `${Math.floor(s / 60)}m${s % 60}s`;
+    return `${Math.floor(s / 3600)}h${Math.floor((s % 3600) / 60)}m`;
   }
 }
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6999,6 +6999,12 @@ class AppController {
   }
 
   _renderBgTaskList(tasks) {
+    // Sort: running first, then by started_at descending
+    tasks.sort((a, b) => {
+      if (a.status === 'running' && b.status !== 'running') return -1;
+      if (a.status !== 'running' && b.status === 'running') return 1;
+      return (b.started_at || '').localeCompare(a.started_at || '');
+    });
     const el = document.getElementById('bg-tasks-list');
     if (!tasks.length) {
       el.innerHTML = '<div style="color:#555;font-size:10px;padding:12px;font-family:var(--font-mono);">No background tasks</div>';
@@ -7081,6 +7087,7 @@ class AppController {
     const stopBtn = document.getElementById('bg-tasks-stop-btn');
     if (stopBtn) {
       stopBtn.addEventListener('click', async () => {
+        if (!confirm('Stop this background task?')) return;
         stopBtn.disabled = true;
         stopBtn.textContent = 'STOPPING...';
         try {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -59,6 +59,7 @@
           <button id="company-culture-toolbar-btn" class="toolbar-icon-btn" title="Company Culture">&#127988;</button>
           <button id="company-direction-toolbar-btn" class="toolbar-icon-btn" title="Company Direction">&#127919;</button>
           <button id="dashboard-toolbar-btn" class="toolbar-icon-btn" title="Dashboard">&#128202;</button>
+          <button id="bg-tasks-toolbar-btn" class="toolbar-icon-btn" title="Background Tasks">&#9641;</button>
           <button id="settings-toolbar-btn" class="toolbar-icon-btn" title="Settings">&#9881;</button>
           <button id="abort-all-toolbar-btn" class="toolbar-icon-btn" title="Stop All Tasks" style="color: #ff4444;">&#9888;</button>
           <span class="status-item" id="connection-status">&#9679; OFFLINE</span>
@@ -621,6 +622,23 @@
   <!-- Reconnecting overlay -->
   <div id="reconnecting-overlay" class="reconnecting-overlay hidden">
     <span class="reconnecting-text">&#128260; Reconnecting...</span>
+  </div>
+
+  <!-- Background Tasks Modal -->
+  <div id="bg-tasks-modal" class="modal-overlay hidden">
+    <div class="modal-content bg-tasks-modal-content">
+      <div class="modal-header">
+        <h3 class="pixel-title">&#9608; BACKGROUND TASKS</h3>
+        <span id="bg-tasks-slots" class="bg-tasks-slots"></span>
+        <button id="bg-tasks-close-btn" class="modal-close">&#10005;</button>
+      </div>
+      <div class="modal-body bg-tasks-body">
+        <div id="bg-tasks-list" class="bg-tasks-list"></div>
+        <div id="bg-tasks-detail" class="bg-tasks-detail">
+          <div class="bg-tasks-detail-empty">Select a task</div>
+        </div>
+      </div>
+    </div>
   </div>
 
   <!-- Trace Viewer Modal -->

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5200,3 +5200,82 @@ body {
 .meeting-minute-meta { font-size: 9px; color: var(--text-dim); margin-top: 2px; }
 .meeting-minute-detail { padding: 8px; }
 .meeting-minute-detail pre { white-space: pre-wrap; color: #ccc; font-size: 10px; }
+
+/* ── Background Tasks Modal ── */
+.bg-tasks-modal-content {
+  width: 90vw;
+  max-width: 900px;
+  height: 70vh;
+  max-height: 600px;
+}
+.bg-tasks-slots {
+  color: #555;
+  font-size: 9px;
+  font-family: var(--font-mono);
+  margin-left: auto;
+  margin-right: 12px;
+}
+.bg-tasks-body {
+  display: flex;
+  gap: 0;
+  height: calc(100% - 40px);
+  overflow: hidden;
+}
+.bg-tasks-list {
+  flex: 0 0 280px;
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+  background: #0a0a0a;
+}
+.bg-tasks-detail {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #0a0a0a;
+  padding: 8px;
+}
+.bg-tasks-detail-empty {
+  color: #555;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+.bg-task-item {
+  padding: 6px 8px;
+  border-left: 2px solid #333;
+  margin: 2px 4px;
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  transition: background 0.1s;
+}
+.bg-task-item:hover { background: #111; }
+.bg-task-item.selected { background: #111; }
+.bg-task-item.status-running { border-left-color: #44aa44; }
+.bg-task-item.status-completed { border-left-color: #555; opacity: 0.6; }
+.bg-task-item.status-failed { border-left-color: #ff4444; opacity: 0.6; }
+.bg-task-item.status-stopped { border-left-color: #aa4444; opacity: 0.6; }
+.bg-task-item-status { font-size: 9px; }
+.bg-task-item-cmd { color: #44aaff; margin: 2px 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.bg-task-item-port { color: #aa44ff; font-size: 9px; }
+.bg-tasks-detail-header { margin-bottom: 6px; }
+.bg-tasks-detail-cmd { color: #44aaff; font-size: 11px; font-weight: bold; font-family: var(--font-mono); word-break: break-all; }
+.bg-tasks-detail-desc { color: #666; font-size: 10px; font-family: var(--font-mono); margin: 4px 0; }
+.bg-tasks-detail-meta { display: flex; flex-wrap: wrap; gap: 10px; font-size: 9px; font-family: var(--font-mono); margin-bottom: 8px; }
+.bg-tasks-detail-output { flex: 1; min-height: 0; border: 1px solid #222; }
+.bg-tasks-detail-actions { margin-top: 6px; text-align: right; }
+.bg-tasks-stop-btn {
+  color: #ff4444;
+  border: 1px solid #ff4444;
+  background: transparent;
+  padding: 3px 12px;
+  font-size: 10px;
+  font-family: var(--font-mono);
+  cursor: pointer;
+  letter-spacing: 1px;
+}
+.bg-tasks-stop-btn:hover { background: #ff444422; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.643",
+  "version": "0.2.644",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.641",
+  "version": "0.2.642",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.644",
+  "version": "0.2.645",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.637",
+  "version": "0.2.638",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.640",
+  "version": "0.2.641",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.636",
+  "version": "0.2.637",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.645",
+  "version": "0.2.646",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.642",
+  "version": "0.2.643",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.639",
+  "version": "0.2.640",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.638",
+  "version": "0.2.639",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.644"
+version = "0.2.645"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.643"
+version = "0.2.644"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.638"
+version = "0.2.639"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.637"
+version = "0.2.638"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.642"
+version = "0.2.643"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.640"
+version = "0.2.641"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.641"
+version = "0.2.642"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.636"
+version = "0.2.637"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.639"
+version = "0.2.640"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.645"
+version = "0.2.646"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -1551,6 +1551,17 @@ async def check_background_task(
     if not task:
         return {"status": "error", "message": f"Task {task_id} not found"}
     output = background_task_manager.read_output_tail(task_id, lines=tail)
+    from datetime import datetime, timezone
+    uptime = 0
+    if task.started_at:
+        start = datetime.fromisoformat(task.started_at)
+        end = datetime.fromisoformat(task.ended_at) if task.ended_at else datetime.now(timezone.utc)
+        # Handle naive datetimes
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=timezone.utc)
+        if end.tzinfo is None:
+            end = end.replace(tzinfo=timezone.utc)
+        uptime = int((end - start).total_seconds())
     return {
         "status": task.status,
         "returncode": task.returncode,
@@ -1560,6 +1571,7 @@ async def check_background_task(
         "started_at": task.started_at,
         "ended_at": task.ended_at,
         "pid": task.pid,
+        "uptime_seconds": uptime,
     }
 
 

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -1492,6 +1492,95 @@ def view_meeting_minutes(
 
 
 # ---------------------------------------------------------------------------
+# Background task tools
+# ---------------------------------------------------------------------------
+
+# Module-level singleton reference — imported here so tests can patch at this path
+from onemancompany.core.background_tasks import background_task_manager
+
+
+@tool
+async def start_background_task(
+    command: str,
+    description: str,
+    working_dir: str = "",
+    employee_id: str = "",
+) -> dict:
+    """Start a long-running background process (deploy, dev server, watcher, build).
+
+    ONLY use for processes that need to keep running after this tool returns.
+    For quick commands (< 2 minutes), use bash() instead.
+    Max 5 concurrent background tasks globally.
+
+    Args:
+        command: Shell command to run.
+        description: Brief description of what this does and why.
+        working_dir: Directory to run in (defaults to project root).
+        employee_id: Your employee ID.
+    """
+    try:
+        from onemancompany.core.config import SOURCE_ROOT
+        wd = working_dir or str(SOURCE_ROOT)
+        task = await background_task_manager.launch(
+            command=command,
+            description=description,
+            working_dir=wd,
+            started_by=employee_id,
+        )
+        return {"status": "ok", "task_id": task.id, "pid": task.pid}
+    except RuntimeError as e:
+        return {"status": "error", "message": str(e)}
+    except Exception as e:
+        return {"status": "error", "message": f"Failed to start: {e}"}
+
+
+@tool
+async def check_background_task(
+    task_id: str,
+    tail: int = 50,
+    employee_id: str = "",
+) -> dict:
+    """Check status and recent output of a background task.
+
+    Args:
+        task_id: The task ID returned by start_background_task.
+        tail: Number of output lines to return (default 50).
+        employee_id: Your employee ID.
+    """
+    task = background_task_manager.get_task(task_id)
+    if not task:
+        return {"status": "error", "message": f"Task {task_id} not found"}
+    output = background_task_manager.read_output_tail(task_id, lines=tail)
+    return {
+        "status": task.status,
+        "returncode": task.returncode,
+        "port": task.port,
+        "address": task.address,
+        "output_tail": output,
+        "started_at": task.started_at,
+        "ended_at": task.ended_at,
+        "pid": task.pid,
+    }
+
+
+@tool
+async def stop_background_task(
+    task_id: str,
+    employee_id: str = "",
+) -> dict:
+    """Stop a running background task. Sends SIGTERM, then SIGKILL after 10s.
+
+    Args:
+        task_id: The task ID to stop.
+        employee_id: Your employee ID.
+    """
+    result = await background_task_manager.terminate(task_id)
+    if result:
+        return {"status": "ok", "task_id": task_id}
+    return {"status": "error", "message": f"Task {task_id} not found or not running"}
+
+
+# ---------------------------------------------------------------------------
 # Tool registration — register all internal tools into the unified registry
 # ---------------------------------------------------------------------------
 
@@ -1514,6 +1603,7 @@ def _register_all_internal_tools() -> None:
         bash, use_tool, set_project_budget,
         set_cron, stop_cron_job, setup_webhook, remove_webhook,
         list_automations,
+        start_background_task, check_background_task, stop_background_task,
     ]
     for t in _base:
         tool_registry.register(t, ToolMeta(name=t.name, category="base"))

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -57,6 +57,7 @@ from onemancompany.core.ceo_conversation import (
     load_messages, append_message,
 )
 from onemancompany.core.errors import ErrorCode, classify_exception
+from onemancompany.core.background_tasks import background_task_manager
 
 # ---------------------------------------------------------------------------
 # Single-file constants
@@ -6157,6 +6158,41 @@ async def confirm_ceo_report(project_id: str):
     if not confirmed:
         raise HTTPException(status_code=404, detail="No pending report for this project")
     return {"status": "ok", "project_id": project_id}
+
+
+# ---------------------------------------------------------------------------
+# Background Tasks
+# ---------------------------------------------------------------------------
+
+@router.get("/api/background-tasks")
+async def list_background_tasks():
+    """List all background tasks."""
+    from onemancompany.core.background_tasks import MAX_CONCURRENT
+    tasks = background_task_manager.get_all()
+    return {
+        "tasks": [t.to_dict() for t in tasks],
+        "running_count": background_task_manager.running_count,
+        "max_concurrent": MAX_CONCURRENT,
+    }
+
+
+@router.get("/api/background-tasks/{task_id}")
+async def get_background_task(task_id: str, tail: int = 50):
+    """Get background task detail + output tail."""
+    task = background_task_manager.get_task(task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail=f"Task {task_id} not found")
+    output = background_task_manager.read_output_tail(task_id, lines=tail)
+    return {"task": task.to_dict(), "output_tail": output}
+
+
+@router.post("/api/background-tasks/{task_id}/stop")
+async def stop_background_task_api(task_id: str):
+    """Stop a running background task."""
+    result = await background_task_manager.terminate(task_id)
+    if not result:
+        raise HTTPException(status_code=409, detail="Task not found or not running")
+    return {"status": "ok", "task_id": task_id}
 
 
 # ---------------------------------------------------------------------------

--- a/src/onemancompany/core/background_tasks.py
+++ b/src/onemancompany/core/background_tasks.py
@@ -18,6 +18,7 @@ import yaml
 from loguru import logger
 
 MAX_CONCURRENT = 5
+_MAX_RETAINED = 50
 _TASKS_FILENAME = "background_tasks.yaml"
 
 
@@ -102,8 +103,28 @@ class BackgroundTaskManager:
     def _yaml_path(self) -> Path:
         return self._data_dir / _TASKS_FILENAME
 
+    def _cleanup_old_tasks(self) -> None:
+        """Remove oldest non-running tasks if we exceed retention limit."""
+        if len(self._tasks) <= _MAX_RETAINED:
+            return
+        # Sort non-running tasks by started_at ascending (oldest first)
+        removable = sorted(
+            [t for t in self._tasks.values() if t.status != "running"],
+            key=lambda t: t.started_at,
+        )
+        to_remove = len(self._tasks) - _MAX_RETAINED
+        for t in removable[:to_remove]:
+            del self._tasks[t.id]
+            # Clean up log directory
+            log_dir = self.output_log_path(t.id).parent
+            if log_dir.exists():
+                import shutil
+                shutil.rmtree(log_dir, ignore_errors=True)
+            logger.debug("[bg_tasks] Cleaned up old task {}", t.id)
+
     def _save(self) -> None:
         """Atomic save to YAML."""
+        self._cleanup_old_tasks()
         import tempfile
         path = self._yaml_path()
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -152,18 +173,20 @@ class BackgroundTaskManager:
 
     @staticmethod
     def _detect_port_from_command(command: str) -> int | None:
-        """Extract port from command arguments like --port 3000 or -p 8080."""
-        m = re.search(r"(?:--port|--PORT|-p)[= ](\d{2,5})", command)
+        """Extract port from command arguments like --port 3000, -p 8080, or -p3000."""
+        m = re.search(r"(?:--port|--PORT|-p)[= ]?(\d{2,5})", command)
         return int(m.group(1)) if m else None
 
     def read_output_tail(self, task_id: str, lines: int = 50) -> str:
         """Read last N lines of a task's output log."""
+        from collections import deque
         log_path = self.output_log_path(task_id)
         if not log_path.exists():
             return ""
         try:
-            all_lines = log_path.read_text().splitlines()
-            return "\n".join(all_lines[-lines:])
+            with open(log_path) as f:
+                tail = deque(f, maxlen=lines)
+            return "".join(tail)  # lines already have \n
         except Exception as e:
             logger.debug("[bg_tasks] Failed to read output for {}: {}", task_id, e)
             return ""
@@ -180,7 +203,7 @@ class BackgroundTaskManager:
                 agent="SYSTEM",
             )))
         except Exception as e:
-            logger.debug("[bg_tasks] Broadcast failed (no event loop?): {}", e)
+            logger.warning("[bg_tasks] Broadcast failed (no event loop?): {}", e)
 
     async def launch(
         self,
@@ -209,13 +232,16 @@ class BackgroundTaskManager:
         log_path = self.output_log_path(task_id)
         log_path.parent.mkdir(parents=True, exist_ok=True)
         log_fd = open(log_path, "w")
-
-        proc = await asyncio.create_subprocess_shell(
-            command,
-            stdout=log_fd,
-            stderr=asyncio.subprocess.STDOUT,
-            cwd=working_dir or None,
-        )
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                command,
+                stdout=log_fd,
+                stderr=asyncio.subprocess.STDOUT,
+                cwd=working_dir or None,
+            )
+        except Exception:
+            log_fd.close()
+            raise
         task.pid = proc.pid
         self._tasks[task_id] = task
         self._processes[task_id] = proc
@@ -268,8 +294,8 @@ class BackgroundTaskManager:
         port_re = re.compile(
             r"(?:https?://[\w.-]+:|localhost:|0\.0\.0\.0:|127\.0\.0\.1:)(\d{2,5})"
         )
-        deadline = asyncio.get_event_loop().time() + 30
-        while asyncio.get_event_loop().time() < deadline:
+        deadline = asyncio.get_running_loop().time() + 30
+        while asyncio.get_running_loop().time() < deadline:
             await asyncio.sleep(2)
             task = self._tasks.get(task_id)
             if not task or task.status != "running" or task.port:

--- a/src/onemancompany/core/background_tasks.py
+++ b/src/onemancompany/core/background_tasks.py
@@ -6,8 +6,10 @@ Output logs at company/background_tasks/{task_id}/output.log.
 """
 from __future__ import annotations
 
+import asyncio
 import os
 import re
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -179,6 +181,151 @@ class BackgroundTaskManager:
             )))
         except Exception as e:
             logger.debug("[bg_tasks] Broadcast failed (no event loop?): {}", e)
+
+    async def launch(
+        self,
+        command: str,
+        description: str,
+        working_dir: str,
+        started_by: str,
+    ) -> "BackgroundTask":
+        """Launch a background process. Raises RuntimeError if at limit."""
+        if not self.can_launch:
+            raise RuntimeError(
+                f"Background task limit reached ({MAX_CONCURRENT} max). "
+                f"Stop a running task first."
+            )
+
+        task_id = uuid.uuid4().hex[:8]
+        task = BackgroundTask(
+            id=task_id,
+            command=command,
+            description=description,
+            working_dir=working_dir or str(self._data_dir),
+            started_by=started_by,
+        )
+
+        # Prepare output log directory
+        log_path = self.output_log_path(task_id)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_fd = open(log_path, "w")
+
+        proc = await asyncio.create_subprocess_shell(
+            command,
+            stdout=log_fd,
+            stderr=asyncio.subprocess.STDOUT,
+            cwd=working_dir or None,
+        )
+        task.pid = proc.pid
+        self._tasks[task_id] = task
+        self._processes[task_id] = proc
+        self._save()
+
+        # Port detection from command args
+        task.port = self._detect_port_from_command(command)
+        if task.port:
+            task.address = f"http://localhost:{task.port}"
+
+        # Start monitor coroutine
+        monitor = asyncio.create_task(self._monitor(task_id, proc, log_fd))
+        self._monitors[task_id] = monitor
+
+        logger.info("[bg_tasks] Launched {} (PID {}): {}", task_id, proc.pid, command[:80])
+        self._broadcast_update(task)
+        return task
+
+    async def _monitor(self, task_id: str, proc, log_fd) -> None:
+        """Wait for process to exit, detect port from output, update status."""
+        task = self._tasks.get(task_id)
+        if not task:
+            return
+
+        try:
+            # Port detection from output (first 30s) — fire and forget
+            if not task.port:
+                try:
+                    from onemancompany.core.async_utils import spawn_background
+                    spawn_background(self._detect_port_from_output(task_id))
+                except Exception as e:
+                    logger.debug("[bg_tasks] Could not start port detection: {}", e)
+
+            returncode = await proc.wait()
+            task.returncode = returncode
+            task.status = "completed" if returncode == 0 else "failed"
+            task.ended_at = datetime.now(timezone.utc).isoformat()
+            logger.info("[bg_tasks] Task {} finished: exit {}", task_id, returncode)
+        except asyncio.CancelledError:
+            raise  # Must re-raise per project rules
+        finally:
+            log_fd.close()
+            self._processes.pop(task_id, None)
+            self._monitors.pop(task_id, None)
+            self._save()
+            self._broadcast_update(task)
+
+    async def _detect_port_from_output(self, task_id: str) -> None:
+        """Scan output log for port patterns during the first 30 seconds."""
+        port_re = re.compile(
+            r"(?:https?://[\w.-]+:|localhost:|0\.0\.0\.0:|127\.0\.0\.1:)(\d{2,5})"
+        )
+        deadline = asyncio.get_event_loop().time() + 30
+        while asyncio.get_event_loop().time() < deadline:
+            await asyncio.sleep(2)
+            task = self._tasks.get(task_id)
+            if not task or task.status != "running" or task.port:
+                return
+            log_path = self.output_log_path(task_id)
+            if not log_path.exists():
+                continue
+            try:
+                text = log_path.read_text()
+                match = port_re.search(text)
+                if match:
+                    task.port = int(match.group(1))
+                    task.address = f"http://localhost:{task.port}"
+                    self._save()
+                    self._broadcast_update(task)
+                    logger.info("[bg_tasks] Detected port {} for task {}", task.port, task_id)
+                    return
+            except Exception as e:
+                logger.debug("[bg_tasks] Port detection read error for {}: {}", task_id, e)
+
+    async def terminate(self, task_id: str) -> bool:
+        """Terminate a running task. Returns True if terminated, False if not found."""
+        task = self._tasks.get(task_id)
+        if not task or task.status != "running":
+            return False
+
+        proc = self._processes.get(task_id)
+        if proc:
+            try:
+                proc.terminate()
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=10)
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    await proc.wait()
+            except ProcessLookupError:
+                logger.debug("[bg_tasks] Process for task {} already gone (ProcessLookupError)", task_id)
+
+        # Cancel monitor
+        monitor = self._monitors.pop(task_id, None)
+        if monitor:
+            monitor.cancel()
+
+        task.status = "stopped"
+        task.ended_at = datetime.now(timezone.utc).isoformat()
+        task.returncode = proc.returncode if proc else None
+        self._processes.pop(task_id, None)
+        self._save()
+        self._broadcast_update(task)
+        logger.info("[bg_tasks] Terminated task {}", task_id)
+        return True
+
+    async def stop_all(self) -> None:
+        """Terminate all running tasks. Called on shutdown."""
+        for task_id in list(self._processes.keys()):
+            await self.terminate(task_id)
 
     def start(self) -> None:
         """Load persisted state on startup."""

--- a/src/onemancompany/core/background_tasks.py
+++ b/src/onemancompany/core/background_tasks.py
@@ -1,0 +1,191 @@
+"""Background task manager — launch and manage long-running processes.
+
+Singleton `background_task_manager` manages async subprocesses.
+State persisted to company/background_tasks.yaml.
+Output logs at company/background_tasks/{task_id}/output.log.
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+from loguru import logger
+
+MAX_CONCURRENT = 5
+_TASKS_FILENAME = "background_tasks.yaml"
+
+
+@dataclass
+class BackgroundTask:
+    id: str
+    command: str
+    description: str
+    working_dir: str
+    started_by: str
+    started_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    status: str = "running"  # running | completed | failed | stopped
+    pid: int | None = None
+    returncode: int | None = None
+    ended_at: str | None = None
+    port: int | None = None
+    address: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "command": self.command,
+            "description": self.description,
+            "working_dir": self.working_dir,
+            "started_by": self.started_by,
+            "started_at": self.started_at,
+            "status": self.status,
+            "pid": self.pid,
+            "returncode": self.returncode,
+            "ended_at": self.ended_at,
+            "port": self.port,
+            "address": self.address,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> BackgroundTask:
+        return cls(
+            id=d["id"],
+            command=d["command"],
+            description=d.get("description", ""),
+            working_dir=d.get("working_dir", ""),
+            started_by=d.get("started_by", ""),
+            started_at=d.get("started_at", ""),
+            status=d.get("status", "running"),
+            pid=d.get("pid"),
+            returncode=d.get("returncode"),
+            ended_at=d.get("ended_at"),
+            port=d.get("port"),
+            address=d.get("address"),
+        )
+
+
+class BackgroundTaskManager:
+    """Manages long-running background processes."""
+
+    def __init__(self, data_dir: Path | None = None):
+        if data_dir is None:
+            from onemancompany.core.config import COMPANY_DIR
+            data_dir = COMPANY_DIR
+        self._data_dir = Path(data_dir)
+        self._tasks: dict[str, BackgroundTask] = {}
+        self._processes: dict[str, "asyncio.subprocess.Process"] = {}
+        self._monitors: dict[str, "asyncio.Task"] = {}
+
+    @property
+    def running_count(self) -> int:
+        return sum(1 for t in self._tasks.values() if t.status == "running")
+
+    @property
+    def can_launch(self) -> bool:
+        return self.running_count < MAX_CONCURRENT
+
+    def get_task(self, task_id: str) -> BackgroundTask | None:
+        return self._tasks.get(task_id)
+
+    def get_all(self) -> list[BackgroundTask]:
+        return sorted(self._tasks.values(), key=lambda t: t.started_at, reverse=True)
+
+    def output_log_path(self, task_id: str) -> Path:
+        return self._data_dir / "background_tasks" / task_id / "output.log"
+
+    def _yaml_path(self) -> Path:
+        return self._data_dir / _TASKS_FILENAME
+
+    def _save(self) -> None:
+        """Atomic save to YAML."""
+        import tempfile
+        path = self._yaml_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        data = {"tasks": [t.to_dict() for t in self._tasks.values()]}
+        fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".yaml")
+        try:
+            with os.fdopen(fd, "w") as f:
+                yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+            os.replace(tmp, str(path))
+        except Exception:
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise
+
+    def _load(self) -> None:
+        """Load tasks from YAML. Mark stale running tasks as stopped."""
+        path = self._yaml_path()
+        if not path.exists():
+            return
+        try:
+            with open(path) as f:
+                data = yaml.safe_load(f) or {}
+        except Exception as e:
+            logger.warning("Failed to load background tasks: {}", e)
+            return
+        for d in data.get("tasks", []):
+            task = BackgroundTask.from_dict(d)
+            if task.status == "running":
+                if not self._is_pid_alive(task.pid):
+                    task.status = "stopped"
+                    task.ended_at = datetime.now(timezone.utc).isoformat()
+                    logger.info("[bg_tasks] Marked stale task {} as stopped (PID {} gone)",
+                                task.id, task.pid)
+            self._tasks[task.id] = task
+        self._save()
+
+    @staticmethod
+    def _is_pid_alive(pid: int | None) -> bool:
+        if pid is None:
+            return False
+        try:
+            os.kill(pid, 0)
+            return True
+        except (OSError, ProcessLookupError):
+            return False
+
+    @staticmethod
+    def _detect_port_from_command(command: str) -> int | None:
+        """Extract port from command arguments like --port 3000 or -p 8080."""
+        m = re.search(r"(?:--port|--PORT|-p)[= ](\d{2,5})", command)
+        return int(m.group(1)) if m else None
+
+    def read_output_tail(self, task_id: str, lines: int = 50) -> str:
+        """Read last N lines of a task's output log."""
+        log_path = self.output_log_path(task_id)
+        if not log_path.exists():
+            return ""
+        try:
+            all_lines = log_path.read_text().splitlines()
+            return "\n".join(all_lines[-lines:])
+        except Exception as e:
+            logger.debug("[bg_tasks] Failed to read output for {}: {}", task_id, e)
+            return ""
+
+    def _broadcast_update(self, task: BackgroundTask) -> None:
+        """Publish event via EventBus (fire-and-forget)."""
+        try:
+            from onemancompany.core.events import event_bus, CompanyEvent
+            from onemancompany.core.models import EventType
+            from onemancompany.core.async_utils import spawn_background
+            spawn_background(event_bus.publish(CompanyEvent(
+                type=EventType.BACKGROUND_TASK_UPDATE,
+                payload=task.to_dict(),
+                agent="SYSTEM",
+            )))
+        except Exception as e:
+            logger.debug("[bg_tasks] Broadcast failed (no event loop?): {}", e)
+
+    def start(self) -> None:
+        """Load persisted state on startup."""
+        self._load()
+        logger.info("[bg_tasks] Loaded {} tasks ({} were running)",
+                    len(self._tasks), sum(1 for t in self._tasks.values() if t.status == "stopped"))
+
+
+# Singleton — import-time creation, call start() during app startup
+background_task_manager = BackgroundTaskManager()

--- a/src/onemancompany/core/models.py
+++ b/src/onemancompany/core/models.py
@@ -124,6 +124,7 @@ class EventType(str, Enum):
     REMOTE_WORKER_REGISTERED = "remote_worker_registered"
     REMOTE_TASK_COMPLETED = "remote_task_completed"
     SALES_TASK_SUBMITTED = "sales_task_submitted"
+    BACKGROUND_TASK_UPDATE = "background_task_update"
     TALENT_PROFILE_ERROR = "talent_profile_error"
     ACTIVITY = "activity"
     # Additional types from legacy Literal definition

--- a/src/onemancompany/main.py
+++ b/src/onemancompany/main.py
@@ -593,6 +593,10 @@ async def lifespan(app: FastAPI):
     from onemancompany.core import system_cron as _system_cron_mod  # triggers @system_cron registrations
     _system_cron_mod.system_cron_manager.start_all()
 
+    # Start background task manager (restores persisted state, marks stale tasks stopped)
+    from onemancompany.core.background_tasks import background_task_manager
+    background_task_manager.start()
+
     # Start code change watcher (CEO-controlled hot reload)
     code_watcher_task = asyncio.create_task(_start_code_watcher())
 
@@ -622,6 +626,9 @@ async def lifespan(app: FastAPI):
 
     # Stop system crons
     await _system_cron_mod.system_cron_manager.stop_all()
+
+    # Stop background task manager (terminates all running processes gracefully)
+    await background_task_manager.stop_all()
 
     # Stop automations (crons + webhooks)
     from onemancompany.core.automation import stop_all_automations

--- a/tests/unit/agents/test_background_task_tools.py
+++ b/tests/unit/agents/test_background_task_tools.py
@@ -1,0 +1,104 @@
+"""Tests for background task agent tools."""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+class TestStartBackgroundTask:
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.agents.common_tools.background_task_manager")
+    async def test_start_returns_task_id(self, mock_mgr):
+        from onemancompany.agents.common_tools import start_background_task
+
+        mock_task = MagicMock()
+        mock_task.id = "abc12345"
+        mock_task.pid = 999
+        mock_mgr.launch = AsyncMock(return_value=mock_task)
+
+        result = await start_background_task.ainvoke({
+            "command": "npm run dev",
+            "description": "Dev server",
+            "employee_id": "emp001",
+        })
+        assert result["status"] == "ok"
+        assert result["task_id"] == "abc12345"
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.agents.common_tools.background_task_manager")
+    async def test_start_returns_error_at_limit(self, mock_mgr):
+        from onemancompany.agents.common_tools import start_background_task
+
+        mock_mgr.launch = AsyncMock(side_effect=RuntimeError("limit reached"))
+        result = await start_background_task.ainvoke({
+            "command": "npm run dev",
+            "description": "Dev server",
+            "employee_id": "emp001",
+        })
+        assert result["status"] == "error"
+        assert "limit" in result["message"]
+
+
+class TestCheckBackgroundTask:
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.agents.common_tools.background_task_manager")
+    async def test_check_returns_status(self, mock_mgr):
+        from onemancompany.agents.common_tools import check_background_task
+
+        mock_task = MagicMock()
+        mock_task.status = "running"
+        mock_task.port = 3000
+        mock_task.address = "http://localhost:3000"
+        mock_task.returncode = None
+        mock_task.started_at = "2026-03-26T14:00:00"
+        mock_task.ended_at = None
+        mock_task.pid = 12345
+        mock_mgr.get_task.return_value = mock_task
+        mock_mgr.read_output_tail.return_value = "server started"
+
+        result = await check_background_task.ainvoke({
+            "task_id": "abc12345",
+            "employee_id": "emp001",
+        })
+        assert result["status"] == "running"
+        assert result["port"] == 3000
+        assert "server started" in result["output_tail"]
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.agents.common_tools.background_task_manager")
+    async def test_check_not_found(self, mock_mgr):
+        from onemancompany.agents.common_tools import check_background_task
+
+        mock_mgr.get_task.return_value = None
+        result = await check_background_task.ainvoke({
+            "task_id": "nope",
+            "employee_id": "emp001",
+        })
+        assert result["status"] == "error"
+
+
+class TestStopBackgroundTask:
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.agents.common_tools.background_task_manager")
+    async def test_stop_running_task(self, mock_mgr):
+        from onemancompany.agents.common_tools import stop_background_task
+
+        mock_mgr.terminate = AsyncMock(return_value=True)
+        result = await stop_background_task.ainvoke({
+            "task_id": "abc12345",
+            "employee_id": "emp001",
+        })
+        assert result["status"] == "ok"
+
+    @pytest.mark.asyncio
+    @patch("onemancompany.agents.common_tools.background_task_manager")
+    async def test_stop_not_found(self, mock_mgr):
+        from onemancompany.agents.common_tools import stop_background_task
+
+        mock_mgr.terminate = AsyncMock(return_value=False)
+        result = await stop_background_task.ainvoke({
+            "task_id": "nope",
+            "employee_id": "emp001",
+        })
+        assert result["status"] == "error"

--- a/tests/unit/agents/test_background_task_tools.py
+++ b/tests/unit/agents/test_background_task_tools.py
@@ -63,6 +63,7 @@ class TestCheckBackgroundTask:
         assert result["status"] == "running"
         assert result["port"] == 3000
         assert "server started" in result["output_tail"]
+        assert "uptime_seconds" in result
 
     @pytest.mark.asyncio
     @patch("onemancompany.agents.common_tools.background_task_manager")

--- a/tests/unit/api/test_background_task_routes.py
+++ b/tests/unit/api/test_background_task_routes.py
@@ -1,0 +1,76 @@
+"""Tests for background task API endpoints."""
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+def _make_client():
+    from starlette.testclient import TestClient
+    from onemancompany.api.routes import router
+    from fastapi import FastAPI
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+class TestListBackgroundTasks:
+
+    @patch("onemancompany.api.routes.background_task_manager")
+    def test_returns_tasks(self, mock_mgr):
+        client = _make_client()
+        mock_task = MagicMock()
+        mock_task.to_dict.return_value = {
+            "id": "t1", "command": "npm dev", "status": "running",
+        }
+        mock_mgr.get_all.return_value = [mock_task]
+        mock_mgr.running_count = 1
+
+        resp = client.get("/api/background-tasks")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["tasks"]) == 1
+        assert data["running_count"] == 1
+        assert data["max_concurrent"] == 5
+
+
+class TestGetBackgroundTask:
+
+    @patch("onemancompany.api.routes.background_task_manager")
+    def test_returns_task_with_output(self, mock_mgr):
+        client = _make_client()
+        mock_task = MagicMock()
+        mock_task.to_dict.return_value = {"id": "t1", "status": "running"}
+        mock_mgr.get_task.return_value = mock_task
+        mock_mgr.read_output_tail.return_value = "hello world"
+
+        resp = client.get("/api/background-tasks/t1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["task"]["id"] == "t1"
+        assert data["output_tail"] == "hello world"
+
+    @patch("onemancompany.api.routes.background_task_manager")
+    def test_not_found(self, mock_mgr):
+        client = _make_client()
+        mock_mgr.get_task.return_value = None
+
+        resp = client.get("/api/background-tasks/nope")
+        assert resp.status_code == 404
+
+
+class TestStopBackgroundTask:
+
+    @patch("onemancompany.api.routes.background_task_manager")
+    def test_stop_running(self, mock_mgr):
+        client = _make_client()
+        mock_mgr.terminate = AsyncMock(return_value=True)
+
+        resp = client.post("/api/background-tasks/t1/stop")
+        assert resp.status_code == 200
+
+    @patch("onemancompany.api.routes.background_task_manager")
+    def test_stop_not_running(self, mock_mgr):
+        client = _make_client()
+        mock_mgr.terminate = AsyncMock(return_value=False)
+
+        resp = client.post("/api/background-tasks/nope/stop")
+        assert resp.status_code == 409

--- a/tests/unit/core/test_background_tasks.py
+++ b/tests/unit/core/test_background_tasks.py
@@ -141,3 +141,93 @@ class TestConcurrencyLimit:
         mgr._tasks["t1"] = t
         assert mgr.running_count == 0
         assert mgr.can_launch is True
+
+
+import asyncio
+
+
+class TestLaunchTask:
+    """BackgroundTaskManager.launch()."""
+
+    @pytest.mark.asyncio
+    async def test_launch_returns_task(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        task = await mgr.launch(
+            command="echo hello",
+            description="test echo",
+            working_dir=str(tmp_path),
+            started_by="emp001",
+        )
+        assert task.status == "running"
+        assert task.pid is not None
+        assert task.id in mgr._tasks
+        # Wait for process to finish
+        await asyncio.sleep(0.5)
+        assert mgr._tasks[task.id].status == "completed"
+        assert mgr._tasks[task.id].returncode == 0
+
+    @pytest.mark.asyncio
+    async def test_launch_writes_output_log(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        task = await mgr.launch(
+            command="echo hello_world",
+            description="test output",
+            working_dir=str(tmp_path),
+            started_by="emp001",
+        )
+        await asyncio.sleep(0.5)
+        log_path = mgr.output_log_path(task.id)
+        assert log_path.exists()
+        content = log_path.read_text()
+        assert "hello_world" in content
+
+    @pytest.mark.asyncio
+    async def test_launch_rejects_when_at_limit(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager, BackgroundTask
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        for i in range(5):
+            t = BackgroundTask(id=f"fake{i}", command="x", description="",
+                               working_dir="/tmp", started_by="emp001")
+            t.status = "running"
+            mgr._tasks[t.id] = t
+
+        with pytest.raises(RuntimeError, match="limit"):
+            await mgr.launch(
+                command="echo nope",
+                description="over limit",
+                working_dir=str(tmp_path),
+                started_by="emp001",
+            )
+
+
+class TestTerminateTask:
+    """BackgroundTaskManager.terminate()."""
+
+    @pytest.mark.asyncio
+    async def test_terminate_running_task(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        task = await mgr.launch(
+            command="sleep 60",
+            description="long running",
+            working_dir=str(tmp_path),
+            started_by="emp001",
+        )
+        assert task.status == "running"
+        result = await mgr.terminate(task.id)
+        assert result is True
+        assert mgr._tasks[task.id].status == "stopped"
+
+    @pytest.mark.asyncio
+    async def test_terminate_nonexistent_task(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        result = await mgr.terminate("nope")
+        assert result is False

--- a/tests/unit/core/test_background_tasks.py
+++ b/tests/unit/core/test_background_tasks.py
@@ -1,0 +1,143 @@
+"""Tests for BackgroundTaskManager."""
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+import yaml
+
+
+class TestBackgroundTaskDataModel:
+    """BackgroundTask dataclass + YAML serialization."""
+
+    def test_create_task(self):
+        from onemancompany.core.background_tasks import BackgroundTask
+        task = BackgroundTask(
+            id="abc12345",
+            command="npm run dev",
+            description="Dev server",
+            working_dir="/tmp",
+            started_by="emp001",
+        )
+        assert task.id == "abc12345"
+        assert task.status == "running"
+        assert task.pid is None
+        assert task.port is None
+
+    def test_to_dict(self):
+        from onemancompany.core.background_tasks import BackgroundTask
+        task = BackgroundTask(
+            id="abc12345",
+            command="npm run dev",
+            description="Dev server",
+            working_dir="/tmp",
+            started_by="emp001",
+        )
+        d = task.to_dict()
+        assert d["id"] == "abc12345"
+        assert d["command"] == "npm run dev"
+        assert d["status"] == "running"
+
+    def test_from_dict(self):
+        from onemancompany.core.background_tasks import BackgroundTask
+        d = {
+            "id": "abc12345",
+            "command": "npm run dev",
+            "description": "Dev server",
+            "working_dir": "/tmp",
+            "started_by": "emp001",
+            "started_at": "2026-03-26T14:00:00",
+            "status": "completed",
+            "pid": 12345,
+            "returncode": 0,
+            "ended_at": "2026-03-26T14:05:00",
+            "port": 3000,
+            "address": "http://localhost:3000",
+        }
+        task = BackgroundTask.from_dict(d)
+        assert task.id == "abc12345"
+        assert task.status == "completed"
+        assert task.port == 3000
+
+
+class TestPortDetection:
+    """Port extraction from command and output."""
+
+    def test_detect_port_from_command_long_flag(self):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+        assert BackgroundTaskManager._detect_port_from_command("npm run dev --port 3000") == 3000
+
+    def test_detect_port_from_command_short_flag(self):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+        assert BackgroundTaskManager._detect_port_from_command("python -m http.server -p 8080") == 8080
+
+    def test_detect_port_from_command_equals(self):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+        assert BackgroundTaskManager._detect_port_from_command("serve --port=4200") == 4200
+
+    def test_detect_port_from_command_none(self):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+        assert BackgroundTaskManager._detect_port_from_command("echo hello") is None
+
+
+class TestBackgroundTaskManagerPersistence:
+    """YAML save/load."""
+
+    def test_save_and_load(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager, BackgroundTask
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        task = BackgroundTask(
+            id="t1", command="echo hi", description="test",
+            working_dir="/tmp", started_by="emp001",
+        )
+        task.pid = 999
+        mgr._tasks["t1"] = task
+        mgr._save()
+
+        mgr2 = BackgroundTaskManager(data_dir=tmp_path)
+        mgr2._load()
+        assert "t1" in mgr2._tasks
+        assert mgr2._tasks["t1"].command == "echo hi"
+
+    def test_load_marks_stale_running_as_stopped(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager, BackgroundTask
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        task = BackgroundTask(
+            id="t1", command="sleep 999", description="stale",
+            working_dir="/tmp", started_by="emp001",
+        )
+        task.status = "running"
+        task.pid = 999999  # non-existent PID
+        mgr._tasks["t1"] = task
+        mgr._save()
+
+        mgr2 = BackgroundTaskManager(data_dir=tmp_path)
+        mgr2._load()
+        assert mgr2._tasks["t1"].status == "stopped"
+
+
+class TestConcurrencyLimit:
+    """Max 5 concurrent tasks."""
+
+    def test_running_count(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager, BackgroundTask
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        for i in range(5):
+            t = BackgroundTask(id=f"t{i}", command=f"cmd{i}", description="",
+                               working_dir="/tmp", started_by="emp001")
+            t.status = "running"
+            mgr._tasks[t.id] = t
+        assert mgr.running_count == 5
+        assert mgr.can_launch is False
+
+    def test_completed_tasks_dont_count(self, tmp_path):
+        from onemancompany.core.background_tasks import BackgroundTaskManager, BackgroundTask
+
+        mgr = BackgroundTaskManager(data_dir=tmp_path)
+        t = BackgroundTask(id="t1", command="cmd", description="",
+                           working_dir="/tmp", started_by="emp001")
+        t.status = "completed"
+        mgr._tasks["t1"] = t
+        assert mgr.running_count == 0
+        assert mgr.can_launch is True

--- a/tests/unit/core/test_background_tasks.py
+++ b/tests/unit/core/test_background_tasks.py
@@ -77,6 +77,10 @@ class TestPortDetection:
         from onemancompany.core.background_tasks import BackgroundTaskManager
         assert BackgroundTaskManager._detect_port_from_command("echo hello") is None
 
+    def test_detect_port_from_command_no_separator(self):
+        from onemancompany.core.background_tasks import BackgroundTaskManager
+        assert BackgroundTaskManager._detect_port_from_command("node server.js -p3000") == 3000
+
 
 class TestBackgroundTaskManagerPersistence:
     """YAML save/load."""
@@ -147,7 +151,7 @@ import asyncio
 
 
 class TestLaunchTask:
-    """BackgroundTaskManager.launch()."""
+    """BackgroundTaskManager.launch() — integration tests using real subprocesses."""
 
     @pytest.mark.asyncio
     async def test_launch_returns_task(self, tmp_path):
@@ -206,7 +210,7 @@ class TestLaunchTask:
 
 
 class TestTerminateTask:
-    """BackgroundTaskManager.terminate()."""
+    """BackgroundTaskManager.terminate() — integration tests using real subprocesses."""
 
     @pytest.mark.asyncio
     async def test_terminate_running_task(self, tmp_path):


### PR DESCRIPTION
## Summary

New background task system allowing agents to launch, monitor, and stop long-running processes (deployments, dev servers, watchers, etc.)

- **Backend**: `BackgroundTaskManager` singleton with async subprocess management, YAML persistence, port auto-detection, max 5 concurrent tasks
- **Agent tools**: `start_background_task`, `check_background_task`, `stop_background_task` (base category, all employees)
- **API**: `GET /api/background-tasks`, `GET /api/background-tasks/{id}`, `POST /api/background-tasks/{id}/stop`
- **Frontend**: Split-panel modal (brutalist/xterm aesthetic) — task list with status-colored borders + detail panel with XTermLog output viewer, STOP button, port/address display
- **Lifecycle**: Startup recovery (marks stale running tasks as stopped), graceful shutdown (terminates all)

## Changes

| File | What |
|------|------|
| `src/onemancompany/core/background_tasks.py` | BackgroundTaskManager + BackgroundTask dataclass (338 lines) |
| `src/onemancompany/agents/common_tools.py` | 3 new agent tools + registration |
| `src/onemancompany/api/routes.py` | 3 REST endpoints |
| `src/onemancompany/core/models.py` | BACKGROUND_TASK_UPDATE EventType |
| `src/onemancompany/main.py` | Startup/shutdown hooks |
| `frontend/index.html` | Modal HTML + toolbar button |
| `frontend/app.js` | Modal logic, XTermLog rendering, WebSocket handler |
| `frontend/style.css` | Split panel styles |
| 3 test files | 30+ tests covering manager, tools, routes |

## Test plan

- [ ] Launch a background task via agent tool (e.g. `npm run dev`)
- [ ] Check task status and output via `check_background_task`
- [ ] Stop task via `stop_background_task`
- [ ] Open Background Tasks modal from toolbar — verify split panel layout
- [ ] Click task in list — verify detail with XTermLog output
- [ ] Click STOP button — verify task terminates
- [ ] Restart server — verify stale tasks marked as stopped
- [ ] Exceed 5 concurrent limit — verify rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)