### PR TITLE
fix: add Docs link to homepage nav

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -636,6 +636,7 @@
       <li><a href="#features">Features</a></li>
       <li><a href="#how">How It Works</a></li>
       <li><a href="#start">Quick Start</a></li>
+      <li><a href="docs/">Docs</a></li>
       <li><a href="https://github.com/1mancompany/OneManCompany">GitHub</a></li>
     </ul>
   </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.680",
+  "version": "0.2.681",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.680"
+version = "0.2.681"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
Add Docs link between Quick Start and GitHub in the nav bar, pointing to docs/ (MkDocs site).