### PR TITLE
fix: pre-install openclaw launch.sh in EA employee directory

### DIFF
--- a/company/human_resource/employees/00002/launch.sh
+++ b/company/human_resource/employees/00002/launch.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# launch.sh — Execute a single task via OpenClaw agent (foreground, company-hosted).
+#
+# Called by SubprocessExecutor per task:
+#   bash launch.sh <employee_dir>
+#
+# Environment variables (injected by platform):
+#   OMC_EMPLOYEE_ID           — Employee ID
+#   OMC_TASK_ID               — Task ID
+#   OMC_PROJECT_ID            — Project ID
+#   OMC_PROJECT_DIR           — Project workspace (cwd)
+#   OMC_TASK_DESCRIPTION_FILE — Path to file containing task/prompt text
+#   OMC_SERVER_URL            — Backend URL
+#
+# Output: single JSON line to stdout, logs to stderr.
+
+set -euo pipefail
+
+EMPLOYEE_DIR="${1:?Usage: launch.sh <employee_dir>}"
+EMPLOYEE_DIR="$(cd "$EMPLOYEE_DIR" && pwd)"
+PROJECT_ROOT="$(cd "$EMPLOYEE_DIR/../../../.." && pwd)"
+
+# ── Load company .env for API keys ────────────────────────────────────────────
+ENV_FILE="$PROJECT_ROOT/.env"
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+fi
+
+OPENCLAW_BIN="openclaw"
+
+# ── Ensure openclaw is installed ──────────────────────────────────────────────
+if ! command -v "$OPENCLAW_BIN" &>/dev/null; then
+    >&2 echo "[launch.sh] openclaw not found, installing..."
+    if command -v npm &>/dev/null; then
+        npm install -g openclaw@latest >&2
+    else
+        >&2 echo "ERROR: npm not found. Install Node.js >= 22.12.0 first."
+        exit 1
+    fi
+fi
+
+# ── Configure openclaw on first run ───────────────────────────────────────────
+OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
+if [ ! -f "$OPENCLAW_CONFIG" ] && [ -n "${OPENROUTER_API_KEY:-}" ]; then
+    >&2 echo "[launch.sh] First run — configuring openclaw with OpenRouter..."
+    "$OPENCLAW_BIN" onboard --non-interactive --accept-risk \
+        --auth-choice openrouter-api-key \
+        --openrouter-api-key "$OPENROUTER_API_KEY" \
+        --flow quickstart >&2 2>&1 || true
+fi
+
+# ── Ensure gateway is running ─────────────────────────────────────────────────
+GATEWAY_PORT=18789
+GATEWAY_PID_FILE="$EMPLOYEE_DIR/gateway.pid"
+GATEWAY_LOG_FILE="$EMPLOYEE_DIR/gateway.log"
+GATEWAY_RUNNING=false
+
+if [ -f "$GATEWAY_PID_FILE" ]; then
+    GW_PID=$(cat "$GATEWAY_PID_FILE")
+    if kill -0 "$GW_PID" 2>/dev/null; then
+        GATEWAY_RUNNING=true
+    else
+        rm -f "$GATEWAY_PID_FILE"
+    fi
+fi
+
+if [ "$GATEWAY_RUNNING" = false ] && lsof -i ":$GATEWAY_PORT" &>/dev/null; then
+    GATEWAY_RUNNING=true
+fi
+
+if [ "$GATEWAY_RUNNING" = false ]; then
+    >&2 echo "[launch.sh] Starting openclaw gateway..."
+    nohup "$OPENCLAW_BIN" gateway > "$GATEWAY_LOG_FILE" 2>&1 &
+    GW_PID=$!
+    echo "$GW_PID" > "$GATEWAY_PID_FILE"
+    # Wait for gateway ready (up to 15s)
+    for _ in $(seq 1 30); do
+        if lsof -i ":$GATEWAY_PORT" &>/dev/null; then
+            >&2 echo "[launch.sh] Gateway ready (PID $GW_PID)"
+            break
+        fi
+        sleep 0.5
+    done
+fi
+
+# ── Read task description from file ──────────────────────────────────────────
+TASK_DESC_FILE="${OMC_TASK_DESCRIPTION_FILE:-}"
+if [ -z "$TASK_DESC_FILE" ] || [ ! -f "$TASK_DESC_FILE" ]; then
+    >&2 echo "ERROR: OMC_TASK_DESCRIPTION_FILE not set or file not found"
+    exit 1
+fi
+OMC_TASK_DESCRIPTION="$(cat "$TASK_DESC_FILE")"
+
+# ── Run task via openclaw agent ───────────────────────────────────────────────
+SESSION_ID="omc-${OMC_EMPLOYEE_ID}-${OMC_TASK_ID:-conv}"
+>&2 echo "[launch.sh] Employee=${OMC_EMPLOYEE_ID} Task=${OMC_TASK_ID} Session=${SESSION_ID}"
+
+RAW=$("$OPENCLAW_BIN" agent --local -m "$OMC_TASK_DESCRIPTION" --session-id "$SESSION_ID" --json 2>/dev/null || echo "")
+
+# ── Parse openclaw JSON response ────────────────────────────────────────────
+python3 -c "
+import json, sys
+
+raw = sys.argv[1] if len(sys.argv) > 1 else ''
+output = '[openclaw] No output returned'
+model = 'openclaw/openrouter'
+in_tok = 0
+out_tok = 0
+
+if raw:
+    try:
+        data = json.loads(raw)
+        payloads = data.get('payloads', [])
+        if payloads:
+            output = payloads[0].get('text', output)
+        meta = data.get('meta', {}).get('agentMeta', {})
+        model = f\"openclaw/{meta.get('model', 'unknown')}\"
+        usage = meta.get('usage', {})
+        in_tok = usage.get('input', 0)
+        out_tok = usage.get('output', 0)
+    except (json.JSONDecodeError, KeyError, IndexError):
+        if raw.strip():
+            output = raw
+
+print(json.dumps({
+    'output': output,
+    'model': model,
+    'input_tokens': in_tok,
+    'output_tokens': out_tok,
+}))
+" "$RAW"

