### PR TITLE
feat: add Delete Project button in project detail

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6372,6 +6372,7 @@ class AppController {
       <span style="color:var(--text-dim);font-size:6px;">${proj.status}</span>
       ${totalCost > 0 ? `<span style="color:var(--pixel-yellow);font-size:6px;">$${totalCost.toFixed(4)}</span>` : ''}
       <button onclick="app.openTraceViewer('${this._escHtml(projectId)}','${this._escHtml(proj.name || projectId)}')" style="margin-left:auto;background:#1a1a1a;color:#4af;border:1px solid #333;padding:1px 8px;font-size:6px;cursor:pointer;font-family:monospace">TRACE</button>
+      <button onclick="app._deleteProject('${this._escHtml(projectId)}')" style="background:#1a1a1a;color:var(--pixel-red);border:1px solid #500;padding:1px 8px;font-size:6px;cursor:pointer;font-family:monospace" title="Delete project and all data">DELETE</button>
     </div>`;
 
     // Build split layout: iteration list (left) + detail (right)
@@ -6892,6 +6893,26 @@ class AppController {
         }
       })
       .catch(err => console.error('[archiveProject] failed:', err));
+  }
+
+  _deleteProject(projectId) {
+    if (!confirm(`Delete project "${projectId}" and ALL its data? This cannot be undone.`)) return;
+    fetch(`/api/projects/${encodeURIComponent(projectId)}`, { method: 'DELETE' })
+      .then(r => {
+        if (!r.ok) throw new Error(`Server error: ${r.status}`);
+        return r.json();
+      })
+      .then(data => {
+        if (data.status === 'deleted') {
+          this.logEntry('CEO', `Project "${projectId}" deleted`, 'ceo');
+          this.updateProjectsPanel();
+          this.loadActiveProjects();
+          document.getElementById('project-modal').classList.add('hidden');
+        }
+      })
+      .catch(err => {
+        this.logEntry('SYSTEM', `Failed to delete project: ${err.message}`, 'system');
+      });
   }
 
   loadActiveProjects() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.716",
+  "version": "0.2.717",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.716"
+version = "0.2.717"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import shutil
 import uuid as _uuid
 from datetime import datetime
 from pathlib import Path, PurePosixPath
@@ -2724,6 +2725,38 @@ async def archive_project_endpoint(project_id: str) -> dict:
     logger.info("[archive] Archived project {} — cancelled {} task(s)", project_id, total_cancelled)
     await event_bus.publish(CompanyEvent(type=EventType.STATE_SNAPSHOT, payload={}, agent=SYSTEM_AGENT))
     return {"status": "archived", "project_id": project_id, "tasks_cancelled": total_cancelled}
+
+
+@router.delete("/api/projects/{project_id}")
+async def delete_project_endpoint(project_id: str) -> dict:
+    """Delete a project and all its data — cancels running tasks first."""
+    from onemancompany.core.project_archive import load_named_project
+    from onemancompany.core.config import PROJECTS_DIR
+
+    # Path traversal guard — critical for rmtree
+    project_dir = (PROJECTS_DIR / project_id).resolve()
+    if not project_dir.is_relative_to(PROJECTS_DIR.resolve()):
+        raise HTTPException(status_code=400, detail="Invalid project ID")
+
+    proj = load_named_project(project_id)
+    if not proj:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    # Cancel all running/pending tasks for all iterations
+    from onemancompany.core.agent_loop import employee_manager
+    iterations = proj.get("iterations", [])
+    total_cancelled = 0
+    for iter_id in iterations:
+        full_pid = f"{project_id}/{iter_id}"
+        total_cancelled += employee_manager.abort_project(full_pid)
+
+    # Delete entire project directory
+    if project_dir.exists():
+        shutil.rmtree(project_dir)
+
+    logger.info("[delete] Deleted project {} — cancelled {} task(s)", project_id, total_cancelled)
+    await event_bus.publish(CompanyEvent(type=EventType.STATE_SNAPSHOT, payload={}, agent=SYSTEM_AGENT))
+    return {"status": "deleted", "project_id": project_id, "tasks_cancelled": total_cancelled}
 
 
 @router.patch("/api/projects/{project_id}/name")

--- a/tests/unit/api/test_routes.py
+++ b/tests/unit/api/test_routes.py
@@ -1899,6 +1899,56 @@ class TestArchiveProject:
         assert resp.json()["status"] == "archived"
 
 
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/projects/{project_id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteProject:
+    async def test_delete_not_found(self):
+        state = _make_state()
+
+        with patch("onemancompany.api.routes.company_state", state), \
+             _store_patches(state), \
+             patch("onemancompany.api.routes.event_bus", EventBus()), \
+             patch("onemancompany.core.project_archive.load_named_project", return_value=None):
+            app = _make_test_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.delete("/api/projects/nonexistent")
+
+        assert resp.status_code == 404
+
+    async def test_delete_success(self, tmp_path):
+        state = _make_state()
+        # Create a fake project dir so rmtree has something to delete
+        proj_dir = tmp_path / "test-proj"
+        proj_dir.mkdir()
+        (proj_dir / "project.yaml").write_text("name: Test")
+
+        with patch("onemancompany.api.routes.company_state", state), \
+             _store_patches(state), \
+             patch("onemancompany.api.routes.event_bus", EventBus()), \
+             patch("onemancompany.core.project_archive.load_named_project", return_value={"name": "Test", "iterations": []}), \
+             patch("onemancompany.core.config.PROJECTS_DIR", tmp_path), \
+             patch("onemancompany.api.routes.shutil.rmtree") as mock_rmtree:
+            app = _make_test_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.delete("/api/projects/test-proj")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deleted"
+        mock_rmtree.assert_called_once()
+
+    def test_path_traversal_guard_logic(self, tmp_path):
+        """Path traversal in project_id must be caught by resolve() check."""
+        from pathlib import Path
+        project_dir = (tmp_path / "../../etc").resolve()
+        assert not project_dir.is_relative_to(tmp_path.resolve()), (
+            "Path traversal should resolve outside PROJECTS_DIR"
+        )
+
 # ---------------------------------------------------------------------------
 # GET /api/projects/{project_id}
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `DELETE /api/projects/{project_id}` — cancels running tasks, then deletes project directory
- Path traversal protection (resolve + is_relative_to) before rmtree
- Red DELETE button in project detail header next to TRACE
- Confirm dialog + error feedback in activity log

## Test plan
- [x] 2218 tests pass (3 new)
- [ ] Open project detail → verify DELETE button appears
- [ ] Click DELETE → verify confirm dialog → project removed from list

🤖 Generated with [Claude Code](https://claude.com/claude-code)