### PR TITLE
fix: don't auto-enable EA reply when opening inbox

### DIFF
--- a/company/operations/sops/ea_dispatch_authority_sop.md
+++ b/company/operations/sops/ea_dispatch_authority_sop.md
@@ -37,12 +37,27 @@ Only escalate to CEO (via dispatch_child to CEO) when you judge there is risk.
 ## 3. Routing Table (Strictly Enforced — Only dispatch to O-level)
 | Domain | Route to | Examples |
 |--------|----------|----------|
-| HR/Hiring/Onboarding/Performance | HR | Hiring, reviews, promotions |
-| Project Execution/Dev/Design/Ops | COO | Project execution, engineering |
-| Sales/Marketing/Clients | CSO | Clients, contracts, deals |
+| HR/Hiring/Onboarding/Performance | HR (00002) | Hiring, reviews, promotions |
+| Project Execution/Dev/Design/Ops | COO (00003) | Project execution, engineering |
+| Sales/Marketing/Clients | CSO (00005) | Clients, contracts, deals |
 
-**For project tasks**: Dispatching directly to regular employees (00006+) is prohibited — route through O-level.
-**For simple tasks**: You may dispatch directly to a suitable regular employee if the task is straightforward and the employee has the right skills.
+**Dispatching directly to regular employees (00006+) is strictly prohibited.**
+Even if CEO says "tell someone to do X", you must route through the corresponding O-level.
+
+### Hiring-Specific Dispatch Rules
+When CEO requests hiring, dispatch to HR with a description that includes ALL of the following:
+1. **Role requirements**: What role to hire, required skills, and any specific talent ID if mentioned
+2. **Action required**: Explicitly state "Search for candidates using search_candidates tool, then submit a shortlist using submit_shortlist tool"
+3. **Acceptance criteria must include**: "Candidate shortlist submitted to CEO for selection" (not just "job description created")
+
+**Common mistake to avoid**: Do NOT dispatch a task that only asks HR to "write a job description." The CEO wants candidates hired, not documents written. HR must search, shortlist, and initiate the full hiring pipeline.
+
+### Task Description Best Practices
+When dispatching to any O-level, your description must specify the **end goal**, not just an intermediate step:
+- BAD: "Create a job description for a developer" (intermediate step only)
+- GOOD: "Hire a developer with skills in Python and React. Search for candidates on Talent Market, submit a shortlist to CEO, and complete the onboarding after CEO selects."
+- BAD: "Write a project plan" (intermediate step only)
+- GOOD: "Build a landing page for the product. Set up the project, assign engineers, and deliver a working deployed page."
 
 ## 4. Acceptance Criteria Rules
 - Every CEO requirement → at least one criterion in dispatch_child's acceptance_criteria.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -370,7 +370,7 @@ class AppController {
           };
           this._appendChatMessage(chatEntry);
         }
-        return { text: `💬 [${p.speaker}] ${(p.message || '').substring(0, 50)}`, cls: 'system', agent: 'MEETING' };
+        return { text: `💬 [${p.speaker}] ${p.message || ''}`, cls: 'system', agent: 'MEETING' };
       },
       'meeting_agenda_update': (p) => {
         // Cache agenda state so it survives modal close/reopen
@@ -455,7 +455,7 @@ class AppController {
         if (!nodes.length) return null;
         const summaries = nodes.map(n => {
           const mins = Math.round(n.waiting_seconds / 60);
-          return `${n.employee_id}: ${(n.description || '').substring(0, 60)} (${mins}m)`;
+          return `${n.employee_id}: ${n.description || ''} (${mins}m)`;
         });
         return { text: `⏰ ${nodes.length} task(s) awaiting review:\n${summaries.join('\n')}`, cls: 'ceo', agent: 'SYSTEM' };
       },
@@ -864,7 +864,7 @@ class AppController {
     'employee_hired': (e) => ({ agent: 'HR', text: `New hire: ${e.name || ''} (${e.role || ''})` }),
     'employee_fired': (e) => ({ agent: 'HR', text: `Departure: ${e.name || ''}` }),
     'tool_added': (e) => ({ agent: 'COO', text: `New tool: ${e.name || ''}` }),
-    'ceo_task': (e) => ({ agent: 'CEO', text: `Task: ${(e.task || '').substring(0, 80)}` }),
+    'ceo_task': (e) => ({ agent: 'CEO', text: `Task: ${e.task || ''}` }),
     'meeting_booked': (e) => ({ agent: 'COO', text: `Room booked: ${e.room_name || ''}` }),
     'meeting_released': (e) => ({ agent: 'COO', text: `Room released: ${e.room_name || ''}` }),
     'promotion': (e) => ({ agent: 'HR', text: `Promoted: ${e.name || ''}` }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.665",
+  "version": "0.2.666",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.666",
+  "version": "0.2.667",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.664",
+  "version": "0.2.665",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.666"
+version = "0.2.667"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.665"
+version = "0.2.666"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.664"
+version = "0.2.665"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -122,15 +122,10 @@ def schedule_auto_open_inbox(node_id: str) -> None:
     async def _auto_open(nid: str):
         try:
             from onemancompany.api.routes import open_ceo_conversation
-            result = await open_ceo_conversation(nid)
+            await open_ceo_conversation(nid)
             logger.info("[auto_open_inbox] Opened CEO conversation for {}", nid)
-            # Auto-enable EA reply so the request is handled without CEO intervention
-            from onemancompany.core.ceo_conversation import get_session
-            session = get_session(nid)
-            if session:
-                description = result.get("description", "") if isinstance(result, dict) else ""
-                session.set_ea_auto_reply(True, description)
-                logger.info("[auto_open_inbox] EA auto-reply enabled for {}", nid)
+            # EA auto-reply is NOT enabled here — CEO must explicitly turn it on
+            # via the sidebar checkbox. This prevents unwanted auto-replies.
         except Exception as _e:
             logger.warning("[auto_open_inbox] Failed for {}: {}", nid, _e)
 


### PR DESCRIPTION
## Summary

`schedule_auto_open_inbox()` was enabling EA auto-reply immediately after opening a CEO inbox conversation, causing every CEO_REQUEST to get an automatic EA response even when the CEO hadn't turned on auto-reply.

**Root cause:** Line 132 called `session.set_ea_auto_reply(True, description)` right after opening. This was intended for the "CEO enabled auto-reply globally" flow but was running unconditionally.

**Fix:** Removed the auto-enable. Now `schedule_auto_open_inbox` only opens the conversation — CEO must explicitly enable EA auto-reply via the sidebar checkbox.

## Changes

- `src/onemancompany/agents/tree_tools.py`: Remove `set_ea_auto_reply(True)` from `_auto_open`

## Test plan

- [ ] Open a CEO inbox message — should NOT auto-reply unless checkbox is checked
- [ ] Enable EA auto-reply checkbox — should auto-reply as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)