--- a/company/human_resource/employees/00003/launch.sh
+++ b/company/human_resource/employees/00003/launch.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# launch.sh — Execute a single task via OpenClaw agent (foreground, company-hosted).
+#
+# Called by SubprocessExecutor per task:
+#   bash launch.sh <employee_dir>
+#
+# Environment variables (injected by platform):
+#   OMC_EMPLOYEE_ID           — Employee ID
+#   OMC_TASK_ID               — Task ID
+#   OMC_PROJECT_ID            — Project ID
+#   OMC_PROJECT_DIR           — Project workspace (cwd)
+#   OMC_TASK_DESCRIPTION_FILE — Path to file containing task/prompt text
+#   OMC_SERVER_URL            — Backend URL
+#
+# Output: single JSON line to stdout, logs to stderr.
+
+set -euo pipefail
+
+EMPLOYEE_DIR="${1:?Usage: launch.sh <employee_dir>}"
+EMPLOYEE_DIR="$(cd "$EMPLOYEE_DIR" && pwd)"
+PROJECT_ROOT="$(cd "$EMPLOYEE_DIR/../../../.." && pwd)"
+
+# ── Load company .env for API keys ────────────────────────────────────────────
+ENV_FILE="$PROJECT_ROOT/.env"
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+fi
+
+OPENCLAW_BIN="openclaw"
+
+# ── Ensure openclaw is installed ──────────────────────────────────────────────
+if ! command -v "$OPENCLAW_BIN" &>/dev/null; then
+    >&2 echo "[launch.sh] openclaw not found, installing..."
+    if command -v npm &>/dev/null; then
+        npm install -g openclaw@latest >&2
+    else
+        >&2 echo "ERROR: npm not found. Install Node.js >= 22.12.0 first."
+        exit 1
+    fi
+fi
+
+# ── Configure openclaw on first run ───────────────────────────────────────────
+OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
+if [ ! -f "$OPENCLAW_CONFIG" ] && [ -n "${OPENROUTER_API_KEY:-}" ]; then
+    >&2 echo "[launch.sh] First run — configuring openclaw with OpenRouter..."
+    "$OPENCLAW_BIN" onboard --non-interactive --accept-risk \
+        --auth-choice openrouter-api-key \
+        --openrouter-api-key "$OPENROUTER_API_KEY" \
+        --flow quickstart >&2 2>&1 || true
+fi
+
+# ── Ensure gateway is running ─────────────────────────────────────────────────
+GATEWAY_PORT=18789
+GATEWAY_PID_FILE="$EMPLOYEE_DIR/gateway.pid"
+GATEWAY_LOG_FILE="$EMPLOYEE_DIR/gateway.log"
+GATEWAY_RUNNING=false
+
+if [ -f "$GATEWAY_PID_FILE" ]; then
+    GW_PID=$(cat "$GATEWAY_PID_FILE")
+    if kill -0 "$GW_PID" 2>/dev/null; then
+        GATEWAY_RUNNING=true
+    else
+        rm -f "$GATEWAY_PID_FILE"
+    fi
+fi
+
+if [ "$GATEWAY_RUNNING" = false ] && lsof -i ":$GATEWAY_PORT" &>/dev/null; then
+    GATEWAY_RUNNING=true
+fi
+
+if [ "$GATEWAY_RUNNING" = false ]; then
+    >&2 echo "[launch.sh] Starting openclaw gateway..."
+    nohup "$OPENCLAW_BIN" gateway > "$GATEWAY_LOG_FILE" 2>&1 &
+    GW_PID=$!
+    echo "$GW_PID" > "$GATEWAY_PID_FILE"
+    # Wait for gateway ready (up to 15s)
+    for _ in $(seq 1 30); do
+        if lsof -i ":$GATEWAY_PORT" &>/dev/null; then
+            >&2 echo "[launch.sh] Gateway ready (PID $GW_PID)"
+            break
+        fi
+        sleep 0.5
+    done
+fi
+
+# ── Read task description from file ──────────────────────────────────────────
+TASK_DESC_FILE="${OMC_TASK_DESCRIPTION_FILE:-}"
+if [ -z "$TASK_DESC_FILE" ] || [ ! -f "$TASK_DESC_FILE" ]; then
+    >&2 echo "ERROR: OMC_TASK_DESCRIPTION_FILE not set or file not found"
+    exit 1
+fi
+OMC_TASK_DESCRIPTION="$(cat "$TASK_DESC_FILE")"
+
+# ── Run task via openclaw agent ───────────────────────────────────────────────
+SESSION_ID="omc-${OMC_EMPLOYEE_ID}-${OMC_TASK_ID:-conv}"
+>&2 echo "[launch.sh] Employee=${OMC_EMPLOYEE_ID} Task=${OMC_TASK_ID} Session=${SESSION_ID}"
+
+RAW=$("$OPENCLAW_BIN" agent --local -m "$OMC_TASK_DESCRIPTION" --session-id "$SESSION_ID" --json 2>/dev/null || echo "")
+
+# ── Parse openclaw JSON response ────────────────────────────────────────────
+python3 -c "
+import json, sys
+
+raw = sys.argv[1] if len(sys.argv) > 1 else ''
+output = '[openclaw] No output returned'
+model = 'openclaw/openrouter'
+in_tok = 0
+out_tok = 0
+
+if raw:
+    try:
+        data = json.loads(raw)
+        payloads = data.get('payloads', [])
+        if payloads:
+            output = payloads[0].get('text', output)
+        meta = data.get('meta', {}).get('agentMeta', {})
+        model = f\"openclaw/{meta.get('model', 'unknown')}\"
+        usage = meta.get('usage', {})
+        in_tok = usage.get('input', 0)
+        out_tok = usage.get('output', 0)
+    except (json.JSONDecodeError, KeyError, IndexError):
+        if raw.strip():
+            output = raw
+
+print(json.dumps({
+    'output': output,
+    'model': model,
+    'input_tokens': in_tok,
+    'output_tokens': out_tok,
+}))
+" "$RAW"

