### PR TITLE
feat: add SubprocessAdapter as first-class conversation vessel

### DIFF
--- a/company/assets/tools/launch_template.sh
+++ b/company/assets/tools/launch_template.sh
@@ -5,13 +5,13 @@
 #   $1 = employee_dir (contains profile.yaml, skills/, progress.log, etc.)
 #
 # Environment variables (auto-injected by SubprocessExecutor):
-#   OMC_EMPLOYEE_ID     — Employee ID (e.g., "00010")
-#   OMC_TASK_ID         — Current task ID
-#   OMC_PROJECT_ID      — Project ID
-#   OMC_PROJECT_DIR     — Project working directory
-#   OMC_TASK_DESCRIPTION — Task description (full prompt)
-#   OMC_SERVER_URL      — Company backend URL (e.g., "http://localhost:8000")
-#   OMC_MAX_ITERATIONS  — Max iterations (default 20)
+#   OMC_EMPLOYEE_ID           — Employee ID (e.g., "00010")
+#   OMC_TASK_ID               — Current task ID
+#   OMC_PROJECT_ID            — Project ID
+#   OMC_PROJECT_DIR           — Project working directory
+#   OMC_TASK_DESCRIPTION_FILE — Path to temp file containing task prompt
+#   OMC_SERVER_URL            — Company backend URL (e.g., "http://localhost:8000")
+#   OMC_MAX_ITERATIONS        — Max iterations (default 20)
 #
 # Output convention:
 #   stdout → JSON: {"output":"...", "model":"...", "input_tokens":N, "output_tokens":N}
@@ -41,6 +41,14 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# ── Read task description from file ──────────────────────────────────────────
+TASK_DESC_FILE="${OMC_TASK_DESCRIPTION_FILE:-}"
+if [ -z "$TASK_DESC_FILE" ] || [ ! -f "$TASK_DESC_FILE" ]; then
+    >&2 echo "ERROR: OMC_TASK_DESCRIPTION_FILE not set or file not found"
+    exit 1
+fi
+OMC_TASK_DESCRIPTION="$(cat "$TASK_DESC_FILE")"
+
 >&2 echo "[launch.sh] Employee=${OMC_EMPLOYEE_ID} Task=${OMC_TASK_ID} PID=$$"
 >&2 echo "[launch.sh] Project=${OMC_PROJECT_ID} Dir=${OMC_PROJECT_DIR}"
 >&2 echo "[launch.sh] Description: ${OMC_TASK_DESCRIPTION:0:200}"
@@ -69,7 +77,7 @@ trap cleanup EXIT
 #     -H "Content-Type: application/json" \
 #     -d "{
 #       \"model\": \"${LLM_MODEL:-google/gemini-3.1-pro-preview}\",
-#       \"messages\": [{\"role\": \"user\", \"content\": \"${OMC_TASK_DESCRIPTION}\"}]
+#       \"messages\": [{\"role\": \"user\", \"content\": $(echo "$OMC_TASK_DESCRIPTION" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')}]
 #     }")
 #
 # OUTPUT=$(echo "$RESULT" | jq -r '.choices[0].message.content // "No output"')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.673",
+  "version": "0.2.674",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.672",
+  "version": "0.2.673",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.672"
+version = "0.2.673"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.673"
+version = "0.2.674"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/conversation_adapters.py
+++ b/src/onemancompany/core/conversation_adapters.py
@@ -174,7 +174,11 @@ def _resolve_conversation_work_dir(conversation: Conversation) -> str:
 
 
 class _BaseConversationAdapter:
