### PR TITLE
fix: openclaw agent requires -m flag for message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.675",
+  "version": "0.2.676",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.675"
+version = "0.2.676"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/talent_market/talents/openclaw/launch.sh
+++ b/src/onemancompany/talent_market/talents/openclaw/launch.sh
@@ -97,7 +97,7 @@ OMC_TASK_DESCRIPTION="$(cat "$TASK_DESC_FILE")"
 # ── Run task via openclaw agent ───────────────────────────────────────────────
 >&2 echo "[launch.sh] Employee=${OMC_EMPLOYEE_ID} Task=${OMC_TASK_ID}"
 
-OUTPUT=$("$OPENCLAW_BIN" agent "$OMC_TASK_DESCRIPTION" 2>/dev/null || echo "")
+OUTPUT=$("$OPENCLAW_BIN" agent -m "$OMC_TASK_DESCRIPTION" 2>/dev/null || echo "")
 
 if [ -z "$OUTPUT" ]; then
     OUTPUT="[openclaw] No output returned"


### PR DESCRIPTION
## Summary
- `openclaw agent` CLI requires `-m` / `--message` flag, not positional argument
- Without it, command exits with error, which was silenced by `2>/dev/null`
- Result: empty output → `[openclaw] No output returned`

One-char fix: `agent "$DESC"` → `agent -m "$DESC"`

## Test plan
- [ ] Verify OpenClaw employee produces actual output in omc-test-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)