--- a/company/human_resource/employees/00004/launch.sh
+++ b/company/human_resource/employees/00004/launch.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# launch.sh — Execute a single task via OpenClaw agent (foreground, company-hosted).
+#
+# Called by SubprocessExecutor per task:
+#   bash launch.sh <employee_dir>
+#
+# Environment variables (injected by platform):
+#   OMC_EMPLOYEE_ID           — Employee ID
+#   OMC_TASK_ID               — Task ID
+#   OMC_PROJECT_ID            — Project ID
+#   OMC_PROJECT_DIR           — Project workspace (cwd)
+#   OMC_TASK_DESCRIPTION_FILE — Path to file containing task/prompt text
+#   OMC_SERVER_URL            — Backend URL
+#
+# Output: single JSON line to stdout, logs to stderr.
+
+set -euo pipefail
+
+EMPLOYEE_DIR="${1:?Usage: launch.sh <employee_dir>}"
+EMPLOYEE_DIR="$(cd "$EMPLOYEE_DIR" && pwd)"
+PROJECT_ROOT="$(cd "$EMPLOYEE_DIR/../../../.." && pwd)"
+
+# ── Load company .env for API keys ────────────────────────────────────────────
+ENV_FILE="$PROJECT_ROOT/.env"
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+fi
+
+OPENCLAW_BIN="openclaw"
+
+# ── Ensure openclaw is installed ──────────────────────────────────────────────
+if ! command -v "$OPENCLAW_BIN" &>/dev/null; then
+    >&2 echo "[launch.sh] openclaw not found, installing..."
+    if command -v npm &>/dev/null; then
+        npm install -g openclaw@latest >&2
+    else
+        >&2 echo "ERROR: npm not found. Install Node.js >= 22.12.0 first."
+        exit 1
+    fi
+fi
+
+# ── Configure openclaw on first run ───────────────────────────────────────────
+OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
+if [ ! -f "$OPENCLAW_CONFIG" ] && [ -n "${OPENROUTER_API_KEY:-}" ]; then
+    >&2 echo "[launch.sh] First run — configuring openclaw with OpenRouter..."
+    "$OPENCLAW_BIN" onboard --non-interactive --accept-risk \
+        --auth-choice openrouter-api-key \
+        --openrouter-api-key "$OPENROUTER_API_KEY" \
+        --flow quickstart >&2 2>&1 || true
+fi
+
+# ── Ensure gateway is running ─────────────────────────────────────────────────
+GATEWAY_PORT=18789
+GATEWAY_PID_FILE="$EMPLOYEE_DIR/gateway.pid"
+GATEWAY_LOG_FILE="$EMPLOYEE_DIR/gateway.log"
+GATEWAY_RUNNING=false
+
+if [ -f "$GATEWAY_PID_FILE" ]; then
+    GW_PID=$(cat "$GATEWAY_PID_FILE")
+    if kill -0 "$GW_PID" 2>/dev/null; then
+        GATEWAY_RUNNING=true
+    else
+        rm -f "$GATEWAY_PID_FILE"
+    fi
+fi
+
+if [ "$GATEWAY_RUNNING" = false ] && lsof -i ":$GATEWAY_PORT" &>/dev/null; then
+    GATEWAY_RUNNING=true
+fi
+
+if [ "$GATEWAY_RUNNING" = false ]; then
+    >&2 echo "[launch.sh] Starting openclaw gateway..."
+    nohup "$OPENCLAW_BIN" gateway > "$GATEWAY_LOG_FILE" 2>&1 &
+    GW_PID=$!
+    echo "$GW_PID" > "$GATEWAY_PID_FILE"
+    # Wait for gateway ready (up to 15s)
+    for _ in $(seq 1 30); do
+        if lsof -i ":$GATEWAY_PORT" &>/dev/null; then
+            >&2 echo "[launch.sh] Gateway ready (PID $GW_PID)"
+            break
+        fi
+        sleep 0.5
+    done
+fi
+
+# ── Read task description from file ──────────────────────────────────────────
+TASK_DESC_FILE="${OMC_TASK_DESCRIPTION_FILE:-}"
+if [ -z "$TASK_DESC_FILE" ] || [ ! -f "$TASK_DESC_FILE" ]; then
+    >&2 echo "ERROR: OMC_TASK_DESCRIPTION_FILE not set or file not found"
+    exit 1
+fi
+OMC_TASK_DESCRIPTION="$(cat "$TASK_DESC_FILE")"
+
+# ── Run task via openclaw agent ───────────────────────────────────────────────
+SESSION_ID="omc-${OMC_EMPLOYEE_ID}-${OMC_TASK_ID:-conv}"
+>&2 echo "[launch.sh] Employee=${OMC_EMPLOYEE_ID} Task=${OMC_TASK_ID} Session=${SESSION_ID}"
+
+RAW=$("$OPENCLAW_BIN" agent --local -m "$OMC_TASK_DESCRIPTION" --session-id "$SESSION_ID" --json 2>/dev/null || echo "")
+
+# ── Parse openclaw JSON response ────────────────────────────────────────────
+python3 -c "
+import json, sys
+
+raw = sys.argv[1] if len(sys.argv) > 1 else ''
+output = '[openclaw] No output returned'
+model = 'openclaw/openrouter'
+in_tok = 0
+out_tok = 0
+
+if raw:
+    try:
+        data = json.loads(raw)
+        payloads = data.get('payloads', [])
+        if payloads:
+            output = payloads[0].get('text', output)
+        meta = data.get('meta', {}).get('agentMeta', {})
+        model = f\"openclaw/{meta.get('model', 'unknown')}\"
+        usage = meta.get('usage', {})
+        in_tok = usage.get('input', 0)
+        out_tok = usage.get('output', 0)
+    except (json.JSONDecodeError, KeyError, IndexError):
+        if raw.strip():
+            output = raw
+
+print(json.dumps({
+    'output': output,
+    'model': model,
+    'input_tokens': in_tok,
+    'output_tokens': out_tok,
+}))
+" "$RAW"

