### PR TITLE
fix: CLI banner right border alignment

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -295,7 +295,7 @@ ${green("What gets installed automatically:")}
   console.log();
   const verTag = `v${cliVersion}`;
   const title = `OneManCompany — AI Company OS ${verTag}`;
-  const pad = Math.max(0, 45 - title.length);
+  const pad = Math.max(0, 44 - title.length);
   console.log(cyan("╔═══════════════════════════════════════════════╗"));
   console.log(cyan(`║   ${title}${" ".repeat(pad)}║`));
   console.log(cyan("╚═══════════════════════════════════════════════╝"));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.714",
+  "version": "0.2.716",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.714"
+version = "0.2.716"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/unit/test_onboard.py
+++ b/tests/unit/test_onboard.py
@@ -67,7 +67,8 @@ class TestApplyFounderFamilies:
         profile.write_text(yaml.dump({"name": "Pat EA", "hosting": "company"}))
 
         console = Console(quiet=True)
-        with patch("onemancompany.onboard.EMPLOYEES_DIR", tmp_path):
+        with patch("onemancompany.onboard.EMPLOYEES_DIR", tmp_path), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)):
             _apply_founder_families(console, {"00004": "openclaw"})
 
         data = yaml.safe_load(profile.read_text())


### PR DESCRIPTION
Padding was off by 1 (45→44), causing the right ║ to misalign with ╗/╝.