### PR TITLE
fix: remove stale Rich Table and model picker instructions from onboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.701",
+  "version": "0.2.702",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.701"
+version = "0.2.702"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -261,29 +261,12 @@ def _step_llm(console: Console) -> tuple[str, str, str]:
     )
 
     # 1. Select provider
-    table = Table(show_header=True, header_style="bold", box=None, padding=(0, 2))
-    table.add_column(COL_NUM, style="cyan", width=4)
-    table.add_column(COL_PROVIDER, min_width=20)
-    table.add_column(COL_AUTH_METHODS, min_width=20)
-
     available_groups = [
         g for g in AUTH_CHOICE_GROUPS
         if any(c.available and c.auth_method == AuthMethod.API_KEY for c in g.choices)
     ]
-    for i, group in enumerate(available_groups, 1):
-        table.add_row(str(i), group.label, group.hint)
-
-    console.print("  Select your LLM provider:\n")
-    console.print(table)
-
-    # Find OpenRouter's actual position in the filtered list
-    or_num = next(
-        (i for i, g in enumerate(available_groups, 1) if g.group_id == PROVIDER_OPENROUTER),
-        None,
-    )
     from InquirerPy import inquirer as _inq
 
-    console.print()
     provider_choices = [
         {"name": f"{g.label}  ({g.hint})", "value": g.group_id}
         for g in available_groups
@@ -320,15 +303,6 @@ def _step_llm(console: Console) -> tuple[str, str, str]:
         all_models = _fetch_openrouter_models(console)
         if all_models:
             console.print(f"  [green]✔[/green] Found {len(all_models)} models")
-        console.print(
-            "  [dim]This only sets the [bold]default[/bold] model, used for company-level features.\n"
-            "  Each employee can use a different LLM — configurable on the web UI.\n\n"
-            "  How to pick a model:\n"
-            "    • Type a [bold]number[/bold] and press [bold]Enter[/bold] to select\n"
-            "    • Type a [bold]keyword[/bold] (e.g. \"claude\") to search\n"
-            "    • Type [bold]n[/bold]/[bold]p[/bold] to go to next/previous page\n"
-            "    • Type [bold]c[/bold] to enter a custom model ID[/dim]\n"
-        )
         model = _select_model_interactive(console, all_models)
     else:
         # For non-OpenRouter providers, ask for model ID directly

--- a/tests/unit/test_onboard.py
+++ b/tests/unit/test_onboard.py
@@ -124,6 +124,27 @@ class TestApplyFounderFamilies:
         mock_run.assert_not_called()
 
 
+class TestNoStaleRichUI:
+    """Onboard must not show Rich Table/instructions alongside InquirerPy prompts."""
+
+    def test_step_llm_no_rich_table_for_providers(self):
+        """_step_llm should not render a Rich Table of providers — InquirerPy select replaces it."""
+        import inspect
+        from onemancompany.onboard import _step_llm
+        source = inspect.getsource(_step_llm)
+        assert "console.print(table)" not in source, "Rich Table still rendered before InquirerPy select"
+        assert "Select your LLM provider" not in source, "Old Rich header text still present"
+
+    def test_step_llm_no_old_model_picker_instructions(self):
+        """Model picker instructions (n/p/c/number) are replaced by InquirerPy fuzzy search."""
+        import inspect
+        from onemancompany.onboard import _step_llm
+        source = inspect.getsource(_step_llm)
+        assert "Type a number" not in source
+        assert "next/previous page" not in source
+        assert "custom model ID" not in source
+
+
 class TestHostingLabels:
     """HOSTING_LABELS constant covers all valid hosting values."""
 


### PR DESCRIPTION
## Summary
InquirerPy select/fuzzy replaced the Rich Table provider list and manual model picker, but the old rendering code was left in place — users saw a non-interactive Rich Table followed by the InquirerPy selector.

Removed:
- Rich Table rendering of provider list
- Model picker manual instructions (n/p/c/number)
- Unused `or_num` variable

Added 2 regression tests to prevent recurrence.

## Test plan
- [x] 2214 tests pass (2 new regression tests)
- [ ] Run onboard — verify only InquirerPy selector appears for provider and model

🤖 Generated with [Claude Code](https://claude.com/claude-code)