--- a/company/human_resource/employees/00005/launch.sh
+++ b/company/human_resource/employees/00005/launch.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# launch.sh — Execute a single task via OpenClaw agent (foreground, company-hosted).
+#
+# Called by SubprocessExecutor per task:
+#   bash launch.sh <employee_dir>
+#
+# Environment variables (injected by platform):
+#   OMC_EMPLOYEE_ID           — Employee ID
+#   OMC_TASK_ID               — Task ID
+#   OMC_PROJECT_ID            — Project ID
+#   OMC_PROJECT_DIR           — Project workspace (cwd)
+#   OMC_TASK_DESCRIPTION_FILE — Path to file containing task/prompt text
+#   OMC_SERVER_URL            — Backend URL
+#
+# Output: single JSON line to stdout, logs to stderr.
+
+set -euo pipefail
+
+EMPLOYEE_DIR="${1:?Usage: launch.sh <employee_dir>}"
+EMPLOYEE_DIR="$(cd "$EMPLOYEE_DIR" && pwd)"
+PROJECT_ROOT="$(cd "$EMPLOYEE_DIR/../../../.." && pwd)"
+
+# ── Load company .env for API keys ────────────────────────────────────────────
+ENV_FILE="$PROJECT_ROOT/.env"
+if [ -f "$ENV_FILE" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+    set +a
+fi
+
+OPENCLAW_BIN="openclaw"
+
+# ── Ensure openclaw is installed ──────────────────────────────────────────────
+if ! command -v "$OPENCLAW_BIN" &>/dev/null; then
+    >&2 echo "[launch.sh] openclaw not found, installing..."
+    if command -v npm &>/dev/null; then
+        npm install -g openclaw@latest >&2
+    else
+        >&2 echo "ERROR: npm not found. Install Node.js >= 22.12.0 first."
+        exit 1
+    fi
+fi
+
+# ── Configure openclaw on first run ───────────────────────────────────────────
+OPENCLAW_CONFIG="$HOME/.openclaw/openclaw.json"
+if [ ! -f "$OPENCLAW_CONFIG" ] && [ -n "${OPENROUTER_API_KEY:-}" ]; then
+    >&2 echo "[launch.sh] First run — configuring openclaw with OpenRouter..."
+    "$OPENCLAW_BIN" onboard --non-interactive --accept-risk \
+        --auth-choice openrouter-api-key \
+        --openrouter-api-key "$OPENROUTER_API_KEY" \
+        --flow quickstart >&2 2>&1 || true
+fi
+
+# ── Ensure gateway is running ─────────────────────────────────────────────────
+GATEWAY_PORT=18789
+GATEWAY_PID_FILE="$EMPLOYEE_DIR/gateway.pid"
+GATEWAY_LOG_FILE="$EMPLOYEE_DIR/gateway.log"
+GATEWAY_RUNNING=false
+
+if [ -f "$GATEWAY_PID_FILE" ]; then
+    GW_PID=$(cat "$GATEWAY_PID_FILE")
+    if kill -0 "$GW_PID" 2>/dev/null; then
+        GATEWAY_RUNNING=true
+    else
+        rm -f "$GATEWAY_PID_FILE"
+    fi
+fi
+
+if [ "$GATEWAY_RUNNING" = false ] && lsof -i ":$GATEWAY_PORT" &>/dev/null; then
+    GATEWAY_RUNNING=true
+fi
+
+if [ "$GATEWAY_RUNNING" = false ]; then
+    >&2 echo "[launch.sh] Starting openclaw gateway..."
+    nohup "$OPENCLAW_BIN" gateway > "$GATEWAY_LOG_FILE" 2>&1 &
+    GW_PID=$!
+    echo "$GW_PID" > "$GATEWAY_PID_FILE"
+    # Wait for gateway ready (up to 15s)
+    for _ in $(seq 1 30); do
+        if lsof -i ":$GATEWAY_PORT" &>/dev/null; then
+            >&2 echo "[launch.sh] Gateway ready (PID $GW_PID)"
+            break
+        fi
+        sleep 0.5
+    done
+fi
+
+# ── Read task description from file ──────────────────────────────────────────
+TASK_DESC_FILE="${OMC_TASK_DESCRIPTION_FILE:-}"
+if [ -z "$TASK_DESC_FILE" ] || [ ! -f "$TASK_DESC_FILE" ]; then
+    >&2 echo "ERROR: OMC_TASK_DESCRIPTION_FILE not set or file not found"
+    exit 1
+fi
+OMC_TASK_DESCRIPTION="$(cat "$TASK_DESC_FILE")"
+
+# ── Run task via openclaw agent ───────────────────────────────────────────────
+SESSION_ID="omc-${OMC_EMPLOYEE_ID}-${OMC_TASK_ID:-conv}"
+>&2 echo "[launch.sh] Employee=${OMC_EMPLOYEE_ID} Task=${OMC_TASK_ID} Session=${SESSION_ID}"
+
+RAW=$("$OPENCLAW_BIN" agent --local -m "$OMC_TASK_DESCRIPTION" --session-id "$SESSION_ID" --json 2>/dev/null || echo "")
+
+# ── Parse openclaw JSON response ────────────────────────────────────────────
+python3 -c "
+import json, sys
+
+raw = sys.argv[1] if len(sys.argv) > 1 else ''
+output = '[openclaw] No output returned'
+model = 'openclaw/openrouter'
+in_tok = 0
+out_tok = 0
+
+if raw:
+    try:
+        data = json.loads(raw)
+        payloads = data.get('payloads', [])
+        if payloads:
+            output = payloads[0].get('text', output)
+        meta = data.get('meta', {}).get('agentMeta', {})
+        model = f\"openclaw/{meta.get('model', 'unknown')}\"
+        usage = meta.get('usage', {})
+        in_tok = usage.get('input', 0)
+        out_tok = usage.get('output', 0)
+    except (json.JSONDecodeError, KeyError, IndexError):
+        if raw.strip():
+            output = raw
+
+print(json.dumps({
+    'output': output,
+    'model': model,
+    'input_tokens': in_tok,
+    'output_tokens': out_tok,
+}))
+" "$RAW"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.690",
+  "version": "0.2.691",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.689",
+  "version": "0.2.690",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.690"
+version = "0.2.691"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.689"
+version = "0.2.690"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
Switching EA to openclaw hosting failed because `launch.sh` didn't exist in the employee directory. Pre-install the openclaw template launch.sh so the switch works immediately.

## Test plan
- [x] 2197 tests pass
- [ ] Switch EA to openclaw → verify no file-not-found error

🤖 Generated with [Claude Code](https://claude.com/claude-code)