### PR TITLE
fix: adhoc task stuck pending — race condition in save_tree_async

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.654",
+  "version": "0.2.655",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.654"
+version = "0.2.655"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -125,7 +125,7 @@ def _push_adhoc_task(
     Returns the node_id.
     """
     from pathlib import Path
-    from onemancompany.core.task_tree import TaskTree, register_tree, save_tree_async
+    from onemancompany.core.task_tree import TaskTree, register_tree, get_tree
     from onemancompany.core.config import EMPLOYEES_DIR
     from onemancompany.core.vessel import employee_manager
 
@@ -143,9 +143,22 @@ def _push_adhoc_task(
     tasks_dir.mkdir(parents=True, exist_ok=True)
     tree_path = tasks_dir / f"{root.id}_tree.yaml"
     register_tree(tree_path, tree)
-    save_tree_async(tree_path)  # initial sync save to create the file
+    # Sync save — file must exist on disk before get_next_scheduled reads it
+    tree.save(tree_path)
 
     employee_manager.schedule_node(employee_id, root.id, str(tree_path))
+
+    # Verify the entry is findable before scheduling
+    entry = employee_manager.get_next_scheduled(employee_id)
+    if entry and entry.node_id == root.id:
+        logger.debug("[ADHOC] Task {} scheduled and findable for {}", root.id, employee_id)
+    else:
+        logger.warning("[ADHOC] Task {} scheduled but NOT findable by get_next_scheduled for {}! "
+                       "schedule_len={}, tree_cache_hit={}",
+                       root.id, employee_id,
+                       len(employee_manager._schedule.get(employee_id, [])),
+                       bool(get_tree(tree_path).get_node(root.id)))
+
     employee_manager._schedule_next(employee_id)
     return root.id, str(tree_path)
 


### PR DESCRIPTION
## Summary

Adhoc tasks (HR review, meetings) created by `_push_adhoc_task()` were intermittently stuck at `pending` forever.

**Root cause:** `save_tree_async()` spawns a background coroutine to write the YAML file. When `get_next_scheduled()` runs 2ms later, it checks `tree_path.exists()` — if the async save hasn't completed, the file doesn't exist on disk and the entry is skipped. The scheduler then reports "no pending tasks → IDLE" even though the task was just created.

Evidence from server log:
```
22:06:10.025 — task e49ebf16b74d created
22:06:10.027 — [SCHEDULE] employee=00002 no pending tasks → IDLE
```

**Fix:** Use sync `tree.save(tree_path)` instead of `save_tree_async()` for adhoc tasks. The tree is small (single node) so sync save is fine.

Also added diagnostic logging: before calling `_schedule_next`, verifies the task is findable by `get_next_scheduled` and logs a warning if not.

## Changes

- `src/onemancompany/api/routes.py`: Sync save + diagnostic verification in `_push_adhoc_task()`

## Test plan

- [ ] Click quarterly review — task should execute immediately (not stuck pending)
- [ ] Check server log for `[ADHOC] Task ... scheduled and findable` message

🤖 Generated with [Claude Code](https://claude.com/claude-code)