### PR TITLE
fix: guard page references in mkdocs override for 404.html

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,10 +6,14 @@ on:
     paths:
       - 'mkdocs-docs/**'
       - 'mkdocs.yml'
-      - 'docs/index.html'
-      - 'docs/index-full.html'
-      - 'docs/robots.txt'
-      - 'docs/llms.txt'
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'mkdocs-docs/**'
+      - 'mkdocs.yml'
+      - 'docs/**'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
@@ -19,8 +23,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: "pages-${{ github.ref }}"
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -44,11 +48,14 @@ jobs:
           cp docs/index-full.html _site/
           cp docs/robots.txt _site/
           cp docs/llms.txt _site/
+          cp -r docs/img _site/img 2>/dev/null || true
           cp -r img _site/ 2>/dev/null || true
 
       - uses: actions/upload-pages-artifact@v3
+        if: github.event_name != 'pull_request'
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/mkdocs-docs/overrides/main.html
+++ b/mkdocs-docs/overrides/main.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block extrahead %}
+  {% if page %}
   <!-- Open Graph -->
   <meta property="og:title" content="{{ page.title }} - OneManCompany Docs" />
   <meta property="og:description" content="{{ page.meta.description | default(config.site_description) }}" />
@@ -52,7 +53,7 @@
     "description": "{{ page.meta.description | default(config.site_description) }}",
     "author": {"@type": "Organization", "name": "OneManCompany"},
     "datePublished": "2026-01-01",
-    "dateModified": "2026-03-18",
+    "dateModified": "2026-03-27",
     "publisher": {
       "@type": "Organization",
       "name": "OneManCompany",
@@ -60,5 +61,6 @@
     }
   }
   </script>
+  {% endif %}
   {% endif %}
 {% endblock %}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.671",
+  "version": "0.2.672",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.670",
+  "version": "0.2.671",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.671"
+version = "0.2.672"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.670"
+version = "0.2.671"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- MkDocs `Deploy Documentation` CI was failing because `mkdocs-docs/overrides/main.html` accesses `page.meta.description`, `page.title`, and `page.canonical_url` — but when rendering `404.html`, `page` is `None`
- Wrap the entire `extrahead` block in `{% if page %}` guard
- Also update `dateModified` from `2026-03-18` to `2026-03-27`

## Test plan
- [ ] Verify `Deploy Documentation` CI passes
- [ ] Verify docs pages still render with correct OG/Twitter meta tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)