### PR TITLE
fix: enable word wrap in XTermLog for full content display

### DIFF
--- a/frontend/xterm-log.js
+++ b/frontend/xterm-log.js
@@ -43,6 +43,7 @@ class XTermLog {
     this._term = new Terminal({
       disableStdin: true,
       convertEol: true,
+      wordWrap: true,
       fontSize: this._fontSize,
       fontFamily: "'JetBrains Mono', 'Fira Code', 'SF Mono', 'Cascadia Code', monospace",
       theme: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.647",
+  "version": "0.2.648",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.647"
+version = "0.2.648"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary

Long lines in execution logs (task descriptions, tool inputs) were being truncated at the xterm.js terminal column boundary. Added `wordWrap: true` to the Terminal config so content wraps to the next row instead of being hidden.

## Changes

- `frontend/xterm-log.js`: Add `wordWrap: true` to Terminal constructor options

## Test plan

- [ ] Open employee execution log with long task descriptions — verify full text wraps and is visible
- [ ] Verify trace viewer feed still renders correctly with wrapped lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)