### PR TITLE
fix: activity log width + CEO report full text + tree title

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -104,8 +104,10 @@ body {
 .collapsible-body.collapsible-flex {
   flex: 1;
   min-height: 0;
+  min-width: 0;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .collapsible-body.collapsible-flex.collapsed {
@@ -549,6 +551,9 @@ body {
   flex: 1;
   overflow: hidden;  /* xterm.js handles its own scrolling */
   min-height: 0;
+  min-width: 0;      /* prevent xterm canvas from overflowing grid column */
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .log-entry {

--- a/frontend/task-tree.js
+++ b/frontend/task-tree.js
@@ -169,7 +169,7 @@ class TaskTreeRenderer {
         // Pre-compute _extraH for each node (word-wrapped description lines)
         const _mc = this._descMaxCharsPerLine, _ml = this._descMaxLines, _lh = this._descLineHeight;
         root.descendants().forEach(d => {
-            const lines = TaskTreeRenderer._wrapText(d.data.description || '', _mc, _ml);
+            const lines = TaskTreeRenderer._wrapText(d.data.title || d.data.description_preview || d.data.description || '', _mc, _ml);
             const extraLines = Math.max(0, lines.length - 1);
             d._extraH = extraLines > 0 ? extraLines * _lh : 0;
         });
@@ -310,7 +310,7 @@ class TaskTreeRenderer {
 
         nodeGroups.each(function(d) {
             const g = d3.select(this);
-            const lines = TaskTreeRenderer._wrapText(d.data.description || '', descMaxChars, descMaxLines);
+            const lines = TaskTreeRenderer._wrapText(d.data.title || d.data.description_preview || d.data.description || '', descMaxChars, descMaxLines);
 
             const text = g.append('text')
                 .attr('x', descTextX)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.663",
+  "version": "0.2.664",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.663"
+version = "0.2.664"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2611,12 +2611,12 @@ class EmployeeManager:
         # Build completion summary from all children (skip CEO info nodes)
         _pdir = node.project_dir or str(Path(entry.tree_path).parent)
         children = [c for c in tree.get_children(node.id) if not c.is_ceo_node]
-        lines = [f"Project Completion Report — {node.description_preview[:100]}", ""]
+        lines = [f"Project Completion Report — {node.description_preview}", ""]
         for i, child in enumerate(children, 1):
             status_icon = "✓" if child.status == TaskPhase.ACCEPTED else "●"
-            lines.append(f"{status_icon} Subtask {i} ({child.employee_id}): {child.description_preview[:80]}")
+            lines.append(f"{status_icon} Subtask {i} ({child.employee_id}): {child.title or child.description_preview}")
             child.load_content(_pdir)
-            lines.append(f"  Result: {(child.result or 'None')[:200]}")
+            lines.append(f"  Result: {child.result or 'None'}")
             lines.append("")
         summary = "\n".join(lines)
 


### PR DESCRIPTION
## Summary

1. **Activity log width overflow** — xterm canvas was overflowing the 340px right panel grid column. Added `min-width:0`, `width:100%`, `box-sizing` on `#activity-log` and `overflow:hidden` on parent `.collapsible-flex`.

2. **CEO project report truncation** — subtask descriptions (was 80 chars) and results (was 200 chars) in the completion report now show full text. Uses `title` when available for subtask labels.

3. **Task tree title display** — D3 tree nodes now show `title || description_preview || description` instead of only `description`.

## Changes

- `frontend/style.css`: Width constraints on activity log containers
- `frontend/task-tree.js`: Prefer title in node card text
- `src/onemancompany/core/vessel.py`: Remove truncation in `_publish_completion_report`

## Test plan

- [ ] Activity log stays within panel width (no horizontal overflow)
- [ ] CEO project report shows full subtask descriptions and results
- [ ] Task tree nodes show title when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)