### PR TITLE
fix: founding team launch.sh still had backward JSON scan

### DIFF
--- a/company/human_resource/employees/00002/launch.sh
+++ b/company/human_resource/employees/00002/launch.sh
@@ -105,16 +105,17 @@ RAW=$("$OPENCLAW_BIN" agent --local -m "$OMC_TASK_DESCRIPTION" --session-id "$SE
 
 # openclaw may output JSON to stderr instead of stdout — try both
 if [ -z "$RAW" ] && [ -f "$STDERR_FILE" ]; then
-    # Extract JSON object from stderr (skip ANSI log lines, find the JSON block)
+    # Extract the outermost JSON object from stderr (skip ANSI log lines).
+    # Scan forward to find the first '{' that parses into a complete JSON object.
+    # Scanning backward would match a tiny nested object, not the root response.
     RAW=$(python3 -c "
 import json, sys
 raw = open(sys.argv[1]).read()
 decoder = json.JSONDecoder()
-# Find the last valid JSON object (openclaw puts log lines before it)
-for i in range(len(raw) - 1, -1, -1):
+for i in range(len(raw)):
     if raw[i] == '{':
         try:
-            obj, _ = decoder.raw_decode(raw[i:])
+            obj, end = decoder.raw_decode(raw[i:])
             print(json.dumps(obj))
             break
         except (json.JSONDecodeError, ValueError):

--- a/company/human_resource/employees/00003/launch.sh
+++ b/company/human_resource/employees/00003/launch.sh
@@ -105,16 +105,17 @@ RAW=$("$OPENCLAW_BIN" agent --local -m "$OMC_TASK_DESCRIPTION" --session-id "$SE
 
 # openclaw may output JSON to stderr instead of stdout — try both
 if [ -z "$RAW" ] && [ -f "$STDERR_FILE" ]; then
-    # Extract JSON object from stderr (skip ANSI log lines, find the JSON block)
+    # Extract the outermost JSON object from stderr (skip ANSI log lines).
+    # Scan forward to find the first '{' that parses into a complete JSON object.
+    # Scanning backward would match a tiny nested object, not the root response.
     RAW=$(python3 -c "
 import json, sys
 raw = open(sys.argv[1]).read()
 decoder = json.JSONDecoder()
-# Find the last valid JSON object (openclaw puts log lines before it)
-for i in range(len(raw) - 1, -1, -1):
+for i in range(len(raw)):
     if raw[i] == '{':
         try:
-            obj, _ = decoder.raw_decode(raw[i:])
+            obj, end = decoder.raw_decode(raw[i:])
             print(json.dumps(obj))
             break
         except (json.JSONDecodeError, ValueError):

--- a/company/human_resource/employees/00004/launch.sh
+++ b/company/human_resource/employees/00004/launch.sh
@@ -105,16 +105,17 @@ RAW=$("$OPENCLAW_BIN" agent --local -m "$OMC_TASK_DESCRIPTION" --session-id "$SE
 
 # openclaw may output JSON to stderr instead of stdout — try both
 if [ -z "$RAW" ] && [ -f "$STDERR_FILE" ]; then
-    # Extract JSON object from stderr (skip ANSI log lines, find the JSON block)
+    # Extract the outermost JSON object from stderr (skip ANSI log lines).
+    # Scan forward to find the first '{' that parses into a complete JSON object.
+    # Scanning backward would match a tiny nested object, not the root response.
     RAW=$(python3 -c "
 import json, sys
 raw = open(sys.argv[1]).read()
 decoder = json.JSONDecoder()
-# Find the last valid JSON object (openclaw puts log lines before it)
-for i in range(len(raw) - 1, -1, -1):
+for i in range(len(raw)):
     if raw[i] == '{':
         try:
-            obj, _ = decoder.raw_decode(raw[i:])
+            obj, end = decoder.raw_decode(raw[i:])
             print(json.dumps(obj))
             break
         except (json.JSONDecodeError, ValueError):

--- a/company/human_resource/employees/00005/launch.sh
+++ b/company/human_resource/employees/00005/launch.sh
@@ -105,16 +105,17 @@ RAW=$("$OPENCLAW_BIN" agent --local -m "$OMC_TASK_DESCRIPTION" --session-id "$SE
 
 # openclaw may output JSON to stderr instead of stdout — try both
 if [ -z "$RAW" ] && [ -f "$STDERR_FILE" ]; then
-    # Extract JSON object from stderr (skip ANSI log lines, find the JSON block)
+    # Extract the outermost JSON object from stderr (skip ANSI log lines).
+    # Scan forward to find the first '{' that parses into a complete JSON object.
+    # Scanning backward would match a tiny nested object, not the root response.
     RAW=$(python3 -c "
 import json, sys
 raw = open(sys.argv[1]).read()
 decoder = json.JSONDecoder()
-# Find the last valid JSON object (openclaw puts log lines before it)
-for i in range(len(raw) - 1, -1, -1):
+for i in range(len(raw)):
     if raw[i] == '{':
         try:
-            obj, _ = decoder.raw_decode(raw[i:])
+            obj, end = decoder.raw_decode(raw[i:])
             print(json.dumps(obj))
             break
         except (json.JSONDecodeError, ValueError):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.727",
+  "version": "0.2.728",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.727"
+version = "0.2.728"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- PR #182 fixed the template at `talent_market/talents/openclaw/launch.sh` but missed the **4 actual copies** at `company/human_resource/employees/0000{2-5}/launch.sh`
- These are what `npx` deploys — so fresh installs still had the broken backward scan
- Synced all 4 founding employee launch.sh files with the fixed template

## Root cause
Duplicate launch.sh files: 1 template + 4 copies. Only template was fixed.

## Test plan
- [x] Verified all 4 files now use forward scan (`for i in range(len(raw))`)
- [x] Full test suite passes (2240 tests)
- [ ] Manual: `npx` fresh install → openclaw employee should return output

🤖 Generated with [Claude Code](https://claude.com/claude-code)