### PR TITLE
fix: extract JSON from stderr — openclaw outputs to stderr not stdout

### DIFF
--- a/company/human_resource/employees/00002/launch.sh
+++ b/company/human_resource/employees/00002/launch.sh
@@ -102,20 +102,33 @@ SESSION_ID="omc-${OMC_EMPLOYEE_ID}-${OMC_TASK_ID:-conv}"
 STDERR_FILE=$(mktemp)
 trap 'rm -f "$STDERR_FILE"' EXIT
 RAW=$("$OPENCLAW_BIN" agent --local -m "$OMC_TASK_DESCRIPTION" --session-id "$SESSION_ID" --json 2>"$STDERR_FILE" || echo "")
-STDERR_CONTENT=$(cat "$STDERR_FILE" 2>/dev/null | tail -5)
-rm -f "$STDERR_FILE"
 
-# If no output but stderr has content, surface the error
-if [ -z "$RAW" ] && [ -n "$STDERR_CONTENT" ]; then
-    >&2 echo "[launch.sh] openclaw error: $STDERR_CONTENT"
+# openclaw may output JSON to stderr instead of stdout — try both
+if [ -z "$RAW" ] && [ -f "$STDERR_FILE" ]; then
+    # Extract JSON object from stderr (skip ANSI log lines, find the JSON block)
+    RAW=$(python3 -c "
+import json, sys
+raw = open(sys.argv[1]).read()
+decoder = json.JSONDecoder()
+# Find the last valid JSON object (openclaw puts log lines before it)
+for i in range(len(raw) - 1, -1, -1):
+    if raw[i] == '{':
+        try:
+            obj, _ = decoder.raw_decode(raw[i:])
+            print(json.dumps(obj))
+            break
+        except (json.JSONDecodeError, ValueError):
+            continue
+" "$STDERR_FILE" 2>/dev/null)
 fi
+
+rm -f "$STDERR_FILE"
 
 # ── Parse openclaw JSON response ────────────────────────────────────────────
 python3 -c "
 import json, sys
 
 raw = sys.argv[1] if len(sys.argv) > 1 else ''
-stderr_hint = sys.argv[2] if len(sys.argv) > 2 else ''
 output = '[openclaw] No output returned'
 model = 'openclaw/openrouter'
 in_tok = 0
@@ -135,8 +148,6 @@ if raw:
     except (json.JSONDecodeError, KeyError, IndexError):
         if raw.strip():
             output = raw
-elif stderr_hint:
-    output = f'[openclaw] Error: {stderr_hint}'
 
 print(json.dumps({
     'output': output,
@@ -144,4 +155,4 @@ print(json.dumps({
     'input_tokens': in_tok,
     'output_tokens': out_tok,
 }))
-" "$RAW" "$STDERR_CONTENT"
+" "$RAW"

--- a/company/human_resource/employees/00003/launch.sh
+++ b/company/human_resource/employees/00003/launch.sh
@@ -102,20 +102,33 @@ SESSION_ID="omc-${OMC_EMPLOYEE_ID}-${OMC_TASK_ID:-conv}"
 STDERR_FILE=$(mktemp)
 trap 'rm -f "$STDERR_FILE"' EXIT
 RAW=$("$OPENCLAW_BIN" agent --local -m "$OMC_TASK_DESCRIPTION" --session-id "$SESSION_ID" --json 2>"$STDERR_FILE" || echo "")
-STDERR_CONTENT=$(cat "$STDERR_FILE" 2>/dev/null | tail -5)
-rm -f "$STDERR_FILE"
 
-# If no output but stderr has content, surface the error
-if [ -z "$RAW" ] && [ -n "$STDERR_CONTENT" ]; then
-    >&2 echo "[launch.sh] openclaw error: $STDERR_CONTENT"
+# openclaw may output JSON to stderr instead of stdout — try both
+if [ -z "$RAW" ] && [ -f "$STDERR_FILE" ]; then
+    # Extract JSON object from stderr (skip ANSI log lines, find the JSON block)
+    RAW=$(python3 -c "
+import json, sys
+raw = open(sys.argv[1]).read()
+decoder = json.JSONDecoder()
+# Find the last valid JSON object (openclaw puts log lines before it)
+for i in range(len(raw) - 1, -1, -1):
+    if raw[i] == '{':
+        try:
+            obj, _ = decoder.raw_decode(raw[i:])
+            print(json.dumps(obj))
+            break
+        except (json.JSONDecodeError, ValueError):
+            continue
+" "$STDERR_FILE" 2>/dev/null)
 fi
+
+rm -f "$STDERR_FILE"
 
 # ── Parse openclaw JSON response ────────────────────────────────────────────
 python3 -c "
 import json, sys
 
 raw = sys.argv[1] if len(sys.argv) > 1 else ''
-stderr_hint = sys.argv[2] if len(sys.argv) > 2 else ''
 output = '[openclaw] No output returned'
 model = 'openclaw/openrouter'
 in_tok = 0
@@ -135,8 +148,6 @@ if raw:
     except (json.JSONDecodeError, KeyError, IndexError):
         if raw.strip():
             output = raw
-elif stderr_hint:
-    output = f'[openclaw] Error: {stderr_hint}'
 
 print(json.dumps({
     'output': output,
@@ -144,4 +155,4 @@ print(json.dumps({
     'input_tokens': in_tok,
     'output_tokens': out_tok,
 }))
-" "$RAW" "$STDERR_CONTENT"
+" "$RAW"

--- a/company/human_resource/employees/00004/launch.sh
+++ b/company/human_resource/employees/00004/launch.sh
@@ -102,20 +102,33 @@ SESSION_ID="omc-${OMC_EMPLOYEE_ID}-${OMC_TASK_ID:-conv}"
 STDERR_FILE=$(mktemp)
 trap 'rm -f "$STDERR_FILE"' EXIT
 RAW=$("$OPENCLAW_BIN" agent --local -m "$OMC_TASK_DESCRIPTION" --session-id "$SESSION_ID" --json 2>"$STDERR_FILE" || echo "")
-STDERR_CONTENT=$(cat "$STDERR_FILE" 2>/dev/null | tail -5)
-rm -f "$STDERR_FILE"
 
-# If no output but stderr has content, surface the error
-if [ -z "$RAW" ] && [ -n "$STDERR_CONTENT" ]; then
-    >&2 echo "[launch.sh] openclaw error: $STDERR_CONTENT"
+# openclaw may output JSON to stderr instead of stdout — try both
+if [ -z "$RAW" ] && [ -f "$STDERR_FILE" ]; then
+    # Extract JSON object from stderr (skip ANSI log lines, find the JSON block)
+    RAW=$(python3 -c "
+import json, sys
+raw = open(sys.argv[1]).read()
+decoder = json.JSONDecoder()
+# Find the last valid JSON object (openclaw puts log lines before it)
+for i in range(len(raw) - 1, -1, -1):
+    if raw[i] == '{':
+        try:
+            obj, _ = decoder.raw_decode(raw[i:])
+            print(json.dumps(obj))
+            break
+        except (json.JSONDecodeError, ValueError):
+            continue
+" "$STDERR_FILE" 2>/dev/null)
 fi
+
+rm -f "$STDERR_FILE"
 
 # ── Parse openclaw JSON response ────────────────────────────────────────────
 python3 -c "
 import json, sys
 
 raw = sys.argv[1] if len(sys.argv) > 1 else ''
-stderr_hint = sys.argv[2] if len(sys.argv) > 2 else ''
 output = '[openclaw] No output returned'
 model = 'openclaw/openrouter'
 in_tok = 0
@@ -135,8 +148,6 @@ if raw:
     except (json.JSONDecodeError, KeyError, IndexError):
         if raw.strip():
             output = raw
-elif stderr_hint:
-    output = f'[openclaw] Error: {stderr_hint}'
 
 print(json.dumps({
     'output': output,
@@ -144,4 +155,4 @@ print(json.dumps({
     'input_tokens': in_tok,
     'output_tokens': out_tok,
 }))
-" "$RAW" "$STDERR_CONTENT"
+" "$RAW"

--- a/company/human_resource/employees/00005/launch.sh
+++ b/company/human_resource/employees/00005/launch.sh
@@ -102,20 +102,33 @@ SESSION_ID="omc-${OMC_EMPLOYEE_ID}-${OMC_TASK_ID:-conv}"
 STDERR_FILE=$(mktemp)
 trap 'rm -f "$STDERR_FILE"' EXIT
 RAW=$("$OPENCLAW_BIN" agent --local -m "$OMC_TASK_DESCRIPTION" --session-id "$SESSION_ID" --json 2>"$STDERR_FILE" || echo "")
-STDERR_CONTENT=$(cat "$STDERR_FILE" 2>/dev/null | tail -5)
-rm -f "$STDERR_FILE"
 
-# If no output but stderr has content, surface the error
-if [ -z "$RAW" ] && [ -n "$STDERR_CONTENT" ]; then
-    >&2 echo "[launch.sh] openclaw error: $STDERR_CONTENT"
+# openclaw may output JSON to stderr instead of stdout — try both
+if [ -z "$RAW" ] && [ -f "$STDERR_FILE" ]; then
+    # Extract JSON object from stderr (skip ANSI log lines, find the JSON block)
+    RAW=$(python3 -c "
+import json, sys
+raw = open(sys.argv[1]).read()
+decoder = json.JSONDecoder()
+# Find the last valid JSON object (openclaw puts log lines before it)
+for i in range(len(raw) - 1, -1, -1):
+    if raw[i] == '{':
+        try:
+            obj, _ = decoder.raw_decode(raw[i:])
+            print(json.dumps(obj))
+            break
+        except (json.JSONDecodeError, ValueError):
+            continue
+" "$STDERR_FILE" 2>/dev/null)
 fi
+
+rm -f "$STDERR_FILE"
 
 # ── Parse openclaw JSON response ────────────────────────────────────────────
 python3 -c "
 import json, sys
 
 raw = sys.argv[1] if len(sys.argv) > 1 else ''
-stderr_hint = sys.argv[2] if len(sys.argv) > 2 else ''
 output = '[openclaw] No output returned'
 model = 'openclaw/openrouter'
 in_tok = 0
@@ -135,8 +148,6 @@ if raw:
     except (json.JSONDecodeError, KeyError, IndexError):
         if raw.strip():
             output = raw
-elif stderr_hint:
-    output = f'[openclaw] Error: {stderr_hint}'
 
 print(json.dumps({
     'output': output,
@@ -144,4 +155,4 @@ print(json.dumps({
     'input_tokens': in_tok,
     'output_tokens': out_tok,
 }))
-" "$RAW" "$STDERR_CONTENT"
+" "$RAW"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.715",
+  "version": "0.2.716",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.714",
+  "version": "0.2.715",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.714"
+version = "0.2.715"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.715"
+version = "0.2.716"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/talent_market/talents/openclaw/launch.sh
+++ b/src/onemancompany/talent_market/talents/openclaw/launch.sh
@@ -102,20 +102,33 @@ SESSION_ID="omc-${OMC_EMPLOYEE_ID}-${OMC_TASK_ID:-conv}"
 STDERR_FILE=$(mktemp)
 trap 'rm -f "$STDERR_FILE"' EXIT
 RAW=$("$OPENCLAW_BIN" agent --local -m "$OMC_TASK_DESCRIPTION" --session-id "$SESSION_ID" --json 2>"$STDERR_FILE" || echo "")
-STDERR_CONTENT=$(cat "$STDERR_FILE" 2>/dev/null | tail -5)
-rm -f "$STDERR_FILE"
 
-# If no output but stderr has content, surface the error
-if [ -z "$RAW" ] && [ -n "$STDERR_CONTENT" ]; then
-    >&2 echo "[launch.sh] openclaw error: $STDERR_CONTENT"
+# openclaw may output JSON to stderr instead of stdout — try both
+if [ -z "$RAW" ] && [ -f "$STDERR_FILE" ]; then
+    # Extract JSON object from stderr (skip ANSI log lines, find the JSON block)
+    RAW=$(python3 -c "
+import json, sys
+raw = open(sys.argv[1]).read()
+decoder = json.JSONDecoder()
+# Find the last valid JSON object (openclaw puts log lines before it)
+for i in range(len(raw) - 1, -1, -1):
+    if raw[i] == '{':
+        try:
+            obj, _ = decoder.raw_decode(raw[i:])
+            print(json.dumps(obj))
+            break
+        except (json.JSONDecodeError, ValueError):
+            continue
+" "$STDERR_FILE" 2>/dev/null)
 fi
+
+rm -f "$STDERR_FILE"
 
 # ── Parse openclaw JSON response ────────────────────────────────────────────
 python3 -c "
 import json, sys
 
 raw = sys.argv[1] if len(sys.argv) > 1 else ''
-stderr_hint = sys.argv[2] if len(sys.argv) > 2 else ''
 output = '[openclaw] No output returned'
 model = 'openclaw/openrouter'
 in_tok = 0
@@ -135,8 +148,6 @@ if raw:
     except (json.JSONDecodeError, KeyError, IndexError):
         if raw.strip():
             output = raw
-elif stderr_hint:
-    output = f'[openclaw] Error: {stderr_hint}'
 
 print(json.dumps({
     'output': output,
@@ -144,4 +155,4 @@ print(json.dumps({
     'input_tokens': in_tok,
     'output_tokens': out_tok,
 }))
-" "$RAW" "$STDERR_CONTENT"
+" "$RAW"

--- a/tests/unit/test_onboard.py
+++ b/tests/unit/test_onboard.py
@@ -159,11 +159,11 @@ class TestOpenclawLaunchShErrorHandling:
         )
 
     def test_launch_sh_captures_stderr_to_file(self):
-        """launch.sh should capture stderr to a temp file for error reporting."""
+        """launch.sh should capture stderr to a temp file for JSON extraction."""
         launch_sh = Path(__file__).parent.parent.parent / "src/onemancompany/talent_market/talents/openclaw/launch.sh"
         content = launch_sh.read_text()
         assert "STDERR_FILE" in content, "launch.sh should capture stderr to a temp file"
-        assert "STDERR_CONTENT" in content, "launch.sh should read stderr content for error reporting"
+        assert "raw_decode" in content, "launch.sh should use raw_decode for robust JSON extraction"
 
 
 class TestHostingLabels:

--- a/tests/unit/test_onboard.py
+++ b/tests/unit/test_onboard.py
@@ -67,7 +67,8 @@ class TestApplyFounderFamilies:
         profile.write_text(yaml.dump({"name": "Pat EA", "hosting": "company"}))
 
         console = Console(quiet=True)
-        with patch("onemancompany.onboard.EMPLOYEES_DIR", tmp_path):
+        with patch("onemancompany.onboard.EMPLOYEES_DIR", tmp_path), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0)):
             _apply_founder_families(console, {"00004": "openclaw"})
 
         data = yaml.safe_load(profile.read_text())


### PR DESCRIPTION
## Summary
openclaw outputs its JSON response to stderr (with ANSI log lines before it), while stdout is empty. launch.sh was only reading stdout → got nothing → showed stderr tail as error.

Now when stdout is empty, scans stderr for the last valid JSON object using `raw_decode()`.

## Test plan
- [x] 2216 tests pass
- [x] Manually verified: `openclaw agent --json` → JSON extracted from stderr correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)