-    """Shared send logic — both executor types use the same prompt + execute flow."""
+    """Shared send logic — all executor types use the same prompt + execute flow."""
+
+    def _prepare_prompt(self, prompt: str, conversation: Conversation) -> str:
+        """Hook for subclasses to transform the prompt before execution."""
+        return prompt
 
     async def send(
         self, conversation: Conversation, messages: list[Message], new_message: Message,
@@ -182,6 +186,7 @@ class _BaseConversationAdapter:
         from onemancompany.core.runtime_context import _interaction_type, _interaction_work_dir
         executor = _get_employee_executor(conversation.employee_id)
         prompt = _build_conversation_prompt(conversation, messages, new_message)
+        prompt = self._prepare_prompt(prompt, conversation)
         work_dir = _resolve_conversation_work_dir(conversation)
         logger.debug(
             "[conversation] {}.send: employee={}, project_id={}, work_dir={}",
@@ -232,38 +237,10 @@ class SubprocessAdapter(_BaseConversationAdapter):
     CLAUDE.md/MCP; subprocess employees need it prepended to the prompt.
     """
 
-    async def send(
-        self, conversation: Conversation, messages: list[Message], new_message: Message,
-    ) -> str:
-        from onemancompany.core.runtime_context import _interaction_type, _interaction_work_dir
-        from onemancompany.core.vessel import TaskContext, employee_manager
+    def _prepare_prompt(self, prompt: str, conversation: Conversation) -> str:
+        from onemancompany.core.vessel import employee_manager
 
-        executor = _get_employee_executor(conversation.employee_id)
-        prompt = _build_conversation_prompt(conversation, messages, new_message)
-        work_dir = _resolve_conversation_work_dir(conversation)
-
-        # Inject company context — same as vessel._execute_task does
         company_ctx = employee_manager._build_company_context_block(conversation.employee_id)
         if company_ctx:
-            prompt = f"{company_ctx}\n\n{prompt}"
-
-        logger.debug(
-            "[conversation] SubprocessAdapter.send: employee={}, project_id={}, work_dir={}",
-            conversation.employee_id,
-            conversation.metadata.get("project_id"),
-            work_dir,
-        )
-
-        ctx = TaskContext(
-            employee_id=conversation.employee_id,
-            project_id=conversation.metadata.get("project_id", ""),
-            work_dir=work_dir,
-        )
-        tok_type = _interaction_type.set(conversation.type)
-        tok_work = _interaction_work_dir.set(work_dir)
-        try:
-            result = await executor.execute(prompt, ctx)
-            return result.output
-        finally:
-            _interaction_type.reset(tok_type)
-            _interaction_work_dir.reset(tok_work)
+            return f"{company_ctx}\n\n{prompt}"
+        return prompt

--- a/src/onemancompany/core/conversation_adapters.py
+++ b/src/onemancompany/core/conversation_adapters.py
@@ -19,6 +19,7 @@ from onemancompany.core.models import ConversationType
 # Single-file constants
 EXECUTOR_TYPE_LANGCHAIN = "langchain"
 EXECUTOR_TYPE_CLAUDE_SESSION = "claude_session"
+EXECUTOR_TYPE_SUBPROCESS = "subprocess"
 
 
 @runtime_checkable
@@ -76,6 +77,7 @@ _EXECUTOR_CLASS_MAP: dict[str, str] = {
     "ClaudeSessionExecutor": EXECUTOR_TYPE_CLAUDE_SESSION,
     "LangChainExecutor": EXECUTOR_TYPE_LANGCHAIN,
     "EmployeeAgent": EXECUTOR_TYPE_LANGCHAIN,
+    "SubprocessExecutor": EXECUTOR_TYPE_SUBPROCESS,
 }
 
 
@@ -218,3 +220,50 @@ class LangChainAdapter(_BaseConversationAdapter):
 @register_adapter(EXECUTOR_TYPE_CLAUDE_SESSION)
 class ClaudeSessionAdapter(_BaseConversationAdapter):
     pass
+
+
+@register_adapter(EXECUTOR_TYPE_SUBPROCESS)
+class SubprocessAdapter(_BaseConversationAdapter):
+    """Adapter for SubprocessExecutor-based employees (e.g. OpenClaw).
+
+    Injects company context (identity, culture, SOPs, guidance, work principles)
+    into the conversation prompt — matching what vessel._execute_task does for
+    scheduled tasks. LangChain gets this via system prompt; Claude CLI via
+    CLAUDE.md/MCP; subprocess employees need it prepended to the prompt.
+    """
+
+    async def send(
+        self, conversation: Conversation, messages: list[Message], new_message: Message,
+    ) -> str:
+        from onemancompany.core.runtime_context import _interaction_type, _interaction_work_dir
+        from onemancompany.core.vessel import TaskContext, employee_manager
+
+        executor = _get_employee_executor(conversation.employee_id)
+        prompt = _build_conversation_prompt(conversation, messages, new_message)
+        work_dir = _resolve_conversation_work_dir(conversation)
+
+        # Inject company context — same as vessel._execute_task does
+        company_ctx = employee_manager._build_company_context_block(conversation.employee_id)
+        if company_ctx:
+            prompt = f"{company_ctx}\n\n{prompt}"
+
+        logger.debug(
+            "[conversation] SubprocessAdapter.send: employee={}, project_id={}, work_dir={}",
+            conversation.employee_id,
+            conversation.metadata.get("project_id"),
+            work_dir,
+        )
+
+        ctx = TaskContext(
+            employee_id=conversation.employee_id,
+            project_id=conversation.metadata.get("project_id", ""),
+            work_dir=work_dir,
+        )
+        tok_type = _interaction_type.set(conversation.type)
+        tok_work = _interaction_work_dir.set(work_dir)
+        try:
+            result = await executor.execute(prompt, ctx)
+            return result.output
+        finally:
+            _interaction_type.reset(tok_type)
+            _interaction_work_dir.reset(tok_work)

--- a/src/onemancompany/core/subprocess_executor.py
+++ b/src/onemancompany/core/subprocess_executor.py
@@ -1,12 +1,18 @@
 """SubprocessExecutor — runs employee tasks as bash subprocesses.
 
 Each company-hosted employee runs via launch.sh. Cancel = OS-level kill.
+
+Prompt delivery: written to a temp file and passed via OMC_TASK_DESCRIPTION_FILE
+env var. The launch.sh reads from this file. This avoids OS limits on env var
+length (typically ~128KB on macOS, ~2MB on Linux) which conversation prompts
+with history can easily exceed.
 """
 from __future__ import annotations
 
 import asyncio
 import json
 import os
+import tempfile
 from typing import Callable
 
 from loguru import logger
@@ -38,13 +44,36 @@ class SubprocessExecutor(Launcher):
         context: TaskContext,
         on_log: Callable[[str, str], None] | None = None,
     ) -> LaunchResult:
+        # Write prompt to temp file to avoid env var length limits.
+        # launch.sh reads from OMC_TASK_DESCRIPTION_FILE.
+        prompt_file = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".txt", prefix="omc_prompt_",
+            delete=False, encoding="utf-8",
+        )
+        prompt_file.write(task_description)
+        prompt_file.close()
+
+        try:
+            return await self._run_subprocess(prompt_file.name, context, on_log)
+        finally:
+            try:
+                os.unlink(prompt_file.name)
+            except OSError as exc:
+                logger.debug("Failed to remove prompt file {}: {}", prompt_file.name, exc)
+
+    async def _run_subprocess(
+        self,
+        prompt_path: str,
+        context: TaskContext,
+        on_log: Callable[[str, str], None] | None,
+    ) -> LaunchResult:
         env = {
             **os.environ,
             "OMC_EMPLOYEE_ID": context.employee_id,
             "OMC_TASK_ID": context.task_id,
             "OMC_PROJECT_ID": context.project_id,
             "OMC_PROJECT_DIR": context.work_dir,
-            "OMC_TASK_DESCRIPTION": task_description,
+            "OMC_TASK_DESCRIPTION_FILE": prompt_path,
             "OMC_SERVER_URL": f"http://localhost:{os.environ.get('OMC_PORT', '8000')}",
         }
 

--- a/src/onemancompany/talent_market/AI_CODER_GUIDE.md
+++ b/src/onemancompany/talent_market/AI_CODER_GUIDE.md
@@ -234,7 +234,7 @@ bash launch.sh <employee_dir>
 | `OMC_TASK_ID` | Task ID |
 | `OMC_PROJECT_ID` | Project ID |
 | `OMC_PROJECT_DIR` | Project working directory |
-| `OMC_TASK_DESCRIPTION` | Full task description |
+| `OMC_TASK_DESCRIPTION_FILE` | Path to temp file containing the task prompt |
 | `OMC_SERVER_URL` | Backend URL |
 | `OMC_MAX_ITERATIONS` | Max agent iteration count (default 20) |
 

--- a/src/onemancompany/talent_market/README.md
+++ b/src/onemancompany/talent_market/README.md
@@ -283,7 +283,7 @@ llm_model: google/gemini-3.1-pro-preview-customtools
 
 **How it works**:
 - The platform uses `SubprocessExecutor` to run `launch.sh` as a **foreground process**
-- Each task = one `launch.sh` invocation, task description passed via `OMC_TASK_DESCRIPTION` environment variable
+- Each task = one `launch.sh` invocation, task prompt written to a temp file and passed via `OMC_TASK_DESCRIPTION_FILE` environment variable
 - Script outputs result JSON to stdout, logs to stderr
 - Timeout and cancellation managed by the platform (SIGTERM -> 30s -> SIGKILL)
 - If no custom `launch.sh` exists, the platform falls back to `LangChainLauncher`
@@ -404,7 +404,7 @@ as a **foreground process** via `SubprocessExecutor`, unlike the background work
 |---|---|---|
 | **Execution** | `SubprocessExecutor` direct invocation | Copied to employee dir on onboarding, manually started |
 | **Lifecycle** | One process per task, exits on completion | Long-running background, polls task queue |
-| **Task source** | `OMC_TASK_DESCRIPTION` environment variable | HTTP polling `/api/remote/tasks/` |
+| **Task source** | `OMC_TASK_DESCRIPTION_FILE` (temp file path) | HTTP polling `/api/remote/tasks/` |
 | **Result output** | stdout JSON | HTTP POST `/api/remote/results` |
 | **Timeout/cancellation** | Platform-managed (SIGTERM -> 30s -> SIGKILL) | Self-managed |
 | **PID management** | Not needed | `worker.pid` file |
@@ -425,7 +425,7 @@ Environment variables (auto-injected):
     OMC_TASK_ID          — Task ID
     OMC_PROJECT_ID       — Project ID
     OMC_PROJECT_DIR      — Project working directory (cwd)
-    OMC_TASK_DESCRIPTION — Full task description
+    OMC_TASK_DESCRIPTION_FILE — Path to temp file containing task prompt
     OMC_SERVER_URL       — Backend URL (http://localhost:8000)
     OMC_MAX_ITERATIONS   — Max agent iteration count (default 20)
 

--- a/src/onemancompany/talent_market/talents/openclaw/launch.sh
+++ b/src/onemancompany/talent_market/talents/openclaw/launch.sh
@@ -5,12 +5,12 @@
 #   bash launch.sh <employee_dir>
 #
 # Environment variables (injected by platform):
-#   OMC_EMPLOYEE_ID      — Employee ID
-#   OMC_TASK_ID          — Task ID
-#   OMC_PROJECT_ID       — Project ID
-#   OMC_PROJECT_DIR      — Project workspace (cwd)
-#   OMC_TASK_DESCRIPTION — Full task description
-#   OMC_SERVER_URL       — Backend URL
+#   OMC_EMPLOYEE_ID           — Employee ID
+#   OMC_TASK_ID               — Task ID
+#   OMC_PROJECT_ID            — Project ID
+#   OMC_PROJECT_DIR           — Project workspace (cwd)
+#   OMC_TASK_DESCRIPTION_FILE — Path to file containing task/prompt text
+#   OMC_SERVER_URL            — Backend URL
 #
 # Output: single JSON line to stdout, logs to stderr.
 
@@ -85,6 +85,14 @@ if [ "$GATEWAY_RUNNING" = false ]; then
         sleep 0.5
     done
 fi
+
+# ── Read task description from file ──────────────────────────────────────────
+TASK_DESC_FILE="${OMC_TASK_DESCRIPTION_FILE:-}"
+if [ -z "$TASK_DESC_FILE" ] || [ ! -f "$TASK_DESC_FILE" ]; then
+    >&2 echo "ERROR: OMC_TASK_DESCRIPTION_FILE not set or file not found"
+    exit 1
+fi
+OMC_TASK_DESCRIPTION="$(cat "$TASK_DESC_FILE")"
 
 # ── Run task via openclaw agent ───────────────────────────────────────────────
 >&2 echo "[launch.sh] Employee=${OMC_EMPLOYEE_ID} Task=${OMC_TASK_ID}"

--- a/tests/unit/core/test_subprocess_executor.py
+++ b/tests/unit/core/test_subprocess_executor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -27,7 +28,7 @@ class TestSubprocessExecutor:
 
         ctx = TaskContext(project_id="p1", work_dir="/tmp", employee_id="00010", task_id="t1")
 
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        with patch("onemancompany.core.subprocess_executor.asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await exe.execute("do work", ctx)
 
         assert result.output == "done"
@@ -49,7 +50,7 @@ class TestSubprocessExecutor:
 
         ctx = TaskContext(project_id="p1", work_dir="/tmp", employee_id="00010", task_id="t1")
 
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        with patch("onemancompany.core.subprocess_executor.asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await exe.execute("do work", ctx)
 
         assert result.output == "plain text result"
@@ -68,7 +69,7 @@ class TestSubprocessExecutor:
 
         ctx = TaskContext(project_id="p1", work_dir="/tmp", employee_id="00010", task_id="t1")
 
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        with patch("onemancompany.core.subprocess_executor.asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await exe.execute("do work", ctx)
 
         assert "Error" in result.output
@@ -91,11 +92,70 @@ class TestSubprocessExecutor:
 
         ctx = TaskContext(project_id="p1", work_dir="/tmp", employee_id="00010", task_id="t1")
 
-        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+        with patch("onemancompany.core.subprocess_executor.asyncio.create_subprocess_exec", return_value=mock_proc):
             with pytest.raises(TimeoutError, match="Timeout"):
                 await exe.execute("do work", ctx)
 
         mock_proc.terminate.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_prompt_written_to_temp_file(self):
+        """Task description is written to a temp file and passed via env var."""
+        from onemancompany.core.subprocess_executor import SubprocessExecutor
+
+        exe = SubprocessExecutor(employee_id="00010", script_path="/tmp/test.sh")
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b'{"output":"ok"}', b"")
+        mock_proc.returncode = 0
+        mock_proc.pid = 12345
+
+        ctx = TaskContext(project_id="p1", work_dir="/tmp", employee_id="00010", task_id="t1")
+        captured_env = {}
+
+        async def capture_exec(*args, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            # Verify the prompt file exists and has correct content
+            prompt_path = kwargs["env"]["OMC_TASK_DESCRIPTION_FILE"]
+            with open(prompt_path) as f:
+                assert f.read() == "hello from CEO"
+            return mock_proc
+
+        with patch("onemancompany.core.subprocess_executor.asyncio.create_subprocess_exec", side_effect=capture_exec):
+            await exe.execute("hello from CEO", ctx)
+
+        assert "OMC_TASK_DESCRIPTION_FILE" in captured_env
+        # Temp file should be cleaned up after execution
+        assert not os.path.exists(captured_env["OMC_TASK_DESCRIPTION_FILE"])
+
+    @pytest.mark.asyncio
+    async def test_prompt_file_cleaned_up_on_error(self):
+        """Temp prompt file is cleaned up even when execution fails."""
+        from onemancompany.core.subprocess_executor import SubprocessExecutor
+
+        exe = SubprocessExecutor(employee_id="00010", script_path="/tmp/test.sh")
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.side_effect = asyncio.TimeoutError()
+        mock_proc.terminate = MagicMock()
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock(return_value=0)
+        mock_proc.pid = 12345
+        mock_proc.returncode = None
+
+        ctx = TaskContext(project_id="p1", work_dir="/tmp", employee_id="00010", task_id="t1")
+        captured_path = {}
+
+        async def capture_exec(*args, **kwargs):
+            captured_path["file"] = kwargs["env"]["OMC_TASK_DESCRIPTION_FILE"]
+            return mock_proc
+
+        with patch("onemancompany.core.subprocess_executor.asyncio.create_subprocess_exec", side_effect=capture_exec):
+            with pytest.raises(TimeoutError):
+                await exe.execute("test prompt", ctx)
+
+        # File should still be cleaned up
+        assert not os.path.exists(captured_path["file"])
 
     @pytest.mark.asyncio
     async def test_cancel_graceful(self):
@@ -171,3 +231,70 @@ class TestSubprocessExecutor:
 
         exe = SubprocessExecutor(employee_id="00010", script_path="/tmp/test.sh")
         await exe.cancel()  # should not raise
+
+
+class TestSubprocessAdapterRegistration:
+    def test_subprocess_adapter_registered(self):
+        """SubprocessAdapter is registered and resolvable."""
+        from onemancompany.core.conversation_adapters import (
+            EXECUTOR_TYPE_SUBPROCESS,
+            get_adapter,
+        )
+
+        adapter_cls = get_adapter(EXECUTOR_TYPE_SUBPROCESS)
+        assert adapter_cls.__name__ == "SubprocessAdapter"
+
+    def test_executor_class_map_contains_subprocess(self):
+        """SubprocessExecutor maps to subprocess type."""
+        from onemancompany.core.conversation_adapters import (
+            EXECUTOR_TYPE_SUBPROCESS,
+            _EXECUTOR_CLASS_MAP,
+        )
+
+        assert _EXECUTOR_CLASS_MAP["SubprocessExecutor"] == EXECUTOR_TYPE_SUBPROCESS
+
+    @pytest.mark.asyncio
+    async def test_subprocess_adapter_injects_company_context(self):
+        """SubprocessAdapter prepends company context to conversation prompt."""
+        from onemancompany.core.conversation_adapters import SubprocessAdapter
+        from onemancompany.core.conversation import Conversation, Message
+        from onemancompany.core.models import ConversationType
+
+        adapter = SubprocessAdapter()
+
+        conv = Conversation(
+            id="test-conv",
+            employee_id="00010",
+            type=ConversationType.ONE_ON_ONE,
+            phase="active",
+            tools_enabled=False,
+            metadata={},
+        )
+        messages = []
+        new_msg = Message(sender="00001", role="ceo", text="Hello")
+
+        mock_executor = AsyncMock()
+        mock_executor.execute.return_value = LaunchResult(output="reply from agent")
+
+        captured_prompt = {}
+
+        async def capture_execute(prompt, ctx):
+            captured_prompt["value"] = prompt
+            return LaunchResult(output="reply from agent")
+
+        mock_executor.execute = capture_execute
+
+        mock_em = MagicMock()
+        mock_em.executors = {"00010": mock_executor}
+        mock_em._build_company_context_block.return_value = "[Company Context]\n## Your Persona\nI am OpenClaw\n[/Company Context]"
+
+        with patch("onemancompany.core.conversation_adapters._get_employee_executor", return_value=mock_executor), \
+             patch("onemancompany.core.conversation_adapters.employee_manager", mock_em, create=True), \
+             patch("onemancompany.core.vessel.employee_manager", mock_em), \
+             patch("onemancompany.core.conversation_adapters._resolve_conversation_work_dir", return_value="/tmp"):
+            result = await adapter.send(conv, messages, new_msg)
+
+        assert result == "reply from agent"
+        assert "[Company Context]" in captured_prompt["value"]
+        assert "I am OpenClaw" in captured_prompt["value"]
+        assert "Hello" in captured_prompt["value"]


### PR DESCRIPTION
## Summary
- **Root cause**: OpenClaw employees use `SubprocessExecutor` but `conversation_adapters._EXECUTOR_CLASS_MAP` had no mapping for it, silently falling back to LangChain adapter which cannot communicate with subprocess-based agents
- **SubprocessAdapter**: New adapter registered alongside LangChain and ClaudeSession, injects company context (identity, culture, SOPs, guidance, work principles) into conversation prompts — matching what `vessel._execute_task` does for scheduled tasks
- **Prompt delivery via file**: Switched from `OMC_TASK_DESCRIPTION` env var to `OMC_TASK_DESCRIPTION_FILE` (temp file) to avoid OS env var length limits on conversation prompts with history
- **launch.sh updated**: OpenClaw's launch.sh reads prompt from file instead of env var
- **Tests**: 6 new tests covering prompt file lifecycle, cleanup on error, adapter registration, executor class mapping, and company context injection

## Test plan
- [x] All 2182 unit tests pass
- [ ] Deploy to omc-test-2, hire an OpenClaw employee, verify 1-on-1 conversation works
- [ ] Verify task execution still works (prompt file path instead of env var)

🤖 Generated with [Claude Code](https://claude.com/claude-code)