### PR TITLE
fix: add async lock + atomic write to CEO conversation messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.718",
+  "version": "0.2.719",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.718"
+version = "0.2.719"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/ceo_conversation.py
+++ b/src/onemancompany/core/ceo_conversation.py
@@ -38,7 +38,7 @@ def load_messages(conv_dir: Path, node_id: str) -> list[dict]:
     return _read_yaml_list(path)
 
 
-def append_message(
+async def append_message(
     conv_dir: Path,
     node_id: str,
     *,
@@ -46,8 +46,14 @@ def append_message(
     text: str,
     attachments: list[dict] | None = None,
 ) -> dict:
-    """Append a message to a conversation and return it."""
+    """Append a message to a conversation with lock + atomic write.
+
+    Per-conversation asyncio.Lock prevents concurrent read-append-write races.
+    Atomic write (temp file + os.replace) ensures crash safety.
+    Reuses store._get_lock and store._atomic_write_text to avoid duplication.
+    """
     import yaml as _yaml
+    from onemancompany.core.store import _get_lock, _atomic_write_text
 
     msg: dict[str, Any] = {
         "sender": sender,
@@ -58,15 +64,12 @@ def append_message(
         msg["attachments"] = attachments
 
     path = _conv_path(conv_dir, node_id)
-    path.parent.mkdir(parents=True, exist_ok=True)
 
-    messages = load_messages(conv_dir, node_id)
-    messages.append(msg)
+    async with _get_lock(str(path)):
+        messages = load_messages(conv_dir, node_id)
+        messages.append(msg)
+        _atomic_write_text(path, _yaml.dump(messages, allow_unicode=True, default_flow_style=False))
 
-    path.write_text(
-        _yaml.dump(messages, allow_unicode=True, default_flow_style=False),
-        encoding=ENCODING_UTF8,
-    )
     return msg
 
 
@@ -335,7 +338,7 @@ class ConversationSession:
             # Persist as CEO_SENDER (EA acts on behalf of CEO — employee
             # must see it as HumanMessage). Broadcast with origin=ea so
             # the frontend can display it differently. Disk = source of truth.
-            ea_msg = append_message(
+            ea_msg = await append_message(
                 self._conv_dir, self.node_id,
                 sender=CEO_SENDER, text=reply_text,
             )
@@ -361,7 +364,7 @@ class ConversationSession:
         """Queue a CEO message for processing."""
         self._ceo_replied = True
         self._cancel_ea_timer()
-        msg = append_message(
+        msg = await append_message(
             self._conv_dir, self.node_id,
             sender=CEO_SENDER, text=text, attachments=attachments,
         )
@@ -404,7 +407,7 @@ class ConversationSession:
                 logger.error("Agent invoke failed for node {}: {}", self.node_id, e)
                 response_text = f"[Error: {e}]"
 
-            agent_msg = append_message(
+            agent_msg = await append_message(
                 self._conv_dir, self.node_id,
                 sender=self.employee_id, text=response_text,
             )

--- a/tests/unit/core/test_ceo_conversation.py
+++ b/tests/unit/core/test_ceo_conversation.py
@@ -23,14 +23,15 @@ from onemancompany.core.ceo_conversation import (
 class TestMessagePersistence:
     """Test YAML-based conversation message storage."""
 
-    def test_append_and_load_messages(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_append_and_load_messages(self, tmp_path):
         from onemancompany.core.ceo_conversation import append_message, load_messages
 
         conv_dir = tmp_path / "conversations"
         node_id = "abc123"
 
-        append_message(conv_dir, node_id, sender="ceo", text="Hello")
-        append_message(conv_dir, node_id, sender="emp001", text="Hi CEO")
+        await append_message(conv_dir, node_id, sender="ceo", text="Hello")
+        await append_message(conv_dir, node_id, sender="emp001", text="Hi CEO")
 
         msgs = load_messages(conv_dir, node_id)
         assert len(msgs) == 2
@@ -45,12 +46,13 @@ class TestMessagePersistence:
         msgs = load_messages(tmp_path / "conversations", "nonexistent")
         assert msgs == []
 
-    def test_append_with_attachments(self, tmp_path):
+    @pytest.mark.asyncio
+    async def test_append_with_attachments(self, tmp_path):
         from onemancompany.core.ceo_conversation import append_message, load_messages
 
         conv_dir = tmp_path / "conversations"
-        append_message(conv_dir, "n1", sender="ceo", text="See attached",
-                       attachments=[{"filename": "doc.pdf", "path": "/workspace/doc.pdf"}])
+        await append_message(conv_dir, "n1", sender="ceo", text="See attached",
+                             attachments=[{"filename": "doc.pdf", "path": "/workspace/doc.pdf"}])
 
         msgs = load_messages(conv_dir, "n1")
         assert msgs[0]["attachments"][0]["filename"] == "doc.pdf"
@@ -328,3 +330,40 @@ class TestEaAnalyzeConversation:
 
         assert result["decision"] == "accept"
         assert result["follow_up_tasks"] == []
+
+
+class TestAppendMessageAtomicAndLocked:
+    """append_message must use atomic writes and file locking."""
+
+    def test_append_message_uses_atomic_write(self):
+        """append_message must use _atomic_write_text, not path.write_text()."""
+        import inspect
+        source = inspect.getsource(append_message)
+        assert "path.write_text" not in source, (
+            "append_message must use _atomic_write_text, not path.write_text()"
+        )
+        assert "_atomic_write_text" in source, (
+            "append_message must delegate to _atomic_write_text"
+        )
+
+    def test_append_message_uses_lock(self):
+        """append_message must acquire a lock to prevent concurrent corruption."""
+        import inspect
+        source = inspect.getsource(append_message)
+        assert "_get_lock" in source, (
+            "append_message must use _get_lock for concurrent access protection"
+        )
+
+    @pytest.mark.asyncio
+    async def test_concurrent_appends_no_lost_messages(self, tmp_path):
+        """Two rapid appends must both be persisted (no lost-update race)."""
+        conv_dir = tmp_path / "conversations"
+        node_id = "race_test"
+
+        await append_message(conv_dir, node_id, sender="ceo", text="msg1")
+        await append_message(conv_dir, node_id, sender="employee", text="msg2")
+
+        msgs = load_messages(conv_dir, node_id)
+        assert len(msgs) == 2
+        assert msgs[0]["text"] == "msg1"
+        assert msgs[1]["text"] == "msg2"


### PR DESCRIPTION
## Summary
**P0.2 System Analysis item:** CEO conversation messages had no file lock — concurrent CEO + EA auto-reply could lose messages.

Now `append_message` is async with per-file `asyncio.Lock` + atomic write via `store._atomic_write_text()`.

## Test plan
- [x] 2226 tests pass (3 new)
- [x] Lock acquired inside function, not just declared
- [x] All callers use await

🤖 Generated with [Claude Code](https://claude.com/claude-code)