### PR TITLE
fix: recover adhoc task trees on restart (HR review stuck pending)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -131,7 +131,7 @@
         <h3 class="pixel-title">ACTIVITY LOG</h3>
       </div>
       <div id="activity-body" class="collapsible-body collapsible-flex">
-        <div id="activity-log" style="background:#0a0a0a;overflow-y:auto;flex:1"></div>
+        <div id="activity-log" style="background:#0a0a0a;flex:1"></div>
       </div>
     </div>
   </div>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -547,7 +547,7 @@ body {
   border-radius: 0 0 2px 2px;
   padding: 8px 10px;
   flex: 1;
-  overflow-y: auto;
+  overflow: hidden;  /* xterm.js handles its own scrolling */
   min-height: 0;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.649",
+  "version": "0.2.650",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.648",
+  "version": "0.2.649",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.649"
+version = "0.2.650"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.648"
+version = "0.2.649"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/task_persistence.py
+++ b/src/onemancompany/core/task_persistence.py
@@ -109,7 +109,7 @@ def recover_schedule_from_trees(
             if orphan_modified:
                 save_tree_async(tree_path)
 
-    # 2. Scan system task trees
+    # 2. Scan system task trees (legacy system_tasks.yaml)
     if employees_dir.exists():
         for sys_path in employees_dir.rglob("system_tasks.yaml"):
             try:
@@ -132,3 +132,30 @@ def recover_schedule_from_trees(
 
             if modified:
                 sys_tree.save(sys_path)
+
+    # 3. Scan adhoc task trees (employees/{id}/tasks/*_tree.yaml)
+    #    Created by _push_adhoc_task() for HR reviews, meeting bookings, etc.
+    if employees_dir.exists():
+        for adhoc_path in employees_dir.rglob("tasks/*_tree.yaml"):
+            try:
+                tree = get_tree(adhoc_path)
+            except Exception:
+                logger.warning("Skipping corrupt adhoc tree: {}", adhoc_path)
+                continue
+
+            modified = False
+            for node in tree._nodes.values():
+                if node.status == TaskPhase.PROCESSING.value:
+                    node.status = TaskPhase.PENDING.value
+                    modified = True
+
+            if modified:
+                save_tree_async(adhoc_path)
+
+            for node in tree._nodes.values():
+                if node.status == TaskPhase.PENDING.value and tree.all_deps_resolved(node.id):
+                    employee_manager.schedule_node(
+                        node.employee_id, node.id, str(adhoc_path),
+                    )
+                    logger.info("[RECOVER] Restored adhoc task {} for employee {}",
+                                node.id, node.employee_id)


### PR DESCRIPTION
## Summary

**1. Recover adhoc task trees on restart (HR review stuck pending)**

Adhoc task trees created by `_push_adhoc_task()` (HR quarterly reviews, meeting bookings, etc.) were never recovered on server restart, causing tasks to stay permanently `pending`.

Root cause: `recover_schedule_from_trees()` scanned `projects_dir/**/task_tree.yaml` and `employees_dir/**/system_tasks.yaml`, but adhoc tasks are stored at `employees/{id}/tasks/{node_id}_tree.yaml` — not matched by either scan.

Fix: Added step 3 to scan `employees/{id}/tasks/*_tree.yaml`.

**2. Remove duplicate scrollbar on activity log**

Activity log had `overflow-y:auto` in both inline HTML and CSS, creating a second scrollbar on top of xterm.js's built-in scrollbar. Removed the outer overflow — xterm.js handles its own scrolling.

## Changes

- `src/onemancompany/core/task_persistence.py`: Add adhoc tree recovery scan
- `frontend/index.html`: Remove inline `overflow-y:auto` from activity-log div
- `frontend/style.css`: Change `overflow-y: auto` to `overflow: hidden` on `#activity-log`

## Test plan

- [ ] Click quarterly review when HR is busy, restart server — pending review task should be recovered
- [ ] Activity log shows single scrollbar (xterm.js built-in only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)