### PR TITLE
feat: founding team agent_family hot-swap (langchain/claude/openclaw)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.683",
+  "version": "0.2.684",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.682",
+  "version": "0.2.683",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.683"
+version = "0.2.684"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.682"
+version = "0.2.683"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -1877,6 +1877,71 @@ async def update_employee_hosting(employee_id: str, body: dict) -> dict:
     }
 
 
+@router.put("/api/employee/{employee_id}/agent-family")
+async def update_agent_family(employee_id: str, body: dict) -> dict:
+    """Switch an employee's agent family (executor backend) with live hot-swap.
+
+    Supported families: langchain, claude, openclaw.
+    Employee must be idle (not running any tasks).
+    No server restart required — executor is swapped immediately.
+    """
+    from onemancompany.core.config import FOUNDING_IDS, employee_configs
+    from onemancompany.core.vessel import switch_agent_family
+
+    new_family = body.get("agent_family", "").strip().lower()
+    if new_family not in ("langchain", "claude", "openclaw"):
+        raise HTTPException(status_code=400, detail="Invalid agent_family. Must be langchain, claude, or openclaw.")
+
+    emp = _require_employee(employee_id)
+    cfg = employee_configs.get(employee_id)
+    if not cfg:
+        raise HTTPException(status_code=404, detail="Employee config not found")
+
+    old_family = cfg.agent_family or "langchain"
+    if old_family == new_family:
+        return {"status": "unchanged", "agent_family": new_family}
+
+    # Resolve the LangChain agent class for founding employees
+    agent_cls = None
+    if employee_id in FOUNDING_IDS:
+        from onemancompany.agents.hr_agent import HRAgent
+        from onemancompany.agents.coo_agent import COOAgent
+        from onemancompany.agents.ea_agent import EAAgent
+        from onemancompany.agents.cso_agent import CSOAgent
+        from onemancompany.core.config import HR_ID, COO_ID, EA_ID, CSO_ID
+        _founding_map = {HR_ID: HRAgent, COO_ID: COOAgent, EA_ID: EAAgent, CSO_ID: CSOAgent}
+        agent_cls = _founding_map.get(employee_id)
+
+    try:
+        executor_name = await switch_agent_family(employee_id, new_family, agent_cls=agent_cls)
+    except RuntimeError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
+    # Persist to profile.yaml
+    await _store.save_employee(employee_id, {"agent_family": new_family})
+
+    family_labels = {"langchain": "LangChain", "claude": "Claude Session", "openclaw": "OpenClaw"}
+    label = family_labels.get(new_family, new_family)
+
+    await event_bus.publish(
+        CompanyEvent(
+            type=EventType.AGENT_DONE,
+            payload={
+                "role": "CEO",
+                "summary": f"Switched {emp['name']} to {label} executor. Active immediately.",
+            },
+            agent="CEO",
+        )
+    )
+
+    return {
+        "status": "updated",
+        "agent_family": new_family,
+        "executor": executor_name,
+        "restart_required": False,
+    }
+
+
 
 
 # ===== Global API Settings =====

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -473,6 +473,7 @@ class EmployeeConfig(BaseModel):
     api_provider: str = "openrouter"  # provider name from PROVIDER_REGISTRY
     api_key: str = ""  # Custom API key (used when api_provider != "openrouter")
     hosting: str = "company"  # "company" = company-hosted (server manages agent loop) | "self" = self-hosted (external process, e.g. Claude Code)
