### PR TITLE
fix: keep OMC_TASK_DESCRIPTION env var for backward compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.674",
+  "version": "0.2.675",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.674"
+version = "0.2.675"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/subprocess_executor.py
+++ b/src/onemancompany/core/subprocess_executor.py
@@ -54,7 +54,7 @@ class SubprocessExecutor(Launcher):
         prompt_file.close()
 
         try:
-            return await self._run_subprocess(prompt_file.name, context, on_log)
+            return await self._run_subprocess(task_description, prompt_file.name, context, on_log)
         finally:
             try:
                 os.unlink(prompt_file.name)
@@ -63,6 +63,7 @@ class SubprocessExecutor(Launcher):
 
     async def _run_subprocess(
         self,
+        task_description: str,
         prompt_path: str,
         context: TaskContext,
         on_log: Callable[[str, str], None] | None,
@@ -74,6 +75,8 @@ class SubprocessExecutor(Launcher):
             "OMC_PROJECT_ID": context.project_id,
             "OMC_PROJECT_DIR": context.work_dir,
             "OMC_TASK_DESCRIPTION_FILE": prompt_path,
+            # Keep OMC_TASK_DESCRIPTION for backward compat with old launch.sh scripts
+            "OMC_TASK_DESCRIPTION": task_description,
             "OMC_SERVER_URL": f"http://localhost:{os.environ.get('OMC_PORT', '8000')}",
         }
 


### PR DESCRIPTION
## Summary
- Deployed employees have old launch.sh scripts that read `OMC_TASK_DESCRIPTION` directly
- PR #150 removed this env var, breaking all existing subprocess employees
- Now SubprocessExecutor sets BOTH `OMC_TASK_DESCRIPTION_FILE` (preferred) and `OMC_TASK_DESCRIPTION` (backward compat)

## Test plan
- [x] 2183 unit tests pass
- [ ] Verify OpenClaw employee works with old launch.sh in omc-test-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)