### PR TITLE
feat: EA analyzes CEO inbox conversations for accept/reject + follow-up tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.677",
+  "version": "0.2.678",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.677"
+version = "0.2.678"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -6032,7 +6032,12 @@ async def _complete_ceo_request(
 
 
 async def _run_conversation_loop(session, node, tree, project_dir):
-    """Run conversation loop and handle completion."""
+    """Run conversation loop and handle completion.
+
+    After CEO ends the conversation, EA analyzes the full dialogue to determine:
+    - accept or reject (drives node status)
+    - any follow-up tasks the CEO requested (dispatched via COO)
+    """
     try:
         summary = await session.run()
         logger.info("[ceo_inbox] conversation completed: node={}, summary_len={}", node.id, len(summary))
@@ -6040,7 +6045,6 @@ async def _run_conversation_loop(session, node, tree, project_dir):
         ea_auto_replied = not session._ceo_replied
         if ea_auto_replied:
             # EA auto-reply: fully automatic, go straight to ACCEPTED.
-            # CEO doesn't need to confirm — can review the conversation later.
             await _complete_ceo_request(
                 node, tree, project_dir,
                 target_status=TaskPhase.ACCEPTED,
@@ -6048,13 +6052,9 @@ async def _run_conversation_loop(session, node, tree, project_dir):
                 notes="EA auto-replied",
             )
         else:
-            # CEO replied directly: go straight to ACCEPTED
-            await _complete_ceo_request(
-                node, tree, project_dir,
-                target_status=TaskPhase.ACCEPTED,
-                result=summary,
-                notes="CEO responded directly",
-            )
+            # CEO replied directly — EA analyzes the conversation for intent
+            verdict = await _ea_analyze_and_settle(session, node, tree, project_dir, summary)
+            logger.info("[ceo_inbox] verdict: node={} decision={}", node.id, verdict.get("decision"))
     except asyncio.CancelledError:
         raise
     except Exception as e:
@@ -6073,6 +6073,76 @@ async def _run_conversation_loop(session, node, tree, project_dir):
         session._cancel_ea_timer()
         unregister_session(session.node_id)
         await ws_manager.broadcast({"type": "ceo_inbox_updated"})
+
+
+async def _ea_analyze_and_settle(session, node, tree, project_dir, summary) -> dict:
+    """EA analyzes CEO conversation and settles the inbox item accordingly."""
+    from onemancompany.core.ceo_conversation import (
+        _ea_analyze_conversation, load_messages, CONVERSATIONS_DIR_NAME,
+    )
+
+    conv_dir = Path(project_dir) / CONVERSATIONS_DIR_NAME
+    history = load_messages(conv_dir, node.id)
+    description = node.description or summary
+
+    verdict = await _ea_analyze_conversation(history, description, node.id)
+    decision = verdict.get("decision", "accept")
+    reason = verdict.get("reason", "")
+
+    if decision == "reject":
+        await _complete_ceo_request(
+            node, tree, project_dir,
+            target_status=TaskPhase.CANCELLED,
+            result=summary,
+            notes=f"CEO rejected: {reason}",
+        )
+    else:
+        await _complete_ceo_request(
+            node, tree, project_dir,
+            target_status=TaskPhase.ACCEPTED,
+            result=summary,
+            notes=f"CEO accepted: {reason}",
+        )
+
+    # Dispatch follow-up tasks if CEO requested additional work
+    follow_ups = verdict.get("follow_up_tasks", [])
+    if follow_ups:
+        await _dispatch_follow_up_tasks(follow_ups, node, project_dir)
+
+    return verdict
+
+
+async def _dispatch_follow_up_tasks(follow_ups: list[dict], source_node, project_dir: str):
+    """Dispatch follow-up tasks extracted from CEO conversation via COO."""
+    from onemancompany.core.vessel import employee_manager
+    from onemancompany.core.config import COO_ID
+
+    for ft in follow_ups:
+        desc = ft.get("description", "")
+        if not desc:
+            continue
+
+        try:
+            # Use COO to dispatch — it knows how to route to the right employee
+            coo_executor = employee_manager.executors.get(COO_ID)
+            if coo_executor:
+                prompt = (
+                    f"The CEO has requested the following additional task during an inbox conversation:\n\n"
+                    f"Task: {desc}\n\n"
+                    f"Context: This came from a conversation about: {source_node.description or 'N/A'}\n\n"
+                    f"Please dispatch this task to the appropriate employee."
+                )
+                logger.info(
+                    "[follow_up] dispatching via COO: desc={}, source_node={}",
+                    desc[:80], source_node.id,
+                )
+                await employee_manager.schedule_system_task(
+                    COO_ID, prompt, source=f"ceo_inbox_follow_up:{source_node.id}",
+                )
+            else:
+                logger.warning("[follow_up] COO executor not found, cannot dispatch: {}", desc[:80])
+        except Exception as exc:
+            logger.error("[follow_up] failed to dispatch task '{}': {}", desc[:80], exc)
 
 
 @router.post("/api/ceo/inbox/{node_id}/message")

--- a/src/onemancompany/core/ceo_conversation.py
+++ b/src/onemancompany/core/ceo_conversation.py
@@ -201,6 +201,89 @@ async def _ea_auto_reply(node_id: str, description: str, broadcast_fn) -> str:
     return reply_text
 
 
+async def _ea_analyze_conversation(
+    history: list[dict], description: str, node_id: str,
+) -> dict:
+    """EA analyzes a completed CEO inbox conversation to extract intent.
+
+    Returns:
+        {
+            "decision": "accept" | "reject",
+            "reason": "brief explanation",
+            "follow_up_tasks": [{"description": "...", "assignee_hint": "..."}]
+        }
+    """
+    from onemancompany.agents.base import make_llm, tracked_ainvoke, _extract_text
+    from onemancompany.core.config import EA_ID
+
+    # Format conversation for the prompt
+    conv_lines = []
+    for m in history:
+        role = "CEO" if m["sender"] == CEO_SENDER else "Employee"
+        conv_lines.append(f"[{role}]: {m['text']}")
+    conv_text = "\n".join(conv_lines)
+
+    try:
+        llm = make_llm(EA_ID)
+    except Exception as exc:
+        logger.error("[ea_analyze] failed to create LLM for node {}: {}", node_id, exc)
+        return {"decision": "accept", "reason": "EA analysis failed, defaulting to accept", "follow_up_tasks": []}
+
+    prompt = (
+        "You are the EA (Executive Assistant). Analyze this completed CEO inbox conversation "
+        "and determine the CEO's intent.\n\n"
+        f"Original request from employee:\n---\n{description}\n---\n\n"
+        f"Conversation:\n---\n{conv_text}\n---\n\n"
+        "Determine:\n"
+        "1. Did the CEO accept or reject the employee's request?\n"
+        "2. Did the CEO mention any follow-up tasks or additional instructions?\n\n"
+        "Guidelines:\n"
+        "- If CEO said things like 'ok', 'approved', 'go ahead', 'sounds good' → accept\n"
+        "- If CEO said things like 'no', 'reject', 'don't do this', 'not now' → reject\n"
+        "- If CEO gave instructions like 'also do X', 'add Y', 'change Z' → extract as follow_up_tasks\n"
+        "- follow_up_tasks should only include NEW tasks the CEO requested, not the original request\n"
+        "- assignee_hint can be a role like 'COO', 'HR', or empty string if unclear\n"
+        "- If the conversation is ambiguous, default to accept\n\n"
+        "Return JSON only:\n"
+        '{"decision": "accept" or "reject", "reason": "brief explanation", '
+        '"follow_up_tasks": [{"description": "task description", "assignee_hint": "role or employee_id"}]}\n'
+        "Only return JSON, no other content."
+    )
+
+    try:
+        resp = await tracked_ainvoke(llm, prompt, category="ea_analyze_conversation", employee_id=EA_ID)
+        raw = _extract_text(resp.content)
+
+        json_match = re.search(r'\{.*\}', raw, re.DOTALL)
+        if json_match:
+            parsed = json.loads(json_match.group())
+            decision = parsed.get("decision", "accept")
+            reason = parsed.get("reason", "")
+            follow_ups = parsed.get("follow_up_tasks", [])
+            # Validate follow_ups structure
+            valid_follow_ups = []
+            for ft in (follow_ups or []):
+                if isinstance(ft, dict) and ft.get("description"):
+                    valid_follow_ups.append({
+                        "description": ft["description"],
+                        "assignee_hint": ft.get("assignee_hint", ""),
+                    })
+            result = {
+                "decision": decision if decision in ("accept", "reject") else "accept",
+                "reason": reason,
+                "follow_up_tasks": valid_follow_ups,
+            }
+            logger.info(
+                "[ea_analyze] node={} decision={} reason={} follow_ups={}",
+                node_id, result["decision"], reason[:80], len(valid_follow_ups),
+            )
+            return result
+    except Exception as exc:
+        logger.error("[ea_analyze] failed for node {}: {}", node_id, exc)
+
+    return {"decision": "accept", "reason": "EA analysis failed, defaulting to accept", "follow_up_tasks": []}
+
+
 class ConversationSession:
     """Manages an async CEO<->employee conversation for one task node."""
 

--- a/tests/unit/core/test_ceo_conversation.py
+++ b/tests/unit/core/test_ceo_conversation.py
@@ -10,6 +10,7 @@ from onemancompany.core.ceo_conversation import (
     EA_SENDER,
     EA_AUTO_REPLY_DELAY_SECONDS,
     ConversationSession,
+    _ea_analyze_conversation,
     append_message,
     load_messages,
     COMPLETE_SIGNAL,
@@ -237,3 +238,93 @@ class TestEaAutoReply:
         msgs = load_messages(tmp_path / "conversations", "ea_skip_test")
         ea_msgs = [m for m in msgs if "EA Auto-Reply" in m.get("text", "")]
         assert len(ea_msgs) == 0
+
+
+class TestEaAnalyzeConversation:
+    """Tests for _ea_analyze_conversation — CEO intent extraction."""
+
+    @pytest.mark.asyncio
+    async def test_accept_decision(self):
+        """EA correctly identifies CEO acceptance."""
+        history = [
+            {"sender": "00003", "text": "Can I hire a new engineer?"},
+            {"sender": "ceo", "text": "Yes, go ahead."},
+        ]
+
+        mock_resp = MagicMock()
+        mock_resp.content = '{"decision": "accept", "reason": "CEO approved", "follow_up_tasks": []}'
+
+        with patch("onemancompany.agents.base.make_llm"), \
+             patch("onemancompany.agents.base.tracked_ainvoke", return_value=mock_resp), \
+             patch("onemancompany.agents.base._extract_text", return_value=mock_resp.content):
+            result = await _ea_analyze_conversation(history, "Hire a new engineer", "node1")
+
+        assert result["decision"] == "accept"
+        assert result["follow_up_tasks"] == []
+
+    @pytest.mark.asyncio
+    async def test_reject_decision(self):
+        """EA correctly identifies CEO rejection."""
+        history = [
+            {"sender": "00003", "text": "Can I buy new servers?"},
+            {"sender": "ceo", "text": "No, reject this. We don't need them."},
+        ]
+
+        mock_resp = MagicMock()
+        mock_resp.content = '{"decision": "reject", "reason": "CEO said no", "follow_up_tasks": []}'
+
+        with patch("onemancompany.agents.base.make_llm"), \
+             patch("onemancompany.agents.base.tracked_ainvoke", return_value=mock_resp), \
+             patch("onemancompany.agents.base._extract_text", return_value=mock_resp.content):
+            result = await _ea_analyze_conversation(history, "Buy new servers", "node2")
+
+        assert result["decision"] == "reject"
+
+    @pytest.mark.asyncio
+    async def test_follow_up_tasks_extracted(self):
+        """EA extracts follow-up tasks from CEO instructions."""
+        history = [
+            {"sender": "00003", "text": "Report: Q1 revenue up 20%"},
+            {"sender": "ceo", "text": "Good. Also prepare a Q2 forecast and update the investor deck."},
+        ]
+
+        mock_resp = MagicMock()
+        mock_resp.content = (
+            '{"decision": "accept", "reason": "CEO approved report", '
+            '"follow_up_tasks": ['
+            '{"description": "Prepare Q2 forecast", "assignee_hint": "COO"}, '
+            '{"description": "Update investor deck", "assignee_hint": ""}'
+            ']}'
+        )
+
+        with patch("onemancompany.agents.base.make_llm"), \
+             patch("onemancompany.agents.base.tracked_ainvoke", return_value=mock_resp), \
+             patch("onemancompany.agents.base._extract_text", return_value=mock_resp.content):
+            result = await _ea_analyze_conversation(history, "Q1 report", "node3")
+
+        assert result["decision"] == "accept"
+        assert len(result["follow_up_tasks"]) == 2
+        assert result["follow_up_tasks"][0]["description"] == "Prepare Q2 forecast"
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_defaults_to_accept(self):
+        """When EA LLM call fails, default to accept with no follow-ups."""
+        with patch("onemancompany.agents.base.make_llm", side_effect=Exception("LLM down")):
+            result = await _ea_analyze_conversation([], "test", "node_err")
+
+        assert result["decision"] == "accept"
+        assert result["follow_up_tasks"] == []
+
+    @pytest.mark.asyncio
+    async def test_malformed_json_defaults_to_accept(self):
+        """When EA returns unparseable response, default to accept."""
+        mock_resp = MagicMock()
+        mock_resp.content = "I think the CEO accepted this request."
+
+        with patch("onemancompany.agents.base.make_llm"), \
+             patch("onemancompany.agents.base.tracked_ainvoke", return_value=mock_resp), \
+             patch("onemancompany.agents.base._extract_text", return_value=mock_resp.content):
+            result = await _ea_analyze_conversation([], "test", "node_bad")
+
+        assert result["decision"] == "accept"
+        assert result["follow_up_tasks"] == []


### PR DESCRIPTION
## Summary
Previously all CEO inbox conversations were marked ACCEPTED regardless of CEO's actual response. Now:

- **EA intent analysis**: When CEO ends a conversation, EA analyzes the full dialogue to determine accept/reject
- **Reject support**: If CEO rejected, node → CANCELLED (not ACCEPTED)
- **Follow-up task dispatch**: If CEO mentioned additional tasks ("also do X"), they are dispatched to COO as system tasks
- EA auto-reply path unchanged (still goes straight to ACCEPTED)

### New functions
- `_ea_analyze_conversation()` — LLM-based conversation analysis returning structured `{decision, reason, follow_up_tasks}`
- `_ea_analyze_and_settle()` — Settles inbox node based on EA verdict
- `_dispatch_follow_up_tasks()` — Dispatches CEO's additional instructions via COO

## Test plan
- [x] 2187 unit tests pass (5 new)
- [ ] Test accept: CEO says "ok go ahead" → node ACCEPTED
- [ ] Test reject: CEO says "no don't do this" → node CANCELLED
- [ ] Test follow-ups: CEO says "ok, also do X" → node ACCEPTED + X dispatched to COO

🤖 Generated with [Claude Code](https://claude.com/claude-code)