### PR TITLE
feat: real-time task progress via WebSocket direct rendering

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -477,12 +477,13 @@ class AppController {
         return null;
       },
       'agent_log':           (p) => {
-        // Debounced re-fetch from disk for grouped trace view
-        if (this.viewingEmployeeId && p.employee_id === this.viewingEmployeeId) {
-          clearTimeout(this._logRefetchTimer);
-          this._logRefetchTimer = setTimeout(() => {
-            this._fetchExecutionLogs(this.viewingEmployeeId);
-          }, 500);
+        // Real-time append: use WS payload directly instead of re-polling REST
+        if (this.viewingEmployeeId && p.employee_id === this.viewingEmployeeId && p.log) {
+          // Skip if REST fetch is in-flight (renderLogs will do a full refresh)
+          if (this._logFetchInFlight) return null;
+          if (this._empXterm) {
+            this._empXterm.appendLog(p.log);
+          }
         }
         return null;  // don't spam the activity log
       },
@@ -1886,6 +1887,7 @@ class AppController {
   }
 
   async _fetchExecutionLogs(empId) {
+    this._logFetchInFlight = true;
     try {
       const resp = await fetch(`/api/employee/${empId}/logs?tail=100`);
       const data = await resp.json();
@@ -1901,6 +1903,8 @@ class AppController {
       }
     } catch (err) {
       console.error('Execution logs fetch error:', err);
+    } finally {
+      this._logFetchInFlight = false;
     }
   }
 

--- a/frontend/xterm-log.js
+++ b/frontend/xterm-log.js
@@ -136,6 +136,38 @@ class XTermLog {
   }
 
   /**
+   * Append a single log entry in real time (no clear/re-render).
+   * Used by WebSocket agent_log handler for live streaming.
+   */
+  appendLog(log) {
+    if (!log || !this._term) return;
+
+    // Buffer tool_call to pair with subsequent tool_result
+    if (log.type === 'tool_call') {
+      this._pendingToolCall = log;
+      return;  // Don't render yet — wait for result
+    }
+
+    if (log.type === 'tool_result' && this._pendingToolCall) {
+      // Pair with pending tool_call for proper grouped rendering
+      const steps = traceGroupSteps([this._pendingToolCall, log]);
+      this._pendingToolCall = null;
+      for (const step of steps) {
+        this._renderStep(step);
+      }
+    } else {
+      // Standalone entry (llm_output, result, etc.)
+      this._pendingToolCall = null;
+      const steps = traceGroupSteps([log]);
+      for (const step of steps) {
+        this._renderStep(step);
+      }
+    }
+
+    this._term.scrollToBottom();
+  }
+
+  /**
    * Render trace feed (full project tree with inline logs)
    */
   renderTraceFeed(nodes, rootId) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.720",
+  "version": "0.2.721",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.720"
+version = "0.2.721"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
**P1.3 System Analysis item:** CEO had no visibility into running tasks.

Now execution logs stream in real time via WebSocket — no more 500ms debounced REST re-polling.

- `appendLog()` on XTermLog renders entries incrementally
- Tool call/result pairing via buffered `_pendingToolCall`
- `_logFetchInFlight` flag prevents duplicate rendering

**No backend changes** — WebSocket already sent full payload, frontend was ignoring it.

## Test plan
- [x] Frontend syntax check passes
- [x] 2229 backend tests pass
- [ ] Open employee detail while task is running → verify logs stream in real time
- [ ] Verify tool calls render with results (not orphaned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)