### PR TITLE
fix: abort paths use safe_cancel() — no more state machine bypass

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.719",
+  "version": "0.2.720",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.719"
+version = "0.2.720"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -1555,9 +1555,8 @@ async def _sync_tree_cancel(cancelled_node_ids: list[tuple[str, str]]) -> None:
         if not tree:
             continue
         node = tree.get_node(node_id)
-        if node and node.status not in (TaskPhase.ACCEPTED, TaskPhase.FAILED, TaskPhase.CANCELLED):
-            # CEO cancellation — force status bypass for terminal override
-            node.status = TaskPhase.CANCELLED.value
+        from onemancompany.core.task_lifecycle import safe_cancel
+        if node and safe_cancel(node):
             node.result = "Cancelled by CEO"
             from onemancompany.core.events import CompanyEvent as _CE
             await event_bus.publish(_CE(
@@ -1595,10 +1594,9 @@ async def abort_task(project_id: str) -> dict:
         tree_path = _Path(pdir) / TASK_TREE_FILENAME
         if tree_path.exists():
             tree = get_tree(tree_path, project_id=project_id)
+            from onemancompany.core.task_lifecycle import safe_cancel as _sc
             for node in tree.all_nodes():
-                if node.status not in (TaskPhase.ACCEPTED, TaskPhase.FAILED, TaskPhase.CANCELLED):
-                    # CEO abort — force status bypass for terminal override
-                    node.status = TaskPhase.CANCELLED.value
+                if _sc(node):
                     node.result = "Cancelled by CEO (project aborted)"
                     cancelled_tree_nodes += 1
             save_tree_async(tree_path)
@@ -1685,9 +1683,9 @@ async def cancel_agent_task(employee_id: str, task_id: str) -> dict:
 
     was_in_progress = node.status == TaskPhase.PROCESSING
 
-    # Force cancel — bypass transition validation
-    node.status = TaskPhase.CANCELLED.value
-    node.completed_at = datetime.now().isoformat()
+    from onemancompany.core.task_lifecycle import safe_cancel
+    safe_cancel(node)
+    node.completed_at = node.completed_at or datetime.now().isoformat()
     node.result = "Cancelled by CEO"
     save_tree_async(tp)
 

--- a/src/onemancompany/core/automation.py
+++ b/src/onemancompany/core/automation.py
@@ -154,8 +154,8 @@ def _cancel_cron_tasks(employee_id: str, task_ids: list[str]) -> list[str]:
                 continue
             tree = TaskTree.load(tp)
             node = tree.get_node(task_id)
-            if node and node.status in (TaskPhase.PENDING.value, TaskPhase.PROCESSING.value):
-                node.status = TaskPhase.CANCELLED.value
+            from onemancompany.core.task_lifecycle import safe_cancel
+            if node and safe_cancel(node):
                 node.completed_at = datetime.now(timezone.utc).isoformat()
                 node.result = "Cancelled: cron stopped"
                 tree.save(tp)

--- a/src/onemancompany/core/task_lifecycle.py
+++ b/src/onemancompany/core/task_lifecycle.py
@@ -147,6 +147,21 @@ def get_valid_targets(current: TaskPhase) -> list[TaskPhase]:
     return list(VALID_TRANSITIONS.get(current, []))
 
 
+def safe_cancel(node) -> bool:
+    """Cancel a node if the transition is valid, skipping terminal states.
+
+    Returns True if the node was cancelled, False if already terminal.
+    Uses node.set_status() which goes through the proper state machine.
+    """
+    current = TaskPhase(node.status)
+    if current in TERMINAL:
+        return False
+    if can_transition(current, TaskPhase.CANCELLED):
+        node.set_status(TaskPhase.CANCELLED)
+        return True
+    return False
+
+
 # ---------------------------------------------------------------------------
 # Documentation string for agents
 # ---------------------------------------------------------------------------

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1028,10 +1028,9 @@ class EmployeeManager:
                     node = tree.get_node(entry.node_id)
                     if not node or node.project_id != project_id:
                         continue
-                    if node.status in (TaskPhase.PENDING.value, TaskPhase.PROCESSING.value, TaskPhase.HOLDING.value):
-                        # Force status — may not follow normal transitions
+                    from onemancompany.core.task_lifecycle import safe_cancel
+                    if safe_cancel(node):
                         logger.debug("[TASK LIFECYCLE] employee={} node={} → CANCELLED (project abort)", emp_id, entry.node_id)
-                        node.status = TaskPhase.CANCELLED.value
                         node.completed_at = datetime.now().isoformat()
                         node.result = "Cancelled by CEO"
                         save_tree_async(entry.tree_path)
@@ -1072,7 +1071,6 @@ class EmployeeManager:
         from onemancompany.core.automation import stop_all_crons_for_employee
 
         count = 0
-        _cancelable = {TaskPhase.PENDING.value, TaskPhase.PROCESSING.value, TaskPhase.HOLDING.value}
 
         # 1. Clear schedule and cancel nodes
         entries = list(self._schedule.get(employee_id, []))
@@ -1093,10 +1091,9 @@ class EmployeeManager:
             try:
                 tree = get_tree(entry.tree_path)
                 node = tree.get_node(entry.node_id)
-                if node and node.status in _cancelable:
-                    # Force status — may not follow normal transitions
+                from onemancompany.core.task_lifecycle import safe_cancel as _safe_cancel
+                if node and _safe_cancel(node):
                     logger.debug("[TASK LIFECYCLE] employee={} node={} → CANCELLED (employee abort)", employee_id, entry.node_id)
-                    node.status = TaskPhase.CANCELLED.value
                     node.completed_at = datetime.now().isoformat()
                     node.result = f"Cancelled: employee {employee_id} aborted"
                     count += 1
@@ -1361,7 +1358,8 @@ class EmployeeManager:
 
         except asyncio.CancelledError:
             agent_error = True
-            node.status = TaskPhase.CANCELLED.value
+            from onemancompany.core.task_lifecycle import safe_cancel as _sc
+            _sc(node)
             logger.debug("[TASK LIFECYCLE] employee={} node={} → CANCELLED", employee_id, entry.node_id)
             node.result = node.result or "Cancelled by CEO"
             if not node.completed_at:

--- a/tests/unit/core/test_store.py
+++ b/tests/unit/core/test_store.py
@@ -287,3 +287,49 @@ class TestAtomicWrite:
         # No leftover temp files
         temps = list(tmp_path.glob("*.tmp"))
         assert temps == []
+
+
+class TestAbortUsesTransition:
+    """Abort paths must not bypass the state machine."""
+
+    def test_no_direct_status_assignment_in_vessel_abort(self):
+        """vessel.py abort_project must not directly assign node.status."""
+        import inspect
+        from onemancompany.core.vessel import EmployeeManager
+        source = inspect.getsource(EmployeeManager.abort_project)
+        assert "node.status = TaskPhase.CANCELLED" not in source, (
+            "abort_project bypasses transition() — must use set_status or force_cancel"
+        )
+
+    def test_no_direct_status_assignment_in_routes_abort(self):
+        """routes.py abort endpoint must not directly assign node.status."""
+        import ast
+        from pathlib import Path
+        routes_path = Path(__file__).parent.parent.parent.parent / "src/onemancompany/api/routes.py"
+        source = routes_path.read_text()
+        # Count direct assignments — should be zero after fix
+        # We check for the pattern "node.status = TaskPhase.CANCELLED.value"
+        count = source.count("node.status = TaskPhase.CANCELLED.value")
+        assert count == 0, (
+            f"Found {count} direct node.status = CANCELLED assignments in routes.py — "
+            "must use node.set_status() or safe_cancel() instead"
+        )
+
+    def test_safe_cancel_accepted_returns_false(self):
+        """safe_cancel on ACCEPTED node should return False without error."""
+        from onemancompany.core.task_lifecycle import safe_cancel, TaskPhase
+        from unittest.mock import MagicMock
+        node = MagicMock()
+        node.status = TaskPhase.ACCEPTED.value
+        result = safe_cancel(node)
+        assert result is False
+
+    def test_safe_cancel_pending_returns_true(self):
+        """safe_cancel on PENDING node should cancel and return True."""
+        from onemancompany.core.task_lifecycle import safe_cancel, TaskPhase
+        from unittest.mock import MagicMock
+        node = MagicMock()
+        node.status = TaskPhase.PENDING.value
+        result = safe_cancel(node)
+        assert result is True
+        node.set_status.assert_called_once_with(TaskPhase.CANCELLED)


### PR DESCRIPTION
## Summary
**P0.3 System Analysis item:** 7 abort paths directly set node.status = CANCELLED, bypassing the state machine.

Now all abort paths use `safe_cancel(node)` which checks terminal states and uses `node.set_status()`.

## Test plan
- [x] 2230 tests pass (4 new)
- [x] Zero direct `node.status = TaskPhase.CANCELLED` assignments remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)