+    agent_family: str = ""  # "langchain" | "claude" | "openclaw" | "" (auto-detect from hosting + launch.sh)
     auth_method: str = "api_key"  # "api_key" | "oauth" (OAuth PKCE for Anthropic)
     oauth_refresh_token: str = ""  # OAuth refresh token (long-lived)
 

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -3118,6 +3118,106 @@ def register_self_hosted(
     return employee_manager.register(employee_id, executor, config=config)
 
 
+def _register_founding_employee(
+    employee_id: str,
+    agent_cls: type,
+    emp_cfgs: dict,
+    employees_dir,
+) -> Vessel:
+    """Register a founding employee with the appropriate executor based on agent_family.
+
+    agent_family priority:
+      1. profile.yaml agent_family field (explicit)
+      2. Fallback: "claude" if hosting=="self", else "langchain"
+    """
+    from onemancompany.core.vessel_config import load_vessel_config
+
+    cfg = emp_cfgs.get(employee_id)
+    emp_dir = employees_dir / employee_id
+    vessel_cfg = load_vessel_config(emp_dir) if emp_dir.exists() else None
+
+    family = (cfg.agent_family if cfg and cfg.agent_family else "").strip().lower()
+    if not family:
+        # Auto-detect from hosting
+        if cfg and cfg.hosting == "self":
+            family = "claude"
+        else:
+            family = "langchain"
+
+    executor = _create_executor_for_family(family, employee_id, agent_cls, emp_dir)
+    vessel = employee_manager.register(employee_id, executor, config=vessel_cfg)
+    logger.info(
+        "[startup] Registered {} ({}) — {} executor",
+        cfg.name if cfg else employee_id, employee_id,
+        type(executor).__name__,
+    )
+    return vessel
+
+
+def _create_executor_for_family(
+    family: str,
+    employee_id: str,
+    agent_cls: type | None,
+    emp_dir,
+) -> Launcher:
+    """Create the appropriate executor for an agent_family string."""
+    from onemancompany.core.config import LAUNCH_SH_FILENAME
+
+    if family == "claude":
+        return ClaudeSessionExecutor(employee_id)
+    elif family == "openclaw":
+        from onemancompany.core.subprocess_executor import SubprocessExecutor
+        script_path = str(emp_dir / LAUNCH_SH_FILENAME)
+        return SubprocessExecutor(employee_id, script_path=script_path)
+    else:
+        # Default: langchain
+        runner = agent_cls() if agent_cls else None
+        if runner is None:
+            from onemancompany.agents.base import EmployeeAgent
+            runner = EmployeeAgent(employee_id)
+        return LangChainExecutor(runner)
+
+
+async def switch_agent_family(
+    employee_id: str,
+    new_family: str,
+    agent_cls: type | None = None,
+) -> str:
+    """Hot-swap an employee's executor to a different agent family.
+
+    Requires employee to be idle (not running any tasks).
+    Returns the new executor class name.
+    """
+    from onemancompany.core.config import EMPLOYEES_DIR, employee_configs
+
+    if employee_id in employee_manager._running_tasks:
+        raise RuntimeError(f"Employee {employee_id} is currently running a task, cannot switch")
+
+    new_family = new_family.strip().lower()
+    if new_family not in ("langchain", "claude", "openclaw"):
+        raise ValueError(f"Invalid agent_family: {new_family}. Must be langchain, claude, or openclaw.")
+
+    emp_dir = EMPLOYEES_DIR / employee_id
+    executor = _create_executor_for_family(new_family, employee_id, agent_cls, emp_dir)
+
+    # Re-register: unregister first to clean up, then register new executor
+    # Preserve vessel config
+    old_config = employee_manager.configs.get(employee_id)
+    employee_manager.unregister(employee_id)
+    employee_manager.register(employee_id, executor, config=old_config)
+
+    # Update in-memory config
+    cfg = employee_configs.get(employee_id)
+    if cfg:
+        cfg.agent_family = new_family
+
+    logger.info(
+        "[agent_family] Switched {} to {} ({})",
+        employee_id, new_family, type(executor).__name__,
+    )
+    return type(executor).__name__
+
+
 def get_agent_loop(employee_id: str) -> Vessel | None:
     """Get an employee's vessel (backward compat for PersistentAgentLoop callers)."""
     return employee_manager.get_handle(employee_id)

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -3118,7 +3118,7 @@ def register_self_hosted(
     return employee_manager.register(employee_id, executor, config=config)
 
 
-def _register_founding_employee(
+def register_founding_employee(
     employee_id: str,
     agent_cls: type,
     emp_cfgs: dict,
@@ -3192,6 +3192,8 @@ async def switch_agent_family(
 
     if employee_id in employee_manager._running_tasks:
         raise RuntimeError(f"Employee {employee_id} is currently running a task, cannot switch")
+    if employee_id in employee_manager._system_tasks:
+        raise RuntimeError(f"Employee {employee_id} has a system task running, cannot switch")
 
     new_family = new_family.strip().lower()
     if new_family not in ("langchain", "claude", "openclaw"):

--- a/src/onemancompany/main.py
+++ b/src/onemancompany/main.py
@@ -490,21 +490,15 @@ async def lifespan(app: FastAPI):
     from onemancompany.core.vessel_config import load_vessel_config
     from onemancompany.core.config import EMPLOYEES_DIR as _EMPLOYEES_DIR, employee_configs as _emp_cfgs
 
-    # Founding employees — hosting-aware registration
+    # Founding employees — agent_family-aware registration
+    from onemancompany.core.vessel import _register_founding_employee
     _founding_agents = {
         _HR_ID: HRAgent, _COO_ID: COOAgent,
         _EA_ID: EAAgent, _CSO_ID: CSOAgent,
     }
     _registered_founding = set()
     for _fid, _agent_cls in _founding_agents.items():
-        _fcfg = _emp_cfgs.get(_fid)
-        _emp_dir_f = _EMPLOYEES_DIR / _fid
-        _f_vessel = load_vessel_config(_emp_dir_f) if _emp_dir_f.exists() else None
-        if _fcfg and _fcfg.hosting == HostingMode.SELF:
-            register_self_hosted(_fid, config=_f_vessel)
-            print(f"[startup] Registered self-hosted founding {_fid}")
-        else:
-            register_agent(_fid, _agent_cls(), config=_f_vessel)
+        _register_founding_employee(_fid, _agent_cls, _emp_cfgs, _EMPLOYEES_DIR)
         _registered_founding.add(_fid)
 
     # Non-founding employees — register ALL in EmployeeManager (unified dispatch)

--- a/src/onemancompany/main.py
+++ b/src/onemancompany/main.py
@@ -491,14 +491,14 @@ async def lifespan(app: FastAPI):
     from onemancompany.core.config import EMPLOYEES_DIR as _EMPLOYEES_DIR, employee_configs as _emp_cfgs
 
     # Founding employees — agent_family-aware registration
-    from onemancompany.core.vessel import _register_founding_employee
+    from onemancompany.core.vessel import register_founding_employee
     _founding_agents = {
         _HR_ID: HRAgent, _COO_ID: COOAgent,
         _EA_ID: EAAgent, _CSO_ID: CSOAgent,
     }
     _registered_founding = set()
     for _fid, _agent_cls in _founding_agents.items():
-        _register_founding_employee(_fid, _agent_cls, _emp_cfgs, _EMPLOYEES_DIR)
+        register_founding_employee(_fid, _agent_cls, _emp_cfgs, _EMPLOYEES_DIR)
         _registered_founding.add(_fid)
 
     # Non-founding employees — register ALL in EmployeeManager (unified dispatch)

--- a/tests/unit/core/test_agent_family.py
+++ b/tests/unit/core/test_agent_family.py
@@ -1,0 +1,95 @@
+"""Tests for agent_family switching — _create_executor_for_family, switch_agent_family."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from onemancompany.core.vessel import (
+    LangChainExecutor,
+    ClaudeSessionExecutor,
+    _create_executor_for_family,
+)
+
+
+class TestCreateExecutorForFamily:
+    def test_langchain_with_agent_cls(self):
+        mock_cls = MagicMock
+        executor = _create_executor_for_family("langchain", "00002", mock_cls, "/tmp")
+        assert isinstance(executor, LangChainExecutor)
+
+    def test_langchain_without_agent_cls(self):
+        with patch("onemancompany.agents.base.EmployeeAgent", MagicMock):
+            executor = _create_executor_for_family("langchain", "00010", None, "/tmp")
+        assert isinstance(executor, LangChainExecutor)
+
+    def test_claude(self):
+        executor = _create_executor_for_family("claude", "00002", MagicMock, "/tmp")
+        assert isinstance(executor, ClaudeSessionExecutor)
+
+    def test_openclaw(self):
+        from pathlib import Path
+        from onemancompany.core.subprocess_executor import SubprocessExecutor
+        executor = _create_executor_for_family("openclaw", "00002", MagicMock, Path("/tmp"))
+        assert isinstance(executor, SubprocessExecutor)
+
+    def test_unknown_defaults_to_langchain(self):
+        executor = _create_executor_for_family("unknown", "00002", MagicMock, "/tmp")
+        assert isinstance(executor, LangChainExecutor)
+
+
+class TestSwitchAgentFamily:
+    @pytest.mark.asyncio
+    async def test_switch_idle_employee(self):
+        from onemancompany.core.vessel import switch_agent_family, employee_manager
+
+        # Register a mock employee first
+        mock_executor = MagicMock()
+        employee_manager.register("99999", mock_executor)
+
+        mock_cfg = MagicMock()
+        mock_cfg.agent_family = "langchain"
+
+        with patch("onemancompany.core.config.employee_configs", {"99999": mock_cfg}), \
+             patch("onemancompany.core.config.EMPLOYEES_DIR", MagicMock()):
+            result = await switch_agent_family("99999", "claude")
+
+        assert result == "ClaudeSessionExecutor"
+        assert isinstance(employee_manager.executors["99999"], ClaudeSessionExecutor)
+        assert mock_cfg.agent_family == "claude"
+
+        # Cleanup
+        employee_manager.unregister("99999")
+
+    @pytest.mark.asyncio
+    async def test_switch_busy_employee_raises(self):
+        from onemancompany.core.vessel import switch_agent_family, employee_manager
+
+        employee_manager._running_tasks["99998"] = MagicMock()
+
+        with pytest.raises(RuntimeError, match="currently running"):
+            await switch_agent_family("99998", "claude")
+
+        # Cleanup
+        employee_manager._running_tasks.pop("99998", None)
+
+    @pytest.mark.asyncio
+    async def test_switch_system_task_running_raises(self):
+        from onemancompany.core.vessel import switch_agent_family, employee_manager
+
+        employee_manager.register("99997", MagicMock())
+        employee_manager._system_tasks["99997"] = MagicMock()
+
+        with pytest.raises(RuntimeError, match="system task"):
+            await switch_agent_family("99997", "claude")
+
+        # Cleanup
+        employee_manager._system_tasks.pop("99997", None)
+        employee_manager.unregister("99997")
+
+    @pytest.mark.asyncio
+    async def test_switch_invalid_family_raises(self):
+        from onemancompany.core.vessel import switch_agent_family
+
+        with pytest.raises(ValueError, match="Invalid agent_family"):
+            await switch_agent_family("99999", "invalid_family")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -396,10 +396,12 @@ class TestLifespan:
         monkeypatch.setattr(main_mod, "_restore_ephemeral_state", MagicMock())
         monkeypatch.setattr(main_mod, "_save_ephemeral_state", MagicMock())
 
+        mock_register_founding = MagicMock()
         mock_register_agent = MagicMock()
         mock_register_self_hosted = MagicMock()
         mock_start_all = AsyncMock()
         mock_stop_all = AsyncMock()
+        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", mock_register_self_hosted)
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", mock_start_all)
@@ -456,7 +458,7 @@ class TestLifespan:
             mock_start_sandbox.assert_called_once()
             mock_start_tm.assert_awaited_once()
             mock_start_all.assert_awaited_once()
-            assert mock_register_agent.call_count == 4  # HR, COO, EA, CSO
+            assert mock_register_founding.call_count == 4  # HR, COO, EA, CSO
 
         # Verify shutdown was called
         mock_stop_all.assert_awaited_once()
@@ -476,8 +478,10 @@ class TestLifespan:
         monkeypatch.setattr(main_mod, "_restore_ephemeral_state", MagicMock())
         monkeypatch.setattr(main_mod, "_save_ephemeral_state", MagicMock())
 
+        mock_register_founding = MagicMock()
         mock_register_agent = MagicMock()
         mock_register_self_hosted = MagicMock()
+        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", mock_register_self_hosted)
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", AsyncMock())
@@ -523,8 +527,9 @@ class TestLifespan:
         async with main_mod.lifespan(mock_app):
             pass
 
-        # 4 founding + 1 non-founding = 5 register_agent calls
-        assert mock_register_agent.call_count == 5
+        # 4 founding via _register_founding_employee, 1 non-founding via register_agent
+        assert mock_register_founding.call_count == 4
+        assert mock_register_agent.call_count == 1
 
     @pytest.mark.asyncio
     async def test_lifespan_registers_self_hosted_employees(self, monkeypatch):
@@ -537,8 +542,10 @@ class TestLifespan:
         monkeypatch.setattr(main_mod, "_restore_ephemeral_state", MagicMock())
         monkeypatch.setattr(main_mod, "_save_ephemeral_state", MagicMock())
 
+        mock_register_founding = MagicMock()
         mock_register_agent = MagicMock()
         mock_register_self_hosted = MagicMock()
+        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", mock_register_self_hosted)
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", AsyncMock())
@@ -596,8 +603,10 @@ class TestLifespan:
         monkeypatch.setattr(main_mod, "_restore_ephemeral_state", MagicMock())
         monkeypatch.setattr(main_mod, "_save_ephemeral_state", MagicMock())
 
+        mock_register_founding = MagicMock()
         mock_register_agent = MagicMock()
         mock_register_self_hosted = MagicMock()
+        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", mock_register_self_hosted)
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", AsyncMock())
@@ -639,7 +648,8 @@ class TestLifespan:
             pass
 
         # Only the 4 founding registrations (HR, COO, EA, CSO), not the extra one
-        assert mock_register_agent.call_count == 4
+        assert mock_register_founding.call_count == 4
+        assert mock_register_agent.call_count == 0
 
     @pytest.mark.asyncio
     async def test_lifespan_skips_high_level_employees(self, monkeypatch):
@@ -652,7 +662,9 @@ class TestLifespan:
         monkeypatch.setattr(main_mod, "_restore_ephemeral_state", MagicMock())
         monkeypatch.setattr(main_mod, "_save_ephemeral_state", MagicMock())
 
+        mock_register_founding = MagicMock()
         mock_register_agent = MagicMock()
+        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", MagicMock())
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", AsyncMock())
@@ -694,7 +706,8 @@ class TestLifespan:
             pass
 
         # Only 4 founding, not 5
-        assert mock_register_agent.call_count == 4
+        assert mock_register_founding.call_count == 4
+        assert mock_register_agent.call_count == 0
 
     @pytest.mark.asyncio
     async def test_lifespan_skips_remote_employees(self, monkeypatch):
@@ -707,7 +720,9 @@ class TestLifespan:
         monkeypatch.setattr(main_mod, "_restore_ephemeral_state", MagicMock())
         monkeypatch.setattr(main_mod, "_save_ephemeral_state", MagicMock())
 
+        mock_register_founding = MagicMock()
         mock_register_agent = MagicMock()
+        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", MagicMock())
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", AsyncMock())
@@ -749,7 +764,8 @@ class TestLifespan:
             pass
 
         # Only 4 founding
-        assert mock_register_agent.call_count == 4
+        assert mock_register_founding.call_count == 4
+        assert mock_register_agent.call_count == 0
 
     @pytest.mark.asyncio
     async def test_lifespan_employee_with_no_config(self, monkeypatch):
@@ -762,8 +778,10 @@ class TestLifespan:
         monkeypatch.setattr(main_mod, "_restore_ephemeral_state", MagicMock())
         monkeypatch.setattr(main_mod, "_save_ephemeral_state", MagicMock())
 
+        mock_register_founding = MagicMock()
         mock_register_agent = MagicMock()
         mock_register_self_hosted = MagicMock()
+        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", mock_register_self_hosted)
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", AsyncMock())
@@ -805,9 +823,10 @@ class TestLifespan:
         async with main_mod.lifespan(mock_app):
             pass
 
-        # _cfg is None, so it goes to register_agent (the last else branch)
-        # 4 founding + 1 = 5
-        assert mock_register_agent.call_count == 5
+        # _cfg is None for non-founding, goes to register_agent
+        # 4 founding via _register_founding_employee, 1 non-founding via register_agent
+        assert mock_register_founding.call_count == 4
+        assert mock_register_agent.call_count == 1
         mock_register_self_hosted.assert_not_called()
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -401,7 +401,7 @@ class TestLifespan:
         mock_register_self_hosted = MagicMock()
         mock_start_all = AsyncMock()
         mock_stop_all = AsyncMock()
-        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
+        monkeypatch.setattr("onemancompany.core.vessel.register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", mock_register_self_hosted)
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", mock_start_all)
@@ -481,7 +481,7 @@ class TestLifespan:
         mock_register_founding = MagicMock()
         mock_register_agent = MagicMock()
         mock_register_self_hosted = MagicMock()
-        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
+        monkeypatch.setattr("onemancompany.core.vessel.register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", mock_register_self_hosted)
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", AsyncMock())
@@ -527,7 +527,7 @@ class TestLifespan:
         async with main_mod.lifespan(mock_app):
             pass
 
-        # 4 founding via _register_founding_employee, 1 non-founding via register_agent
+        # 4 founding via register_founding_employee, 1 non-founding via register_agent
         assert mock_register_founding.call_count == 4
         assert mock_register_agent.call_count == 1
 
@@ -545,7 +545,7 @@ class TestLifespan:
         mock_register_founding = MagicMock()
         mock_register_agent = MagicMock()
         mock_register_self_hosted = MagicMock()
-        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
+        monkeypatch.setattr("onemancompany.core.vessel.register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", mock_register_self_hosted)
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", AsyncMock())
@@ -606,7 +606,7 @@ class TestLifespan:
         mock_register_founding = MagicMock()
         mock_register_agent = MagicMock()
         mock_register_self_hosted = MagicMock()
-        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
+        monkeypatch.setattr("onemancompany.core.vessel.register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", mock_register_self_hosted)
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", AsyncMock())
@@ -664,7 +664,7 @@ class TestLifespan:
 
         mock_register_founding = MagicMock()
         mock_register_agent = MagicMock()
-        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
+        monkeypatch.setattr("onemancompany.core.vessel.register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", MagicMock())
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", AsyncMock())
@@ -722,7 +722,7 @@ class TestLifespan:
 
         mock_register_founding = MagicMock()
         mock_register_agent = MagicMock()
-        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
+        monkeypatch.setattr("onemancompany.core.vessel.register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", MagicMock())
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", AsyncMock())
@@ -781,7 +781,7 @@ class TestLifespan:
         mock_register_founding = MagicMock()
         mock_register_agent = MagicMock()
         mock_register_self_hosted = MagicMock()
-        monkeypatch.setattr("onemancompany.core.vessel._register_founding_employee", mock_register_founding)
+        monkeypatch.setattr("onemancompany.core.vessel.register_founding_employee", mock_register_founding)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_agent", mock_register_agent)
         monkeypatch.setattr("onemancompany.core.agent_loop.register_self_hosted", mock_register_self_hosted)
         monkeypatch.setattr("onemancompany.core.agent_loop.start_all_loops", AsyncMock())
@@ -824,7 +824,7 @@ class TestLifespan:
             pass
 
         # _cfg is None for non-founding, goes to register_agent
-        # 4 founding via _register_founding_employee, 1 non-founding via register_agent
+        # 4 founding via register_founding_employee, 1 non-founding via register_agent
         assert mock_register_founding.call_count == 4
         assert mock_register_agent.call_count == 1
         mock_register_self_hosted.assert_not_called()


### PR DESCRIPTION
## Summary
Founding employees (HR, COO, EA, CSO) can now switch between three executor backends **without server restart**:

- **langchain**: in-process LangChain agent (default, existing behavior)
- **claude**: Claude CLI session via MCP bridge
- **openclaw**: OpenClaw subprocess via launch.sh

### Key changes
- `agent_family` field added to `EmployeeConfig` (profile.yaml)
- `_register_founding_employee()` reads `agent_family` on startup to pick executor
- `switch_agent_family()` hot-swaps executor in `employee_manager` (unregister + register)
- `PUT /api/employee/{id}/agent-family` endpoint for live switching from frontend
- Tools, skills, and prompts are **completely unaffected** — only the execution backend changes

### How it works
1. CEO saves `agent_family: openclaw` in employee detail panel
2. Backend calls `switch_agent_family()` → creates new executor → replaces in `employee_manager.executors`
3. Next task/conversation uses the new executor immediately
4. Employee must be idle (not running any task) to switch

## Test plan
- [x] 2187 unit tests pass
- [ ] Test switching founding employee to claude → verify conversation works via MCP
- [ ] Test switching to openclaw → verify launch.sh is called
- [ ] Test switching back to langchain → verify LangChain agent is restored
- [ ] Verify switch fails gracefully when employee is busy

🤖 Generated with [Claude Code](https://claude.com/claude-code)