### PR TITLE
fix: CLI banner spacing + center LOGO in onboard

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -294,7 +294,7 @@ ${green("What gets installed automatically:")}
 
   console.log();
   const verTag = `v${cliVersion}`;
-  const title = `OneManCompany — AI Company OS  ${verTag}`;
+  const title = `OneManCompany — AI Company OS ${verTag}`;
   const pad = Math.max(0, 45 - title.length);
   console.log(cyan("╔═══════════════════════════════════════════════╗"));
   console.log(cyan(`║   ${title}${" ".repeat(pad)}║`));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.705",
+  "version": "0.2.706",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.706",
+  "version": "0.2.707",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.706"
+version = "0.2.707"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.705"
+version = "0.2.706"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -245,7 +245,7 @@ def _select_model_interactive(console: Console, all_models: list[dict]) -> str:
     model = _inq.fuzzy(
         message="Select model (type to filter):",
         choices=choices,
-        max_height="15",
+        max_height="30",
         style=_IStyle({**INQ_STYLE.dict, "fuzzy_match": "#ff44cc"}),
     ).execute()
 
@@ -373,7 +373,7 @@ def _step_agent_family(console: Console) -> dict[str, str]:
     _print_step(console, 1, "VESSEL DEPLOY", "Agent Family Assignment")
     console.print(
         "\n  [dim]Each vessel carries an AI consciousness.[/dim]\n"
-        "  [dim]Choose the neural architecture for your founding team.[/dim]\n"
+        "  [dim]Select the agent families available to your founding team.[/dim]\n"
     )
 
     # Show options with Rich Table (auto-expands to terminal width)
@@ -832,20 +832,20 @@ def _generate_mcp_configs(skillsmp_key: str) -> None:
 def _step_done(console: Console, host: str, port: int) -> None:
     console.print()
     url = f"http://{'localhost' if host == '0.0.0.0' else host}:{port}"
+    genesis_art = Text(
+        "░▒▓  ██████╗ ███████╗███╗   ██╗███████╗\n"
+        "░▒▓ ██╔════╝ ██╔════╝████╗  ██║██╔════╝\n"
+        "░▒▓ ██║  ███╗█████╗  ██╔██╗ ██║█████╗\n"
+        "░▒▓ ██║   ██║██╔══╝  ██║╚██╗██║██╔══╝\n"
+        "░▒▓ ╚██████╔╝███████╗██║ ╚████║███████╗\n"
+        "░▒▓  ╚═════╝ ╚══════╝╚═╝  ╚═══╝╚══════╝\n"
+        "\n"
+        "░▒▓  G E N E S I S   C O M P L E T E",
+        style="bold bright_green",
+        justify="center",
+    )
+    console.print(Panel(genesis_art, border_style="bright_green", expand=True, padding=(1, 2)))
     console.print(Panel(
-        "[bold bright_green]"
-        "  ╔═══════════════════════════════════════════╗\n"
-        "  ║                                           ║\n"
-        "  ║   ██████╗ ███████╗███╗   ██╗███████╗     ║\n"
-        "  ║  ██╔════╝ ██╔════╝████╗  ██║██╔════╝     ║\n"
-        "  ║  ██║  ███╗█████╗  ██╔██╗ ██║█████╗       ║\n"
-        "  ║  ██║   ██║██╔══╝  ██║╚██╗██║██╔══╝       ║\n"
-        "  ║  ╚██████╔╝███████╗██║ ╚████║███████╗     ║\n"
-        "  ║   ╚═════╝ ╚══════╝╚═╝  ╚═══╝╚══════╝     ║\n"
-        "  ║                                           ║\n"
-        "  ║   G E N E S I S   C O M P L E T E        ║\n"
-        "  ╚═══════════════════════════════════════════╝\n"
-        "[/bold bright_green]\n"
         "  [bright_cyan]Your company is online. Neural cores activated.[/bright_cyan]\n\n"
         "  [bold]FOUNDING TEAM DEPLOYED:[/bold]\n"
         "  [bright_green]  ▸[/bright_green] Pat EA       [dim]// Executive Assistant — task routing & quality gate[/dim]\n"

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -124,7 +124,7 @@ def _print_step(console: Console, num: int, codename: str, subtitle: str) -> Non
 
 def _step_welcome(console: Console) -> None:
     console.print(Panel(
-        Text(LOGO, style="bold bright_cyan"),
+        Text(LOGO, style="bold bright_cyan", justify="center"),
         border_style="bright_magenta",
         padding=(1, 2),
         expand=True,


### PR DESCRIPTION
Two one-line fixes: remove double space in CLI banner title, center LOGO text in onboard Panel.