### PR TITLE
fix: AuthChoiceGroup.hint not auth_methods in onboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.697",
+  "version": "0.2.698",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.697"
+version = "0.2.698"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -285,7 +285,7 @@ def _step_llm(console: Console) -> tuple[str, str, str]:
 
     console.print()
     provider_choices = [
-        {"name": f"{g.label}  ({', '.join(g.auth_methods)})", "value": g.group_id}
+        {"name": f"{g.label}  ({g.hint})", "value": g.group_id}
         for g in available_groups
     ]
     or_default = PROVIDER_OPENROUTER if any(g.group_id == PROVIDER_OPENROUTER for g in available_groups) else available_groups[0].group_id


### PR DESCRIPTION
Provider selector crashed with AttributeError — AuthChoiceGroup has `hint` field, not `auth_methods`.