### PR TITLE
fix: add encoding="utf-8" to all file I/O for Windows GBK compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.728",
+  "version": "0.2.729",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.729",
+  "version": "0.2.730",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.730",
+  "version": "0.2.731",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.728"
+version = "0.2.729"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.730"
+version = "0.2.731"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.729"
+version = "0.2.730"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -19,7 +19,6 @@ from onemancompany.core.config import (
     BLOCK_TYPE_TEXT,
     CHAT_CLASS_ANTHROPIC,
     CHAT_CLASS_OPENAI,
-    ENCODING_UTF8,
     FOUNDING_IDS,
     MAX_SUMMARY_LEN,
     PF_DEPARTMENT,
@@ -43,6 +42,7 @@ from onemancompany.core.config import (
     get_provider,
     load_employee_skills,
     settings,
+    read_text_utf,
 )
 from onemancompany.core.models import AuthMethod
 from onemancompany.core.events import CompanyEvent, event_bus
@@ -380,7 +380,7 @@ def get_employee_talent_persona(employee_id: str) -> str:
     path = EMPLOYEES_DIR / employee_id / PROMPTS_DIR_NAME / TALENT_PERSONA_FILENAME
     if not path.exists():
         return ""
-    content = path.read_text(encoding=ENCODING_UTF8).strip()
+    content = read_text_utf(path).strip()
     return f"\n{content}" if content else ""
 
 
@@ -490,7 +490,7 @@ def get_employee_tools_prompt(employee_id: str) -> str:
                     fpath = tool_folder / fname
                     if fpath.is_file():
                         try:
-                            content = fpath.read_text(encoding=ENCODING_UTF8)
+                            content = read_text_utf(fpath)
                         except (UnicodeDecodeError, ValueError):
                             content = f"[binary, {fpath.stat().st_size} bytes]"
                         parts.append(f"  - {fname}:\n```\n{content}\n```")
@@ -941,7 +941,7 @@ class BaseAgentRunner:
         """Load prompt from employee's prompts/ dir."""
         path = EMPLOYEES_DIR / self.employee_id / PROMPTS_DIR_NAME / filename
         if path.exists():
-            return path.read_text(encoding=ENCODING_UTF8)
+            return read_text_utf(path)
         return None
 
     @staticmethod
@@ -949,7 +949,7 @@ class BaseAgentRunner:
         """Load from company/shared_prompts/."""
         path = SHARED_PROMPTS_DIR / filename
         if path.exists():
-            return path.read_text(encoding=ENCODING_UTF8)
+            return read_text_utf(path)
         return None
 
     def _get_company_direction_section(self) -> str:
@@ -969,7 +969,7 @@ class BaseAgentRunner:
         soul_path = EMPLOYEES_DIR / self.employee_id / WORKSPACE_DIR_NAME / SOUL_FILENAME
         if soul_path.exists():
             try:
-                content = soul_path.read_text(encoding=ENCODING_UTF8).strip()
+                content = read_text_utf(soul_path).strip()
                 if content:
                     return (
                         "## Your Personal Knowledge (SOUL.md)\n"
@@ -1028,7 +1028,7 @@ class BaseAgentRunner:
                 if not content_path:
                     continue
                 try:
-                    content = content_path.read_text(encoding=ENCODING_UTF8)
+                    content = read_text_utf(content_path)
                     pb.add(ps.name, content, priority=ps.priority)
                 except Exception as _e:
                     logger.warning("Failed to load prompt section %s: %s", ps.name, _e)

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -15,7 +15,7 @@ from langchain_core.tools import tool
 from loguru import logger
 
 from onemancompany.agents.base import get_employee_skills_prompt, get_employee_tools_prompt, make_llm, tracked_ainvoke
-from onemancompany.core.config import COO_ID, ENCODING_UTF8, HR_ID, MAX_DISCUSSION_SUMMARY_LEN, MAX_PRINCIPLES_LEN, MEETING_SYSTEM_SENDER, PF_CURRENT_TASK_SUMMARY, PF_DEPARTMENT, PF_EMPLOYEE_NUMBER, PF_ID, PF_LEVEL, PF_NAME, PF_NICKNAME, PF_PERMISSIONS, PF_ROLE, PF_RUNTIME, PF_SKILLS, PF_STATUS, PF_TOOL_PERMISSIONS, PF_WORK_PRINCIPLES, PROJECT_YAML_FILENAME, PROJECTS_DIR, ROOMS_DIR, STATUS_IDLE, SYSTEM_SENDER, get_workspace_dir
+from onemancompany.core.config import COO_ID, ENCODING_UTF8, HR_ID, MAX_DISCUSSION_SUMMARY_LEN, MAX_PRINCIPLES_LEN, MEETING_SYSTEM_SENDER, PF_CURRENT_TASK_SUMMARY, PF_DEPARTMENT, PF_EMPLOYEE_NUMBER, PF_ID, PF_LEVEL, PF_NAME, PF_NICKNAME, PF_PERMISSIONS, PF_ROLE, PF_RUNTIME, PF_SKILLS, PF_STATUS, PF_TOOL_PERMISSIONS, PF_WORK_PRINCIPLES, PROJECT_YAML_FILENAME, PROJECTS_DIR, ROOMS_DIR, STATUS_IDLE, SYSTEM_SENDER, get_workspace_dir, read_text_utf, write_text_utf
 from onemancompany.core.events import CompanyEvent, event_bus
 from onemancompany.core.state import company_state
 from onemancompany.core.store import load_employee, load_all_employees
@@ -101,7 +101,7 @@ def read(file_path: str, employee_id: str = "", offset: int = 0, limit: int = 0)
     if not resolved.is_file():
         return {"status": "error", "message": f"Not a file: {file_path}"}
     try:
-        content = resolved.read_text(encoding=ENCODING_UTF8)
+        content = read_text_utf(resolved)
         lines = content.splitlines(keepends=True)
         total_lines = len(lines)
 
@@ -211,10 +211,10 @@ async def write(
                 "status": "error",
                 "message": f"You must read '{file_path}' before overwriting it. Use read() first.",
             }
-        original_content = resolved.read_text(encoding=ENCODING_UTF8)
+        original_content = read_text_utf(resolved)
 
     resolved.parent.mkdir(parents=True, exist_ok=True)
-    resolved.write_text(content, encoding=ENCODING_UTF8)
+    write_text_utf(resolved, content)
     _files_read_by_employee.setdefault(employee_id, set()).add(str(resolved))
 
     result: dict = {
@@ -272,7 +272,7 @@ async def edit(
     if old_string == new_string:
         return {"status": "error", "message": "old_string and new_string are identical."}
 
-    content = resolved.read_text(encoding=ENCODING_UTF8)
+    content = read_text_utf(resolved)
     count = content.count(old_string)
 
     if count == 0:
@@ -291,7 +291,7 @@ async def edit(
         new_content = content.replace(old_string, new_string, 1)
         replacements = 1
 
-    resolved.write_text(new_content, encoding=ENCODING_UTF8)
+    write_text_utf(resolved, new_content)
     return {
         "status": "ok",
         "path": str(resolved),
@@ -957,7 +957,7 @@ async def pull_meeting(
                 # Clear room chat for next meeting
                 chat_path = ROOMS_DIR / f"{room.id}_chat.yaml"
                 if chat_path.exists():
-                    chat_path.write_text("[]", encoding="utf-8")
+                    write_text_utf(chat_path, "[]")
         except Exception as _archive_err:
             logger.debug("Failed to archive meeting: {}", _archive_err)
 
@@ -1076,7 +1076,7 @@ def use_tool(tool_name_or_id: str, employee_id: str) -> dict:
                     continue
                 # Skip binary files — just report size
                 try:
-                    content = fpath.read_text(encoding=ENCODING_UTF8)
+                    content = read_text_utf(fpath)
                     result["files"][fname] = content
                 except (UnicodeDecodeError, ValueError):
                     result["files"][fname] = f"[binary file, {fpath.stat().st_size} bytes]"
@@ -1443,7 +1443,7 @@ def update_project_team(members: list[dict]) -> dict:
     if not project_yaml.exists():
         return {"status": "error", "message": "project.yaml not found."}
 
-    data = yaml.safe_load(project_yaml.read_text(encoding=ENCODING_UTF8)) or {}
+    data = yaml.safe_load(read_text_utf(project_yaml)) or {}
     team = data.get("team", [])
 
     existing_ids = {t.get("employee_id") for t in team}
@@ -1462,10 +1462,7 @@ def update_project_team(members: list[dict]) -> dict:
         added += 1
 
     data["team"] = team
-    project_yaml.write_text(
-        yaml.dump(data, allow_unicode=True, sort_keys=False),
-        encoding=ENCODING_UTF8,
-    )
+    write_text_utf(project_yaml, yaml.dump(data, allow_unicode=True, sort_keys=False))
 
     return {"status": "ok", "added": added, "total": len(team)}
 

--- a/src/onemancompany/agents/coo_agent.py
+++ b/src/onemancompany/agents/coo_agent.py
@@ -17,7 +17,7 @@ from langchain_core.tools import tool
 from langgraph.prebuilt import create_react_agent
 
 from onemancompany.agents.base import BaseAgentRunner, extract_final_content, make_llm
-from onemancompany.core.config import COO_ID, HR_ID, MAX_SUMMARY_LEN, OrgDir, PF_DEPARTMENT, PF_NAME, PF_REMOTE, PF_ROLE, PROJECTS_DIR, ROOMS_DIR, STATUS_IDLE, STATUS_WORKING, TOOL_YAML_FILENAME, TOOLS_DIR, WORKFLOWS_DIR, load_assets, save_company_direction, save_workflow, slugify_tool_name
+from onemancompany.core.config import COO_ID, HR_ID, MAX_SUMMARY_LEN, OrgDir, PF_DEPARTMENT, PF_NAME, PF_REMOTE, PF_ROLE, PROJECTS_DIR, ROOMS_DIR, STATUS_IDLE, STATUS_WORKING, TOOL_YAML_FILENAME, TOOLS_DIR, WORKFLOWS_DIR, load_assets, open_utf, save_company_direction, save_workflow, slugify_tool_name
 from onemancompany.core.events import CompanyEvent, event_bus
 from onemancompany.core.models import EventType
 from onemancompany.core.state import MeetingRoom, OfficeTool, company_state
@@ -87,7 +87,7 @@ def _persist_tool(t: OfficeTool) -> None:
     folder = TOOLS_DIR / t.folder_name
     folder.mkdir(parents=True, exist_ok=True)
     path = folder / TOOL_YAML_FILENAME
-    with open(path, "w", encoding="utf-8") as f:
+    with open_utf(path, "w") as f:
         yaml.dump(
             {
                 "id": t.id,
@@ -526,7 +526,7 @@ def add_meeting_room(name: str, capacity: int = 6, description: str = "") -> dic
     # Persist to assets/rooms/
     ROOMS_DIR.mkdir(parents=True, exist_ok=True)
     room_path = ROOMS_DIR / f"{room_id}.yaml"
-    with open(room_path, "w", encoding="utf-8") as f:
+    with open_utf(room_path, "w") as f:
         yaml.dump(
             {
                 "name": name,

--- a/src/onemancompany/agents/coo_agent.py
+++ b/src/onemancompany/agents/coo_agent.py
@@ -87,7 +87,7 @@ def _persist_tool(t: OfficeTool) -> None:
     folder = TOOLS_DIR / t.folder_name
     folder.mkdir(parents=True, exist_ok=True)
     path = folder / TOOL_YAML_FILENAME
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         yaml.dump(
             {
                 "id": t.id,
@@ -170,7 +170,7 @@ def register_asset(
                     src = Path(source_project_dir) / f
                     if src.exists():
                         try:
-                            ast.parse(src.read_text())
+                            ast.parse(src.read_text(encoding="utf-8"))
                         except SyntaxError as e:
                             return {"status": "error", "message": f"Python syntax error in {f}: {e}"}
     elif tool_type == "reference":
@@ -526,7 +526,7 @@ def add_meeting_room(name: str, capacity: int = 6, description: str = "") -> dic
     # Persist to assets/rooms/
     ROOMS_DIR.mkdir(parents=True, exist_ok=True)
     room_path = ROOMS_DIR / f"{room_id}.yaml"
-    with open(room_path, "w") as f:
+    with open(room_path, "w", encoding="utf-8") as f:
         yaml.dump(
             {
                 "name": name,

--- a/src/onemancompany/agents/coo_agent.py
+++ b/src/onemancompany/agents/coo_agent.py
@@ -17,7 +17,7 @@ from langchain_core.tools import tool
 from langgraph.prebuilt import create_react_agent
 
 from onemancompany.agents.base import BaseAgentRunner, extract_final_content, make_llm
-from onemancompany.core.config import COO_ID, HR_ID, MAX_SUMMARY_LEN, OrgDir, PF_DEPARTMENT, PF_NAME, PF_REMOTE, PF_ROLE, PROJECTS_DIR, ROOMS_DIR, STATUS_IDLE, STATUS_WORKING, TOOL_YAML_FILENAME, TOOLS_DIR, WORKFLOWS_DIR, load_assets, open_utf, save_company_direction, save_workflow, slugify_tool_name
+from onemancompany.core.config import COO_ID, HR_ID, MAX_SUMMARY_LEN, OrgDir, PF_DEPARTMENT, PF_NAME, PF_REMOTE, PF_ROLE, PROJECTS_DIR, ROOMS_DIR, STATUS_IDLE, STATUS_WORKING, TOOL_YAML_FILENAME, TOOLS_DIR, WORKFLOWS_DIR, load_assets, open_utf, read_text_utf, save_company_direction, save_workflow, slugify_tool_name
 from onemancompany.core.events import CompanyEvent, event_bus
 from onemancompany.core.models import EventType
 from onemancompany.core.state import MeetingRoom, OfficeTool, company_state
@@ -170,7 +170,7 @@ def register_asset(
                     src = Path(source_project_dir) / f
                     if src.exists():
                         try:
-                            ast.parse(src.read_text(encoding="utf-8"))
+                            ast.parse(read_text_utf(src))
                         except SyntaxError as e:
                             return {"status": "error", "message": f"Python syntax error in {f}: {e}"}
     elif tool_type == "reference":
@@ -879,10 +879,10 @@ class COOAgent(BaseAgentRunner):
         )
 
     def _get_role_identity_section(self) -> str:
-        from onemancompany.core.config import EMPLOYEES_DIR, ENCODING_UTF8
+        from onemancompany.core.config import EMPLOYEES_DIR, read_text_utf
         guide_path = EMPLOYEES_DIR / self.employee_id / "role_guide.md"
         if guide_path.exists():
-            return guide_path.read_text(encoding=ENCODING_UTF8)
+            return read_text_utf(guide_path)
         return ""
 
     def _customize_prompt(self, pb) -> None:

--- a/src/onemancompany/agents/cso_agent.py
+++ b/src/onemancompany/agents/cso_agent.py
@@ -246,10 +246,10 @@ class CSOAgent(BaseAgentRunner):
         )
 
     def _get_role_identity_section(self) -> str:
-        from onemancompany.core.config import EMPLOYEES_DIR, ENCODING_UTF8
+        from onemancompany.core.config import EMPLOYEES_DIR, read_text_utf
         guide_path = EMPLOYEES_DIR / self.employee_id / "role_guide.md"
         if guide_path.exists():
-            return guide_path.read_text(encoding=ENCODING_UTF8)
+            return read_text_utf(guide_path)
         return ""
 
     def _customize_prompt(self, pb) -> None:

--- a/src/onemancompany/agents/ea_agent.py
+++ b/src/onemancompany/agents/ea_agent.py
@@ -30,10 +30,10 @@ class EAAgent(BaseAgentRunner):
         )
 
     def _get_role_identity_section(self) -> str:
-        from onemancompany.core.config import EMPLOYEES_DIR, ENCODING_UTF8
+        from onemancompany.core.config import EMPLOYEES_DIR, read_text_utf
         guide_path = EMPLOYEES_DIR / self.employee_id / "role_guide.md"
         if guide_path.exists():
-            return guide_path.read_text(encoding=ENCODING_UTF8)
+            return read_text_utf(guide_path)
         return ""
 
     def _customize_prompt(self, pb) -> None:

--- a/src/onemancompany/agents/hr_agent.py
+++ b/src/onemancompany/agents/hr_agent.py
@@ -194,10 +194,10 @@ class HRAgent(BaseAgentRunner):
         )
 
     def _get_role_identity_section(self) -> str:
-        from onemancompany.core.config import EMPLOYEES_DIR, ENCODING_UTF8
+        from onemancompany.core.config import EMPLOYEES_DIR, read_text_utf
         guide_path = EMPLOYEES_DIR / self.employee_id / "role_guide.md"
         if guide_path.exists():
-            return guide_path.read_text(encoding=ENCODING_UTF8)
+            return read_text_utf(guide_path)
         return ""
 
     def _customize_prompt(self, pb) -> None:

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -23,7 +23,6 @@ from onemancompany.core.config import (
     DEFAULT_TOOL_PERMISSIONS,
     DEFAULT_TOOL_PERMISSIONS_FALLBACK,
     DEFAULT_DEPARTMENT,
-    ENCODING_UTF8,
     HR_ID,
     open_utf,
     MANIFEST_FILENAME,
@@ -44,6 +43,8 @@ from onemancompany.core.config import (
     EmployeeConfig,
     ensure_employee_dir,
     settings,
+    read_text_utf,
+    write_text_utf,
 )
 from onemancompany.core import store as _store
 from onemancompany.core.models import EventType, HostingMode
@@ -104,7 +105,7 @@ def _load_nickname_pool() -> list[str]:
 
     if src.exists():
         pool = [
-            line.strip() for line in src.read_text(encoding=ENCODING_UTF8).splitlines() if line.strip()
+            line.strip() for line in read_text_utf(src).splitlines() if line.strip()
         ]
         logger.debug("Loaded {} nicknames from {}", len(pool), src)
         return pool
@@ -601,7 +602,7 @@ async def clone_talent_repo(repo_url: str, talent_id: str) -> Path:
             for sub in tmp_clone.iterdir():
                 if sub.is_dir() and (sub / PROFILE_FILENAME).exists():
                     try:
-                        profile_id = (_yaml.safe_load((sub / PROFILE_FILENAME).read_text(encoding="utf-8")) or {}).get("id", "")
+                        profile_id = (_yaml.safe_load(read_text_utf(sub / PROFILE_FILENAME)) or {}).get("id", "")
                     except Exception:
                         profile_id = ""
                     dest_name = profile_id or sub.name
@@ -753,7 +754,7 @@ def copy_talent_assets(talent_dir: Path, emp_dir) -> None:
                 prompts_dir.mkdir(exist_ok=True)
                 dst_persona = prompts_dir / TALENT_PERSONA_FILENAME
                 if not dst_persona.exists():
-                    dst_persona.write_text(spt.strip() + "\n", encoding=ENCODING_UTF8)
+                    write_text_utf(dst_persona, spt.strip() + "\n")
 
     # Copy CLAUDE.md for Claude CLI discovery
     dst_claude_md = emp_dir / CLAUDE_MD_FILENAME
@@ -778,7 +779,7 @@ def copy_talent_assets(talent_dir: Path, emp_dir) -> None:
             f"- Save all outputs to the project workspace path specified in your task.\n"
             f"- Do NOT loop or re-analyze. Produce output, verify once, then finish.\n"
         )
-        dst_claude_md.write_text(claude_md_content, encoding=ENCODING_UTF8)
+        write_text_utf(dst_claude_md, claude_md_content)
 
     # Copy manifest.json (frontend UI config — OAuth buttons, settings sections)
     talent_manifest_json = talent_dir / MANIFEST_FILENAME
@@ -971,9 +972,7 @@ async def execute_hire(
             "company_url": f"http://{settings.host}:{settings.port}",
             "talent_id": talent_id,
         }
-        (emp_dir / CONNECTION_JSON_FILENAME).write_text(
-            _json.dumps(connection, indent=2, ensure_ascii=False), encoding=ENCODING_UTF8,
-        )
+        write_text_utf(emp_dir / CONNECTION_JSON_FILENAME, _json.dumps(connection, indent=2, ensure_ascii=False))
 
     # Copy talent skills + tools
     if talent_dir and talent_dir.exists() and not remote:
@@ -1003,11 +1002,9 @@ async def execute_hire(
         skill_dir.mkdir(parents=True, exist_ok=True)
         skill_file = skill_dir / SKILL_FILENAME
         if not skill_file.exists():
-            skill_file.write_text(
+            write_text_utf(skill_file,
                 f"---\nname: {skill_name}\ndescription: \"{name}'s {skill_name} skill.\"\n---\n\n"
-                f"# {skill_name}\n\n(Auto-created by HR during hiring.)\n",
-                encoding=ENCODING_UTF8,
-            )
+                f"# {skill_name}\n\n(Auto-created by HR during hiring.)\n")
 
     # Inject default skills (ontology, proactive-agent, self-improving-agent)
     _inject_default_skills(skills_dir)
@@ -1017,20 +1014,18 @@ async def execute_hire(
     workspace_dir.mkdir(exist_ok=True)
     soul_path = workspace_dir / SOUL_FILENAME
     if not soul_path.exists():
-        soul_path.write_text(
+        write_text_utf(soul_path,
             f"# {name} ({nickname}) — Personal Knowledge\n\n"
             f"**Role**: {role}\n"
             f"**Department**: {department}\n\n"
             f"## Lessons Learned\n\n"
-            f"(Will be updated automatically after each task.)\n",
-            encoding=ENCODING_UTF8,
-        )
+            f"(Will be updated automatically after each task.)\n")
 
     # Generate initial work_principles.md (unified location for all hosting modes)
     from onemancompany.core.store import WORK_PRINCIPLES_FILENAME
     wp_path = emp_dir / WORK_PRINCIPLES_FILENAME
     if not wp_path.exists():
-        wp_path.write_text(
+        write_text_utf(wp_path,
             f"# {name} ({nickname}) Work Principles\n\n"
             f"**Department**: {department}\n"
             f"**Title**: {make_title(1, role)}\n"
@@ -1039,9 +1034,7 @@ async def execute_hire(
             f"1. Complete assigned work diligently and maintain professional standards\n"
             f"2. Actively collaborate with the team and communicate progress promptly\n"
             f"3. Continuously learn and improve professional skills\n"
-            f"4. Follow company rules and guidelines\n",
-            encoding=ENCODING_UTF8,
-        )
+            f"4. Follow company rules and guidelines\n")
 
     # Generate standalone run.py for company-hosted employees
     if hosting == HostingMode.COMPANY:

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -161,7 +161,7 @@ def _update_tool_allowed_users(tool_name: str, employee_id: str, *, add: bool) -
     if not tool_yaml.exists():
         logger.warning("_update_tool_allowed_users: tool.yaml not found for '{}', skipping", tool_name)
         return
-    with open(tool_yaml) as f:
+    with open(tool_yaml, encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
     allowed: list = data.get("allowed_users", [])
     if add:
@@ -171,7 +171,7 @@ def _update_tool_allowed_users(tool_name: str, employee_id: str, *, add: bool) -
         if employee_id in allowed:
             allowed.remove(employee_id)
     data["allowed_users"] = allowed
-    with open(tool_yaml, "w") as f:
+    with open(tool_yaml, "w", encoding="utf-8") as f:
         yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
 
 
@@ -225,7 +225,7 @@ def install_talent_functions(talent_dir: Path, emp_dir, employee_id: str) -> lis
     if not fn_manifest_path.exists():
         return []
 
-    with open(fn_manifest_path) as f:
+    with open(fn_manifest_path, encoding="utf-8") as f:
         raw = yaml.safe_load(f) or {}
 
     declarations = raw.get("functions", [])
@@ -278,7 +278,7 @@ def install_talent_functions(talent_dir: Path, emp_dir, employee_id: str) -> lis
                 tool_meta["allowed_users"] = [employee_id]
             # scope == "company" → omit allowed_users entirely → unrestricted
 
-            with open(tool_dir / TOOL_YAML_FILENAME, "w") as f:
+            with open(tool_dir / TOOL_YAML_FILENAME, "w", encoding="utf-8") as f:
                 yaml.dump(tool_meta, f, default_flow_style=False, allow_unicode=True)
 
         # Ensure the bringing employee has access
@@ -311,7 +311,7 @@ def install_talent_agent_config(talent_dir: Path, emp_dir, employee_id: str) -> 
         shutil.rmtree(str(dst_agent_dir))
     shutil.copytree(str(agent_dir), str(dst_agent_dir))
 
-    with open(manifest_path) as f:
+    with open(manifest_path, encoding="utf-8") as f:
         manifest = yaml.safe_load(f) or {}
 
     # Validate runner module if declared
@@ -515,7 +515,7 @@ def install_talent_vessel_config(talent_dir: Path, emp_dir, employee_id: str) ->
                 shutil.copytree(str(ps_src), str(ps_dst))
 
         # Copy runner/hooks .py files
-        with open(talent_vessel_yaml) as f:
+        with open(talent_vessel_yaml, encoding="utf-8") as f:
             raw = yaml.safe_load(f) or {}
         for key in ("runner", "hooks"):
             mod = (raw.get(key) or {}).get("module", "")
@@ -600,7 +600,7 @@ async def clone_talent_repo(repo_url: str, talent_id: str) -> Path:
             for sub in tmp_clone.iterdir():
                 if sub.is_dir() and (sub / PROFILE_FILENAME).exists():
                     try:
-                        profile_id = (_yaml.safe_load((sub / PROFILE_FILENAME).read_text()) or {}).get("id", "")
+                        profile_id = (_yaml.safe_load((sub / PROFILE_FILENAME).read_text(encoding="utf-8")) or {}).get("id", "")
                     except Exception:
                         profile_id = ""
                     dest_name = profile_id or sub.name
@@ -706,7 +706,7 @@ def copy_talent_assets(talent_dir: Path, emp_dir) -> None:
         manifest = talent_tools / MANIFEST_YAML_FILENAME
         custom_tools: list[str] = []
         if manifest.exists():
-            with open(manifest) as f:
+            with open(manifest, encoding="utf-8") as f:
                 mdata = yaml.safe_load(f) or {}
             custom_tools = mdata.get("custom_tools", [])
 
@@ -745,7 +745,7 @@ def copy_talent_assets(talent_dir: Path, emp_dir) -> None:
     else:
         talent_profile_path = talent_dir / PROFILE_FILENAME
         if talent_profile_path.exists():
-            with open(talent_profile_path) as f:
+            with open(talent_profile_path, encoding="utf-8") as f:
                 talent_data = yaml.safe_load(f) or {}
             spt = talent_data.get("system_prompt_template", "")
             if spt and spt.strip():
@@ -810,7 +810,7 @@ def copy_talent_assets(talent_dir: Path, emp_dir) -> None:
         emp_tools.mkdir(exist_ok=True)
         emp_manifest = emp_tools / MANIFEST_YAML_FILENAME
         if emp_manifest.exists():
-            with open(emp_manifest) as f:
+            with open(emp_manifest, encoding="utf-8") as f:
                 emp_mdata = yaml.safe_load(f) or {}
         else:
             emp_mdata = {"builtin_tools": [], "custom_tools": []}
@@ -819,7 +819,7 @@ def copy_talent_assets(talent_dir: Path, emp_dir) -> None:
             if fn not in existing:
                 existing.append(fn)
         emp_mdata["custom_tools"] = existing
-        with open(emp_manifest, "w") as f:
+        with open(emp_manifest, "w", encoding="utf-8") as f:
             yaml.dump(emp_mdata, f, allow_unicode=True, default_flow_style=False)
 
 

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -25,6 +25,7 @@ from onemancompany.core.config import (
     DEFAULT_DEPARTMENT,
     ENCODING_UTF8,
     HR_ID,
+    open_utf,
     MANIFEST_FILENAME,
     MANIFEST_YAML_FILENAME,
     PROFILE_FILENAME,
@@ -161,7 +162,7 @@ def _update_tool_allowed_users(tool_name: str, employee_id: str, *, add: bool) -
     if not tool_yaml.exists():
         logger.warning("_update_tool_allowed_users: tool.yaml not found for '{}', skipping", tool_name)
         return
-    with open(tool_yaml, encoding="utf-8") as f:
+    with open_utf(tool_yaml) as f:
         data = yaml.safe_load(f) or {}
     allowed: list = data.get("allowed_users", [])
     if add:
@@ -171,7 +172,7 @@ def _update_tool_allowed_users(tool_name: str, employee_id: str, *, add: bool) -
         if employee_id in allowed:
             allowed.remove(employee_id)
     data["allowed_users"] = allowed
-    with open(tool_yaml, "w", encoding="utf-8") as f:
+    with open_utf(tool_yaml, "w") as f:
         yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
 
 
@@ -225,7 +226,7 @@ def install_talent_functions(talent_dir: Path, emp_dir, employee_id: str) -> lis
     if not fn_manifest_path.exists():
         return []
 
-    with open(fn_manifest_path, encoding="utf-8") as f:
+    with open_utf(fn_manifest_path) as f:
         raw = yaml.safe_load(f) or {}
 
     declarations = raw.get("functions", [])
@@ -278,7 +279,7 @@ def install_talent_functions(talent_dir: Path, emp_dir, employee_id: str) -> lis
                 tool_meta["allowed_users"] = [employee_id]
             # scope == "company" → omit allowed_users entirely → unrestricted
 
-            with open(tool_dir / TOOL_YAML_FILENAME, "w", encoding="utf-8") as f:
+            with open_utf(tool_dir / TOOL_YAML_FILENAME, "w") as f:
                 yaml.dump(tool_meta, f, default_flow_style=False, allow_unicode=True)
 
         # Ensure the bringing employee has access
@@ -311,7 +312,7 @@ def install_talent_agent_config(talent_dir: Path, emp_dir, employee_id: str) -> 
         shutil.rmtree(str(dst_agent_dir))
     shutil.copytree(str(agent_dir), str(dst_agent_dir))
 
-    with open(manifest_path, encoding="utf-8") as f:
+    with open_utf(manifest_path) as f:
         manifest = yaml.safe_load(f) or {}
 
     # Validate runner module if declared
@@ -515,7 +516,7 @@ def install_talent_vessel_config(talent_dir: Path, emp_dir, employee_id: str) ->
                 shutil.copytree(str(ps_src), str(ps_dst))
 
         # Copy runner/hooks .py files
-        with open(talent_vessel_yaml, encoding="utf-8") as f:
+        with open_utf(talent_vessel_yaml) as f:
             raw = yaml.safe_load(f) or {}
         for key in ("runner", "hooks"):
             mod = (raw.get(key) or {}).get("module", "")
@@ -706,7 +707,7 @@ def copy_talent_assets(talent_dir: Path, emp_dir) -> None:
         manifest = talent_tools / MANIFEST_YAML_FILENAME
         custom_tools: list[str] = []
         if manifest.exists():
-            with open(manifest, encoding="utf-8") as f:
+            with open_utf(manifest) as f:
                 mdata = yaml.safe_load(f) or {}
             custom_tools = mdata.get("custom_tools", [])
 
@@ -745,7 +746,7 @@ def copy_talent_assets(talent_dir: Path, emp_dir) -> None:
     else:
         talent_profile_path = talent_dir / PROFILE_FILENAME
         if talent_profile_path.exists():
-            with open(talent_profile_path, encoding="utf-8") as f:
+            with open_utf(talent_profile_path) as f:
                 talent_data = yaml.safe_load(f) or {}
             spt = talent_data.get("system_prompt_template", "")
             if spt and spt.strip():
@@ -810,7 +811,7 @@ def copy_talent_assets(talent_dir: Path, emp_dir) -> None:
         emp_tools.mkdir(exist_ok=True)
         emp_manifest = emp_tools / MANIFEST_YAML_FILENAME
         if emp_manifest.exists():
-            with open(emp_manifest, encoding="utf-8") as f:
+            with open_utf(emp_manifest) as f:
                 emp_mdata = yaml.safe_load(f) or {}
         else:
             emp_mdata = {"builtin_tools": [], "custom_tools": []}
@@ -819,7 +820,7 @@ def copy_talent_assets(talent_dir: Path, emp_dir) -> None:
             if fn not in existing:
                 existing.append(fn)
         emp_mdata["custom_tools"] = existing
-        with open(emp_manifest, "w", encoding="utf-8") as f:
+        with open_utf(emp_manifest, "w") as f:
             yaml.dump(emp_mdata, f, allow_unicode=True, default_flow_style=False)
 
 

--- a/src/onemancompany/agents/termination.py
+++ b/src/onemancompany/agents/termination.py
@@ -67,14 +67,14 @@ async def execute_fire(employee_id: str, reason: str = "CEO decision") -> dict:
 
         manifest_path = EMPLOYEES_DIR / employee_id / "tools" / MANIFEST_YAML_FILENAME
         if manifest_path.exists():
-            with open(manifest_path) as f:
+            with open(manifest_path, encoding="utf-8") as f:
                 mdata = yaml.safe_load(f) or {}
             for tool_name in mdata.get("custom_tools", []):
                 unregister_tool_user(tool_name, employee_id)
                 # Clean up orphaned personal tools (no remaining users)
                 tool_yaml_path = TOOLS_DIR / tool_name / TOOL_YAML_FILENAME
                 if tool_yaml_path.exists():
-                    with open(tool_yaml_path) as f:
+                    with open(tool_yaml_path, encoding="utf-8") as f:
                         tool_data = yaml.safe_load(f) or {}
                     if (tool_data.get("source_talent") and
                             "allowed_users" in tool_data and

--- a/src/onemancompany/agents/termination.py
+++ b/src/onemancompany/agents/termination.py
@@ -18,6 +18,7 @@ from onemancompany.core.config import (
     TOOL_YAML_FILENAME,
     TOOLS_DIR,
     move_employee_to_ex,
+    open_utf,
 )
 from onemancompany.core.events import CompanyEvent, event_bus
 from onemancompany.core.models import EventType
@@ -67,14 +68,14 @@ async def execute_fire(employee_id: str, reason: str = "CEO decision") -> dict:
 
         manifest_path = EMPLOYEES_DIR / employee_id / "tools" / MANIFEST_YAML_FILENAME
         if manifest_path.exists():
-            with open(manifest_path, encoding="utf-8") as f:
+            with open_utf(manifest_path) as f:
                 mdata = yaml.safe_load(f) or {}
             for tool_name in mdata.get("custom_tools", []):
                 unregister_tool_user(tool_name, employee_id)
                 # Clean up orphaned personal tools (no remaining users)
                 tool_yaml_path = TOOLS_DIR / tool_name / TOOL_YAML_FILENAME
                 if tool_yaml_path.exists():
-                    with open(tool_yaml_path, encoding="utf-8") as f:
+                    with open_utf(tool_yaml_path) as f:
                         tool_data = yaml.safe_load(f) or {}
                     if (tool_data.get("source_talent") and
                             "allowed_users" in tool_data and

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from langchain_core.tools import tool
 from loguru import logger
 
-from onemancompany.core.config import CEO_ID, ENCODING_UTF8, PROJECT_YAML_FILENAME, SYSTEM_AGENT, TASK_TREE_FILENAME
+from onemancompany.core.config import CEO_ID, PROJECT_YAML_FILENAME, SYSTEM_AGENT, TASK_TREE_FILENAME, read_text_utf, write_text_utf
 from onemancompany.core.models import EventType
 from onemancompany.core.task_lifecycle import NodeType, TaskPhase
 from onemancompany.core.task_tree import TaskTree
@@ -86,7 +86,7 @@ def _add_to_project_team(project_dir: str, employee_id: str) -> None:
         return
     project_yaml = root / PROJECT_YAML_FILENAME
     try:
-        data = yaml.safe_load(project_yaml.read_text(encoding=ENCODING_UTF8)) or {}
+        data = yaml.safe_load(read_text_utf(project_yaml)) or {}
         team = data.get("team", [])
         if any(m.get("employee_id") == employee_id for m in team):
             return  # already in team
@@ -97,10 +97,7 @@ def _add_to_project_team(project_dir: str, employee_id: str) -> None:
             "joined_at": datetime.now().isoformat(),
         })
         data["team"] = team
-        project_yaml.write_text(
-            yaml.dump(data, allow_unicode=True, sort_keys=False),
-            encoding=ENCODING_UTF8,
-        )
+        write_text_utf(project_yaml, yaml.dump(data, allow_unicode=True, sort_keys=False))
     except Exception:
         logger.warning("Failed to add {} to project team in {}", employee_id, project_dir)
 
@@ -707,12 +704,9 @@ def set_project_name(name: str) -> dict:
         return {"status": "error", "message": "Project file not found."}
 
     project_yaml = root / PROJECT_YAML_FILENAME
-    data = yaml.safe_load(project_yaml.read_text(encoding=ENCODING_UTF8)) or {}
+    data = yaml.safe_load(read_text_utf(project_yaml)) or {}
     data["name"] = name.strip()
-    project_yaml.write_text(
-        yaml.dump(data, allow_unicode=True, sort_keys=False),
-        encoding=ENCODING_UTF8,
-    )
+    write_text_utf(project_yaml, yaml.dump(data, allow_unicode=True, sort_keys=False))
     return {"status": "ok", "name": name.strip()}
 
 

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -4839,7 +4839,7 @@ async def get_tool_definition(tool_id: str):
     if not tool or not tool.folder_name:
         raise HTTPException(status_code=404, detail="Tool not found")
     tool_yaml_path = TOOLS_DIR / tool.folder_name / "tool.yaml"
-    raw = tool_yaml_path.read_text() if tool_yaml_path.exists() else ""
+    raw = tool_yaml_path.read_text(encoding="utf-8") if tool_yaml_path.exists() else ""
     tool_data = {}
     try:
         tool_data = _yaml.safe_load(raw) or {}
@@ -5027,7 +5027,7 @@ async def tool_oauth_login(tool_id: str):
     if not tool_yaml_path.exists():
         raise HTTPException(status_code=404, detail="Tool config not found")
 
-    tool_data = _yaml.safe_load(tool_yaml_path.read_text()) or {}
+    tool_data = _yaml.safe_load(tool_yaml_path.read_text(encoding="utf-8")) or {}
     oauth_cfg = tool_data.get("oauth")
     if not oauth_cfg:
         raise HTTPException(status_code=400, detail="Tool does not use OAuth")
@@ -5070,7 +5070,7 @@ async def tool_oauth_logout(tool_id: str):
         raise HTTPException(status_code=404, detail="Tool not found")
 
     tool_yaml_path = TOOLS_DIR / tool.folder_name / "tool.yaml"
-    tool_data = _yaml.safe_load(tool_yaml_path.read_text()) or {}
+    tool_data = _yaml.safe_load(tool_yaml_path.read_text(encoding="utf-8")) or {}
     oauth_cfg = tool_data.get("oauth")
     if not oauth_cfg:
         raise HTTPException(status_code=400, detail="Tool does not use OAuth")
@@ -5098,7 +5098,7 @@ async def tool_oauth_set_credentials(tool_id: str, body: dict):
         raise HTTPException(status_code=404, detail="Tool not found")
 
     tool_yaml_path = TOOLS_DIR / tool.folder_name / "tool.yaml"
-    tool_data = _yaml.safe_load(tool_yaml_path.read_text()) or {}
+    tool_data = _yaml.safe_load(tool_yaml_path.read_text(encoding="utf-8")) or {}
     oauth_cfg = tool_data.get("oauth")
     if not oauth_cfg:
         raise HTTPException(status_code=400, detail="Tool does not use OAuth")
@@ -5120,7 +5120,7 @@ async def tool_oauth_set_credentials(tool_id: str, body: dict):
     env_path = DATA_ROOT / DOT_ENV_FILENAME
     lines = []
     if env_path.exists():
-        lines = env_path.read_text().splitlines()
+        lines = env_path.read_text(encoding="utf-8").splitlines()
 
     # Update or append
     updated = set()
@@ -5166,7 +5166,7 @@ async def tool_save_env_vars(tool_id: str, body: dict):
     env_path = DATA_ROOT / DOT_ENV_FILENAME
     lines = []
     if env_path.exists():
-        lines = env_path.read_text().splitlines()
+        lines = env_path.read_text(encoding="utf-8").splitlines()
 
     updated = set()
     for i, line in enumerate(lines):
@@ -5194,7 +5194,7 @@ async def tool_get_template(tool_id: str, filename: str):
         raise HTTPException(status_code=404, detail="Tool not found")
 
     tool_yaml_path = TOOLS_DIR / tool.folder_name / "tool.yaml"
-    tool_data = _yaml.safe_load(tool_yaml_path.read_text()) or {}
+    tool_data = _yaml.safe_load(tool_yaml_path.read_text(encoding="utf-8")) or {}
     templates_cfg = tool_data.get("templates")
     if not templates_cfg:
         raise HTTPException(status_code=400, detail="Tool does not have templates")
@@ -5223,7 +5223,7 @@ async def tool_save_template(tool_id: str, filename: str, body: dict):
         raise HTTPException(status_code=400, detail="Empty content")
 
     tool_yaml_path = TOOLS_DIR / tool.folder_name / "tool.yaml"
-    tool_data = _yaml.safe_load(tool_yaml_path.read_text()) or {}
+    tool_data = _yaml.safe_load(tool_yaml_path.read_text(encoding="utf-8")) or {}
     templates_cfg = tool_data.get("templates")
     if not templates_cfg:
         raise HTTPException(status_code=400, detail="Tool does not have templates")
@@ -5250,7 +5250,7 @@ async def tool_delete_template(tool_id: str, filename: str):
         raise HTTPException(status_code=404, detail="Tool not found")
 
     tool_yaml_path = TOOLS_DIR / tool.folder_name / "tool.yaml"
-    tool_data = _yaml.safe_load(tool_yaml_path.read_text()) or {}
+    tool_data = _yaml.safe_load(tool_yaml_path.read_text(encoding="utf-8")) or {}
     templates_cfg = tool_data.get("templates")
     if not templates_cfg:
         raise HTTPException(status_code=400, detail="Tool does not have templates")
@@ -5459,7 +5459,7 @@ async def submit_credentials(service_name: str, request: Request) -> dict:
     from onemancompany.core.config import COMPANY_ROOT
     env_path = COMPANY_ROOT.parent / DOT_ENV_FILENAME
     if env_path.exists():
-        existing = env_path.read_text()
+        existing = env_path.read_text(encoding="utf-8")
     else:
         existing = ""
 
@@ -5499,7 +5499,7 @@ async def save_employee_secrets(employee_id: str, request: Request) -> dict:
 
     from onemancompany.core.config import COMPANY_ROOT
     env_path = COMPANY_ROOT.parent / DOT_ENV_FILENAME
-    existing = env_path.read_text() if env_path.exists() else ""
+    existing = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
 
     updated_keys = {}
     for key, value in body.items():

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -44,6 +44,8 @@ from onemancompany.core.config import (
     TL_FIELD_ACTION,
     TL_FIELD_DETAIL,
     TL_FIELD_EMPLOYEE_ID,
+    read_text_utf,
+    write_text_utf,
 )
 from onemancompany.core.events import CompanyEvent, event_bus
 from onemancompany.core.models import AuthMethod, DecisionStatus, EventType, HostingMode
@@ -191,7 +193,7 @@ def _scan_employee_projects(employee_id: str, projects_dir: str = "") -> list[di
         if not pyaml.exists():
             continue
         try:
-            data = yaml.safe_load(pyaml.read_text(encoding=ENCODING_UTF8)) or {}
+            data = yaml.safe_load(read_text_utf(pyaml)) or {}
         except Exception:
             logger.warning("Failed to parse {}", pyaml)
             continue
@@ -1473,14 +1475,14 @@ async def get_employee_logs(employee_id: str, tail: int = 100) -> dict:
 @router.get("/api/employee/{employee_id}/progress-log")
 async def get_employee_progress_log(employee_id: str, limit: int = 50) -> dict:
     """Get cross-task work history summaries from progress.log."""
-    from onemancompany.core.config import EMPLOYEES_DIR, ENCODING_UTF8
+    from onemancompany.core.config import EMPLOYEES_DIR
 
     limit = max(1, min(limit, 200))
     path = EMPLOYEES_DIR / employee_id / "progress.log"
     if not path.exists():
         return {"entries": []}
     try:
-        lines = path.read_text(encoding=ENCODING_UTF8).strip().split("\n")
+        lines = read_text_utf(path).strip().split("\n")
         entries = []
         for line in lines[-limit:]:
             if line.startswith("[") and "]" in line:
@@ -1501,7 +1503,7 @@ def _read_node_log(project_dir: str, node_id: str, limit: int) -> list[dict]:
     if not log_path.exists():
         return []
     try:
-        lines = log_path.read_text(encoding="utf-8").strip().split("\n")
+        lines = read_text_utf(log_path).strip().split("\n")
         logs = []
         for line in lines[-limit:]:
             try:
@@ -1830,7 +1832,7 @@ async def update_employee_hosting(employee_id: str, body: dict) -> dict:
     from onemancompany.core.config import EMPLOYEES_DIR, invalidate_manifest_cache
     manifest_path = EMPLOYEES_DIR / employee_id / MANIFEST_FILENAME
     if manifest_path.exists():
-        manifest = _json.loads(manifest_path.read_text(encoding=ENCODING_UTF8))
+        manifest = _json.loads(read_text_utf(manifest_path))
         manifest["hosting"] = new_hosting
         sections = manifest.get("settings", {}).get("sections", [])
 
@@ -1860,7 +1862,7 @@ async def update_employee_hosting(employee_id: str, body: dict) -> dict:
                     ],
                 })
 
-        manifest_path.write_text(_json.dumps(manifest, indent=2, ensure_ascii=False), encoding=ENCODING_UTF8)
+        write_text_utf(manifest_path, _json.dumps(manifest, indent=2, ensure_ascii=False))
         invalidate_manifest_cache(employee_id)
 
     hosting_labels = {"company": "LangChain", "self": "Claude Code", "openclaw": "OpenClaw"}
@@ -1998,7 +2000,7 @@ async def update_api_settings(body: dict) -> dict:
         config = load_app_config()
         tm = config.setdefault("talent_market", {})
         tm["api_key"] = api_key
-        APP_CONFIG_PATH.write_text(yaml.dump(config, default_flow_style=False, allow_unicode=True), encoding=ENCODING_UTF8)
+        write_text_utf(APP_CONFIG_PATH, yaml.dump(config, default_flow_style=False, allow_unicode=True))
         reload_app_config()
 
         # Reconnect Talent Market with new API key
@@ -3239,7 +3241,7 @@ async def get_node_execution_logs(node_id: str):
         return []
 
     logs = []
-    for line in log_path.read_text(encoding="utf-8").strip().split("\n"):
+    for line in read_text_utf(log_path).strip().split("\n"):
         if line:
             try:
                 logs.append(_json.loads(line))
@@ -3333,7 +3335,7 @@ async def get_employee_project_retrospective(employee_id: str, project_id: str) 
     timeline_entries: list[dict] = []
     for yaml_file in pdir.glob("*.yaml"):
         try:
-            data = yaml.safe_load(yaml_file.read_text(encoding=ENCODING_UTF8)) or {}
+            data = yaml.safe_load(read_text_utf(yaml_file)) or {}
         except Exception as exc:
             logger.debug("Failed to parse {}: {}", yaml_file, exc)
             continue
@@ -4839,7 +4841,7 @@ async def get_tool_definition(tool_id: str):
     if not tool or not tool.folder_name:
         raise HTTPException(status_code=404, detail="Tool not found")
     tool_yaml_path = TOOLS_DIR / tool.folder_name / "tool.yaml"
-    raw = tool_yaml_path.read_text(encoding="utf-8") if tool_yaml_path.exists() else ""
+    raw = read_text_utf(tool_yaml_path) if tool_yaml_path.exists() else ""
     tool_data = {}
     try:
         tool_data = _yaml.safe_load(raw) or {}
@@ -4965,7 +4967,7 @@ async def get_tool_definition(tool_id: str):
             for tf in sorted(templates_dir.iterdir()):
                 if tf.is_file() and not tf.name.startswith("."):
                     # Parse frontmatter for name/description
-                    content = tf.read_text(encoding=ENCODING_UTF8)
+                    content = read_text_utf(tf)
                     tmpl_meta = {"filename": tf.name, "name": tf.stem, "description": ""}
                     if content.startswith("---"):
                         parts = content.split("---", 2)
@@ -5027,7 +5029,7 @@ async def tool_oauth_login(tool_id: str):
     if not tool_yaml_path.exists():
         raise HTTPException(status_code=404, detail="Tool config not found")
 
-    tool_data = _yaml.safe_load(tool_yaml_path.read_text(encoding="utf-8")) or {}
+    tool_data = _yaml.safe_load(read_text_utf(tool_yaml_path)) or {}
     oauth_cfg = tool_data.get("oauth")
     if not oauth_cfg:
         raise HTTPException(status_code=400, detail="Tool does not use OAuth")
@@ -5070,7 +5072,7 @@ async def tool_oauth_logout(tool_id: str):
         raise HTTPException(status_code=404, detail="Tool not found")
 
     tool_yaml_path = TOOLS_DIR / tool.folder_name / "tool.yaml"
-    tool_data = _yaml.safe_load(tool_yaml_path.read_text(encoding="utf-8")) or {}
+    tool_data = _yaml.safe_load(read_text_utf(tool_yaml_path)) or {}
     oauth_cfg = tool_data.get("oauth")
     if not oauth_cfg:
         raise HTTPException(status_code=400, detail="Tool does not use OAuth")
@@ -5098,7 +5100,7 @@ async def tool_oauth_set_credentials(tool_id: str, body: dict):
         raise HTTPException(status_code=404, detail="Tool not found")
 
     tool_yaml_path = TOOLS_DIR / tool.folder_name / "tool.yaml"
-    tool_data = _yaml.safe_load(tool_yaml_path.read_text(encoding="utf-8")) or {}
+    tool_data = _yaml.safe_load(read_text_utf(tool_yaml_path)) or {}
     oauth_cfg = tool_data.get("oauth")
     if not oauth_cfg:
         raise HTTPException(status_code=400, detail="Tool does not use OAuth")
@@ -5120,7 +5122,7 @@ async def tool_oauth_set_credentials(tool_id: str, body: dict):
     env_path = DATA_ROOT / DOT_ENV_FILENAME
     lines = []
     if env_path.exists():
-        lines = env_path.read_text(encoding="utf-8").splitlines()
+        lines = read_text_utf(env_path).splitlines()
 
     # Update or append
     updated = set()
@@ -5135,7 +5137,7 @@ async def tool_oauth_set_credentials(tool_id: str, body: dict):
         lines.append(f"{client_id_env}={client_id}")
     if client_secret_env not in updated:
         lines.append(f"{client_secret_env}={client_secret}")
-    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    write_text_utf(env_path, "\n".join(lines) + "\n")
 
     return {"status": "ok", "message": "Credentials saved"}
 
@@ -5166,7 +5168,7 @@ async def tool_save_env_vars(tool_id: str, body: dict):
     env_path = DATA_ROOT / DOT_ENV_FILENAME
     lines = []
     if env_path.exists():
-        lines = env_path.read_text(encoding="utf-8").splitlines()
+        lines = read_text_utf(env_path).splitlines()
 
     updated = set()
     for i, line in enumerate(lines):
@@ -5177,7 +5179,7 @@ async def tool_save_env_vars(tool_id: str, body: dict):
     for name, value in to_save.items():
         if name not in updated:
             lines.append(f"{name}={value}")
-    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    write_text_utf(env_path, "\n".join(lines) + "\n")
 
     return {"status": "ok", "message": f"{len(to_save)} variable(s) saved"}
 
@@ -5194,7 +5196,7 @@ async def tool_get_template(tool_id: str, filename: str):
         raise HTTPException(status_code=404, detail="Tool not found")
 
     tool_yaml_path = TOOLS_DIR / tool.folder_name / "tool.yaml"
-    tool_data = _yaml.safe_load(tool_yaml_path.read_text(encoding="utf-8")) or {}
+    tool_data = _yaml.safe_load(read_text_utf(tool_yaml_path)) or {}
     templates_cfg = tool_data.get("templates")
     if not templates_cfg:
         raise HTTPException(status_code=400, detail="Tool does not have templates")
@@ -5204,7 +5206,7 @@ async def tool_get_template(tool_id: str, filename: str):
     if not file_path.is_file() or not file_path.resolve().is_relative_to(templates_dir.resolve()):
         raise HTTPException(status_code=404, detail="Template not found")
 
-    return {"filename": filename, "content": file_path.read_text(encoding=ENCODING_UTF8)}
+    return {"filename": filename, "content": read_text_utf(file_path)}
 
 
 @router.put("/api/tools/{tool_id}/templates/{filename}")
@@ -5223,7 +5225,7 @@ async def tool_save_template(tool_id: str, filename: str, body: dict):
         raise HTTPException(status_code=400, detail="Empty content")
 
     tool_yaml_path = TOOLS_DIR / tool.folder_name / "tool.yaml"
-    tool_data = _yaml.safe_load(tool_yaml_path.read_text(encoding="utf-8")) or {}
+    tool_data = _yaml.safe_load(read_text_utf(tool_yaml_path)) or {}
     templates_cfg = tool_data.get("templates")
     if not templates_cfg:
         raise HTTPException(status_code=400, detail="Tool does not have templates")
@@ -5234,7 +5236,7 @@ async def tool_save_template(tool_id: str, filename: str, body: dict):
     if not file_path.resolve().is_relative_to(templates_dir.resolve()):
         raise HTTPException(status_code=400, detail="Invalid filename")
 
-    file_path.write_text(content, encoding=ENCODING_UTF8)
+    write_text_utf(file_path, content)
     return {"status": "ok", "filename": filename}
 
 
@@ -5250,7 +5252,7 @@ async def tool_delete_template(tool_id: str, filename: str):
         raise HTTPException(status_code=404, detail="Tool not found")
 
     tool_yaml_path = TOOLS_DIR / tool.folder_name / "tool.yaml"
-    tool_data = _yaml.safe_load(tool_yaml_path.read_text(encoding="utf-8")) or {}
+    tool_data = _yaml.safe_load(read_text_utf(tool_yaml_path)) or {}
     templates_cfg = tool_data.get("templates")
     if not templates_cfg:
         raise HTTPException(status_code=400, detail="Tool does not have templates")
@@ -5459,7 +5461,7 @@ async def submit_credentials(service_name: str, request: Request) -> dict:
     from onemancompany.core.config import COMPANY_ROOT
     env_path = COMPANY_ROOT.parent / DOT_ENV_FILENAME
     if env_path.exists():
-        existing = env_path.read_text(encoding="utf-8")
+        existing = read_text_utf(env_path)
     else:
         existing = ""
 
@@ -5480,7 +5482,7 @@ async def submit_credentials(service_name: str, request: Request) -> dict:
         result_lines.append(line)
 
     result_lines.extend(new_lines)
-    env_path.write_text("\n".join(result_lines) + "\n", encoding="utf-8")
+    write_text_utf(env_path, "\n".join(result_lines) + "\n")
 
     await event_bus.publish(CompanyEvent(
         type=EventType.CREDENTIALS_SUBMITTED,
@@ -5499,7 +5501,7 @@ async def save_employee_secrets(employee_id: str, request: Request) -> dict:
 
     from onemancompany.core.config import COMPANY_ROOT
     env_path = COMPANY_ROOT.parent / DOT_ENV_FILENAME
-    existing = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
+    existing = read_text_utf(env_path) if env_path.exists() else ""
 
     updated_keys = {}
     for key, value in body.items():
@@ -5517,7 +5519,7 @@ async def save_employee_secrets(employee_id: str, request: Request) -> dict:
         result_lines.append(line)
     for k, v in updated_keys.items():
         result_lines.append(f"{k}={v}")
-    env_path.write_text("\n".join(result_lines) + "\n", encoding="utf-8")
+    write_text_utf(env_path, "\n".join(result_lines) + "\n")
 
     return {"status": "ok", "fields_saved": list(body.keys())}
 
@@ -6715,13 +6717,13 @@ async def clear_conversation_history(conv_id: str) -> dict:
         scanned += 1
         msg_path = conv_dir / "messages.yaml"
         if msg_path.exists():
-            msg_path.write_text("[]\n", encoding="utf-8")
+            write_text_utf(msg_path, "[]\n")
             cleared += 1
 
     # Keep legacy 1-on-1 history endpoint consistent.
     legacy_history_path = conversation_core.EMPLOYEES_DIR / conv.employee_id / "oneonone_history.yaml"
     if legacy_history_path.exists():
-        legacy_history_path.write_text("[]\n", encoding="utf-8")
+        write_text_utf(legacy_history_path, "[]\n")
 
     return {
         "status": "cleared",

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -5135,7 +5135,7 @@ async def tool_oauth_set_credentials(tool_id: str, body: dict):
         lines.append(f"{client_id_env}={client_id}")
     if client_secret_env not in updated:
         lines.append(f"{client_secret_env}={client_secret}")
-    env_path.write_text("\n".join(lines) + "\n")
+    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
     return {"status": "ok", "message": "Credentials saved"}
 
@@ -5177,7 +5177,7 @@ async def tool_save_env_vars(tool_id: str, body: dict):
     for name, value in to_save.items():
         if name not in updated:
             lines.append(f"{name}={value}")
-    env_path.write_text("\n".join(lines) + "\n")
+    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
     return {"status": "ok", "message": f"{len(to_save)} variable(s) saved"}
 
@@ -5480,7 +5480,7 @@ async def submit_credentials(service_name: str, request: Request) -> dict:
         result_lines.append(line)
 
     result_lines.extend(new_lines)
-    env_path.write_text("\n".join(result_lines) + "\n")
+    env_path.write_text("\n".join(result_lines) + "\n", encoding="utf-8")
 
     await event_bus.publish(CompanyEvent(
         type=EventType.CREDENTIALS_SUBMITTED,
@@ -5517,7 +5517,7 @@ async def save_employee_secrets(employee_id: str, request: Request) -> dict:
         result_lines.append(line)
     for k, v in updated_keys.items():
         result_lines.append(f"{k}={v}")
-    env_path.write_text("\n".join(result_lines) + "\n")
+    env_path.write_text("\n".join(result_lines) + "\n", encoding="utf-8")
 
     return {"status": "ok", "fields_saved": list(body.keys())}
 

--- a/src/onemancompany/core/automation.py
+++ b/src/onemancompany/core/automation.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import yaml
 from loguru import logger
 
-from onemancompany.core.config import EMPLOYEES_DIR, ENCODING_UTF8
+from onemancompany.core.config import EMPLOYEES_DIR, read_text_utf, write_text_utf
 from onemancompany.core.interval import parse_interval as _parse_interval
 
 # Single-file constants
@@ -41,7 +41,7 @@ def _load_automations(employee_id: str) -> dict:
     if not path.exists():
         return {_KEY_CRONS: [], _KEY_WEBHOOKS: []}
     try:
-        data = yaml.safe_load(path.read_text(encoding=ENCODING_UTF8)) or {}
+        data = yaml.safe_load(read_text_utf(path)) or {}
         data.setdefault(_KEY_CRONS, [])
         data.setdefault(_KEY_WEBHOOKS, [])
         return data
@@ -52,7 +52,7 @@ def _load_automations(employee_id: str) -> dict:
 def _save_automations(employee_id: str, data: dict) -> None:
     path = _automations_file(employee_id)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(yaml.dump(data, allow_unicode=True, default_flow_style=False), encoding=ENCODING_UTF8)
+    write_text_utf(path, yaml.dump(data, allow_unicode=True, default_flow_style=False))
 
 
 # ---------------------------------------------------------------------------

--- a/src/onemancompany/core/background_tasks.py
+++ b/src/onemancompany/core/background_tasks.py
@@ -17,6 +17,8 @@ from pathlib import Path
 import yaml
 from loguru import logger
 
+from onemancompany.core.config import open_utf
+
 MAX_CONCURRENT = 5
 _MAX_RETAINED = 50
 _TASKS_FILENAME = "background_tasks.yaml"
@@ -145,7 +147,7 @@ class BackgroundTaskManager:
         if not path.exists():
             return
         try:
-            with open(path, encoding="utf-8") as f:
+            with open_utf(path) as f:
                 data = yaml.safe_load(f) or {}
         except Exception as e:
             logger.warning("Failed to load background tasks: {}", e)
@@ -184,7 +186,7 @@ class BackgroundTaskManager:
         if not log_path.exists():
             return ""
         try:
-            with open(log_path, encoding="utf-8") as f:
+            with open_utf(log_path) as f:
                 tail = deque(f, maxlen=lines)
             return "".join(tail)  # lines already have \n
         except Exception as e:
@@ -231,7 +233,7 @@ class BackgroundTaskManager:
         # Prepare output log directory
         log_path = self.output_log_path(task_id)
         log_path.parent.mkdir(parents=True, exist_ok=True)
-        log_fd = open(log_path, "w", encoding="utf-8")
+        log_fd = open_utf(log_path, "w")
         try:
             proc = await asyncio.create_subprocess_shell(
                 command,

--- a/src/onemancompany/core/background_tasks.py
+++ b/src/onemancompany/core/background_tasks.py
@@ -145,7 +145,7 @@ class BackgroundTaskManager:
         if not path.exists():
             return
         try:
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 data = yaml.safe_load(f) or {}
         except Exception as e:
             logger.warning("Failed to load background tasks: {}", e)
@@ -184,7 +184,7 @@ class BackgroundTaskManager:
         if not log_path.exists():
             return ""
         try:
-            with open(log_path) as f:
+            with open(log_path, encoding="utf-8") as f:
                 tail = deque(f, maxlen=lines)
             return "".join(tail)  # lines already have \n
         except Exception as e:
@@ -231,7 +231,7 @@ class BackgroundTaskManager:
         # Prepare output log directory
         log_path = self.output_log_path(task_id)
         log_path.parent.mkdir(parents=True, exist_ok=True)
-        log_fd = open(log_path, "w")
+        log_fd = open(log_path, "w", encoding="utf-8")
         try:
             proc = await asyncio.create_subprocess_shell(
                 command,
@@ -304,7 +304,7 @@ class BackgroundTaskManager:
             if not log_path.exists():
                 continue
             try:
-                text = log_path.read_text()
+                text = log_path.read_text(encoding="utf-8")
                 match = port_re.search(text)
                 if match:
                     task.port = int(match.group(1))

--- a/src/onemancompany/core/background_tasks.py
+++ b/src/onemancompany/core/background_tasks.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import yaml
 from loguru import logger
 
-from onemancompany.core.config import open_utf
+from onemancompany.core.config import open_utf, read_text_utf
 
 MAX_CONCURRENT = 5
 _MAX_RETAINED = 50
@@ -306,7 +306,7 @@ class BackgroundTaskManager:
             if not log_path.exists():
                 continue
             try:
-                text = log_path.read_text(encoding="utf-8")
+                text = read_text_utf(log_path)
                 match = port_re.search(text)
                 if match:
                     task.port = int(match.group(1))

--- a/src/onemancompany/core/ceo_conversation.py
+++ b/src/onemancompany/core/ceo_conversation.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from loguru import logger
 
-from onemancompany.core.config import AGENT_DIR_NAME, CONVERSATIONS_DIR_NAME, ENCODING_UTF8
+from onemancompany.core.config import AGENT_DIR_NAME, CONVERSATIONS_DIR_NAME, read_text_utf
 
 CEO_SENDER = "ceo"
 EA_SENDER = "ea"
@@ -114,7 +114,7 @@ async def _build_agent_and_invoke(
     persona_path = EMPLOYEES_DIR / employee_id / AGENT_DIR_NAME / "system_prompt.md"
     if persona_path.exists():
         try:
-            builder.add("persona", persona_path.read_text(encoding=ENCODING_UTF8), priority=15)
+            builder.add("persona", read_text_utf(persona_path), priority=15)
         except Exception as exc:
             logger.debug("Failed to load persona for {}: {}", employee_id, exc)
 

--- a/src/onemancompany/core/claude_session.py
+++ b/src/onemancompany/core/claude_session.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 from loguru import logger
 
-from onemancompany.core.config import BLOCK_KEY_TEXT, BLOCK_KEY_TYPE, BLOCK_TYPE_TEXT, EMPLOYEES_DIR, ENCODING_UTF8, PROJECTS_DIR
+from onemancompany.core.config import BLOCK_KEY_TEXT, BLOCK_KEY_TYPE, BLOCK_TYPE_TEXT, EMPLOYEES_DIR, ENCODING_UTF8, PROJECTS_DIR, read_text_utf, write_text_utf
 
 LLM_TRACES_FILENAME = "llm_traces.jsonl"
 
@@ -95,7 +95,7 @@ def _load_sessions(employee_id: str) -> dict:
     if not path.exists():
         return {}
     try:
-        return json.loads(path.read_text(encoding=ENCODING_UTF8))
+        return json.loads(read_text_utf(path))
     except (json.JSONDecodeError, OSError):
         return {}
 
@@ -103,7 +103,7 @@ def _load_sessions(employee_id: str) -> dict:
 def _save_sessions(employee_id: str, data: dict) -> None:
     path = _sessions_file(employee_id)
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding=ENCODING_UTF8)
+    write_text_utf(path, json.dumps(data, indent=2, ensure_ascii=False))
 
 
 def get_or_create_session(

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -553,7 +553,7 @@ def _read_app_config_from_disk() -> dict:
     """Read config.yaml from disk. Returns empty dict if missing."""
     if not APP_CONFIG_PATH.exists():
         return {}
-    with open(APP_CONFIG_PATH) as f:
+    with open(APP_CONFIG_PATH, encoding="utf-8") as f:
         return yaml.safe_load(f) or {}
 
 
@@ -589,7 +589,7 @@ def load_employee_configs() -> dict[str, EmployeeConfig]:
         profile_path = emp_dir / PROFILE_FILENAME
         if not profile_path.exists():
             continue
-        with open(profile_path) as f:
+        with open(profile_path, encoding="utf-8") as f:
             raw = yaml.safe_load(f) or {}
         emp_id = emp_dir.name
         try:
@@ -624,7 +624,7 @@ def load_employee_profile_yaml(employee_id: str) -> dict:
     profile_path = EMPLOYEES_DIR / employee_id / PROFILE_FILENAME
     if not profile_path.exists():
         return {}
-    with open(profile_path) as f:
+    with open(profile_path, encoding="utf-8") as f:
         return yaml.safe_load(f) or {}
 
 
@@ -632,7 +632,7 @@ def save_employee_profile_yaml(employee_id: str, data: dict) -> None:
     """Write a full profile dict to employees/{id}/profile.yaml."""
     profile_path = EMPLOYEES_DIR / employee_id / PROFILE_FILENAME
     profile_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(profile_path, "w") as f:
+    with open(profile_path, "w", encoding="utf-8") as f:
         yaml.dump(data, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -683,7 +683,7 @@ def load_assets() -> tuple[dict, dict]:
                 # New folder-based format
                 tool_yaml = entry / "tool.yaml"
                 if tool_yaml.exists():
-                    with open(tool_yaml) as fh:
+                    with open(tool_yaml, encoding="utf-8") as fh:
                         data = yaml.safe_load(fh) or {}
                     data["_folder_name"] = entry.name
                     # List extra files in the folder (excluding tool.yaml)
@@ -695,7 +695,7 @@ def load_assets() -> tuple[dict, dict]:
                     tools[tool_id] = data
             elif entry.suffix == ".yaml" and entry.is_file():
                 # Legacy flat YAML format
-                with open(entry) as fh:
+                with open(entry, encoding="utf-8") as fh:
                     data = yaml.safe_load(fh) or {}
                 data["_legacy"] = True
                 tools[entry.stem] = data
@@ -705,7 +705,7 @@ def load_assets() -> tuple[dict, dict]:
                 # Skip chat history files (e.g., *_chat.yaml)
                 if f.stem.endswith("_chat"):
                     continue
-                with open(f) as fh:
+                with open(f, encoding="utf-8") as fh:
                     data = yaml.safe_load(fh) or {}
                 if not isinstance(data, dict):
                     logger.warning("Skipping malformed room file {}: expected dict, got {}", f.name, type(data).__name__)
@@ -754,7 +754,7 @@ def load_ex_employee_configs() -> dict[str, EmployeeConfig]:
             continue
         emp_id = emp_dir.name
         try:
-            with open(profile_path) as f:
+            with open(profile_path, encoding="utf-8") as f:
                 raw = yaml.safe_load(f) or {}
             result[emp_id] = EmployeeConfig(**raw)
         except Exception as e:
@@ -796,7 +796,7 @@ def load_company_culture() -> list[dict]:
     """Load company culture items from company_culture.yaml."""
     if not COMPANY_CULTURE_FILE.exists():
         return []
-    with open(COMPANY_CULTURE_FILE) as f:
+    with open(COMPANY_CULTURE_FILE, encoding="utf-8") as f:
         data = yaml.safe_load(f)
     if isinstance(data, list):
         return data
@@ -811,7 +811,7 @@ def load_company_direction() -> str:
     """Load company direction from company_direction.yaml."""
     if not COMPANY_DIRECTION_FILE.exists():
         return ""
-    with open(COMPANY_DIRECTION_FILE) as f:
+    with open(COMPANY_DIRECTION_FILE, encoding="utf-8") as f:
         data = yaml.safe_load(f)
     if isinstance(data, dict):
         return data.get("direction", "")
@@ -826,7 +826,7 @@ def save_company_direction(direction: str) -> None:
         "updated_at": datetime.now().isoformat(),
         "updated_by": "CEO",
     }
-    with open(COMPANY_DIRECTION_FILE, "w") as f:
+    with open(COMPANY_DIRECTION_FILE, "w", encoding="utf-8") as f:
         yaml.dump(data, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -890,7 +890,7 @@ def load_talent_profile(talent_id: str) -> dict:
     for base in (TALENTS_RUNTIME_DIR, TALENTS_DIR):
         profile_path = base / talent_id / PROFILE_FILENAME
         if profile_path.exists():
-            with open(profile_path) as f:
+            with open(profile_path, encoding="utf-8") as f:
                 return yaml.safe_load(f) or {}
     return {}
 
@@ -905,7 +905,7 @@ def load_talent_tools(talent_id: str) -> list[str]:
     manifest_path = TALENTS_DIR / talent_id / "tools" / "manifest.yaml"
     if not manifest_path.exists():
         return []
-    with open(manifest_path) as f:
+    with open(manifest_path, encoding="utf-8") as f:
         data = yaml.safe_load(f) or {}
     tools: list[str] = list(data.get("builtin_tools", []))
     tools.extend(data.get("custom_tools", []))
@@ -941,7 +941,7 @@ def list_available_talents() -> list[dict]:
         profile_path = talent_dir / PROFILE_FILENAME
         if not profile_path.exists():
             continue
-        with open(profile_path) as f:
+        with open(profile_path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         result.append({
             "id": data.get("id", talent_dir.name),

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -162,6 +162,25 @@ CONFIG_YAML_FILENAME = "config.yaml"
 ENCODING_UTF8 = "utf-8"
 
 
+def open_utf(path, mode="r", **kwargs):
+    """Open a file with UTF-8 encoding. Drop-in replacement for open().
+
+    Windows defaults to GBK/CP936. This wrapper ensures all text I/O
+    uses UTF-8 regardless of platform locale.
+    """
+    return open(path, mode, encoding=ENCODING_UTF8, **kwargs)
+
+
+def read_text_utf(path) -> str:
+    """Read a file as UTF-8 text. Drop-in replacement for Path.read_text()."""
+    return Path(path).read_text(encoding=ENCODING_UTF8)
+
+
+def write_text_utf(path, content: str) -> None:
+    """Write text to a file as UTF-8. Drop-in replacement for Path.write_text()."""
+    Path(path).write_text(content, encoding=ENCODING_UTF8)
+
+
 class LogLevel(str, Enum):
     DEBUG = "DEBUG"
     INFO = "INFO"
@@ -553,7 +572,7 @@ def _read_app_config_from_disk() -> dict:
     """Read config.yaml from disk. Returns empty dict if missing."""
     if not APP_CONFIG_PATH.exists():
         return {}
-    with open(APP_CONFIG_PATH, encoding="utf-8") as f:
+    with open_utf(APP_CONFIG_PATH) as f:
         return yaml.safe_load(f) or {}
 
 
@@ -589,7 +608,7 @@ def load_employee_configs() -> dict[str, EmployeeConfig]:
         profile_path = emp_dir / PROFILE_FILENAME
         if not profile_path.exists():
             continue
-        with open(profile_path, encoding="utf-8") as f:
+        with open_utf(profile_path) as f:
             raw = yaml.safe_load(f) or {}
         emp_id = emp_dir.name
         try:
@@ -624,7 +643,7 @@ def load_employee_profile_yaml(employee_id: str) -> dict:
     profile_path = EMPLOYEES_DIR / employee_id / PROFILE_FILENAME
     if not profile_path.exists():
         return {}
-    with open(profile_path, encoding="utf-8") as f:
+    with open_utf(profile_path) as f:
         return yaml.safe_load(f) or {}
 
 
@@ -632,7 +651,7 @@ def save_employee_profile_yaml(employee_id: str, data: dict) -> None:
     """Write a full profile dict to employees/{id}/profile.yaml."""
     profile_path = EMPLOYEES_DIR / employee_id / PROFILE_FILENAME
     profile_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(profile_path, "w", encoding="utf-8") as f:
+    with open_utf(profile_path, "w") as f:
         yaml.dump(data, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -683,7 +702,7 @@ def load_assets() -> tuple[dict, dict]:
                 # New folder-based format
                 tool_yaml = entry / "tool.yaml"
                 if tool_yaml.exists():
-                    with open(tool_yaml, encoding="utf-8") as fh:
+                    with open_utf(tool_yaml) as fh:
                         data = yaml.safe_load(fh) or {}
                     data["_folder_name"] = entry.name
                     # List extra files in the folder (excluding tool.yaml)
@@ -695,7 +714,7 @@ def load_assets() -> tuple[dict, dict]:
                     tools[tool_id] = data
             elif entry.suffix == ".yaml" and entry.is_file():
                 # Legacy flat YAML format
-                with open(entry, encoding="utf-8") as fh:
+                with open_utf(entry) as fh:
                     data = yaml.safe_load(fh) or {}
                 data["_legacy"] = True
                 tools[entry.stem] = data
@@ -705,7 +724,7 @@ def load_assets() -> tuple[dict, dict]:
                 # Skip chat history files (e.g., *_chat.yaml)
                 if f.stem.endswith("_chat"):
                     continue
-                with open(f, encoding="utf-8") as fh:
+                with open_utf(f) as fh:
                     data = yaml.safe_load(fh) or {}
                 if not isinstance(data, dict):
                     logger.warning("Skipping malformed room file {}: expected dict, got {}", f.name, type(data).__name__)
@@ -754,7 +773,7 @@ def load_ex_employee_configs() -> dict[str, EmployeeConfig]:
             continue
         emp_id = emp_dir.name
         try:
-            with open(profile_path, encoding="utf-8") as f:
+            with open_utf(profile_path) as f:
                 raw = yaml.safe_load(f) or {}
             result[emp_id] = EmployeeConfig(**raw)
         except Exception as e:
@@ -796,7 +815,7 @@ def load_company_culture() -> list[dict]:
     """Load company culture items from company_culture.yaml."""
     if not COMPANY_CULTURE_FILE.exists():
         return []
-    with open(COMPANY_CULTURE_FILE, encoding="utf-8") as f:
+    with open_utf(COMPANY_CULTURE_FILE) as f:
         data = yaml.safe_load(f)
     if isinstance(data, list):
         return data
@@ -811,7 +830,7 @@ def load_company_direction() -> str:
     """Load company direction from company_direction.yaml."""
     if not COMPANY_DIRECTION_FILE.exists():
         return ""
-    with open(COMPANY_DIRECTION_FILE, encoding="utf-8") as f:
+    with open_utf(COMPANY_DIRECTION_FILE) as f:
         data = yaml.safe_load(f)
     if isinstance(data, dict):
         return data.get("direction", "")
@@ -826,7 +845,7 @@ def save_company_direction(direction: str) -> None:
         "updated_at": datetime.now().isoformat(),
         "updated_by": "CEO",
     }
-    with open(COMPANY_DIRECTION_FILE, "w", encoding="utf-8") as f:
+    with open_utf(COMPANY_DIRECTION_FILE, "w") as f:
         yaml.dump(data, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -890,7 +909,7 @@ def load_talent_profile(talent_id: str) -> dict:
     for base in (TALENTS_RUNTIME_DIR, TALENTS_DIR):
         profile_path = base / talent_id / PROFILE_FILENAME
         if profile_path.exists():
-            with open(profile_path, encoding="utf-8") as f:
+            with open_utf(profile_path) as f:
                 return yaml.safe_load(f) or {}
     return {}
 
@@ -905,7 +924,7 @@ def load_talent_tools(talent_id: str) -> list[str]:
     manifest_path = TALENTS_DIR / talent_id / "tools" / "manifest.yaml"
     if not manifest_path.exists():
         return []
-    with open(manifest_path, encoding="utf-8") as f:
+    with open_utf(manifest_path) as f:
         data = yaml.safe_load(f) or {}
     tools: list[str] = list(data.get("builtin_tools", []))
     tools.extend(data.get("custom_tools", []))
@@ -941,7 +960,7 @@ def list_available_talents() -> list[dict]:
         profile_path = talent_dir / PROFILE_FILENAME
         if not profile_path.exists():
             continue
-        with open(profile_path, encoding="utf-8") as f:
+        with open_utf(profile_path) as f:
             data = yaml.safe_load(f) or {}
         result.append({
             "id": data.get("id", talent_dir.name),

--- a/src/onemancompany/core/conversation.py
+++ b/src/onemancompany/core/conversation.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import yaml
 from loguru import logger
 
-from onemancompany.core.config import CONVERSATIONS_DIR_NAME, PROJECTS_DIR, EMPLOYEES_DIR
+from onemancompany.core.config import CONVERSATIONS_DIR_NAME, PROJECTS_DIR, EMPLOYEES_DIR, open_utf
 from onemancompany.core.events import event_bus, CompanyEvent
 from onemancompany.core.models import ConversationType, ConversationPhase, EventType
 
@@ -102,14 +102,14 @@ def save_conversation_meta(conv: Conversation) -> None:
     conv_dir.mkdir(parents=True, exist_ok=True)
     meta_path = conv_dir / CONVERSATION_META_FILENAME
     logger.debug("[conversation] save meta: id={}, phase={}", conv.id, conv.phase)
-    with open(meta_path, "w", encoding="utf-8") as f:
+    with open_utf(meta_path, "w") as f:
         yaml.dump(conv.to_dict(), f, allow_unicode=True)
 
 
 def load_conversation_meta(conv_id: str, conv_dir: Path) -> Conversation:
     """Load conversation metadata from disk."""
     meta_path = conv_dir / CONVERSATION_META_FILENAME
-    with open(meta_path, encoding="utf-8") as f:
+    with open_utf(meta_path) as f:
         data = yaml.safe_load(f)
     return Conversation.from_dict(data)
 
@@ -121,10 +121,10 @@ async def append_message(conv_dir: Path, msg: Message) -> None:
     async with _get_lock(str(msg_path)):
         existing: list[dict] = []
         if msg_path.exists():
-            with open(msg_path, encoding="utf-8") as f:
+            with open_utf(msg_path) as f:
                 existing = yaml.safe_load(f) or []
         existing.append(msg.to_dict())
-        with open(msg_path, "w", encoding="utf-8") as f:
+        with open_utf(msg_path, "w") as f:
             yaml.dump(existing, f, allow_unicode=True)
     logger.debug("[conversation] appended message from {} in {}", msg.sender, conv_dir.name)
 
@@ -134,7 +134,7 @@ def load_messages(conv_dir: Path) -> list[Message]:
     msg_path = conv_dir / CONVERSATION_MESSAGES_FILENAME
     if not msg_path.exists():
         return []
-    with open(msg_path, encoding="utf-8") as f:
+    with open_utf(msg_path) as f:
         data = yaml.safe_load(f) or []
     return [Message.from_dict(m) for m in data]
 

--- a/src/onemancompany/core/conversation.py
+++ b/src/onemancompany/core/conversation.py
@@ -102,14 +102,14 @@ def save_conversation_meta(conv: Conversation) -> None:
     conv_dir.mkdir(parents=True, exist_ok=True)
     meta_path = conv_dir / CONVERSATION_META_FILENAME
     logger.debug("[conversation] save meta: id={}, phase={}", conv.id, conv.phase)
-    with open(meta_path, "w") as f:
+    with open(meta_path, "w", encoding="utf-8") as f:
         yaml.dump(conv.to_dict(), f, allow_unicode=True)
 
 
 def load_conversation_meta(conv_id: str, conv_dir: Path) -> Conversation:
     """Load conversation metadata from disk."""
     meta_path = conv_dir / CONVERSATION_META_FILENAME
-    with open(meta_path) as f:
+    with open(meta_path, encoding="utf-8") as f:
         data = yaml.safe_load(f)
     return Conversation.from_dict(data)
 
@@ -121,10 +121,10 @@ async def append_message(conv_dir: Path, msg: Message) -> None:
     async with _get_lock(str(msg_path)):
         existing: list[dict] = []
         if msg_path.exists():
-            with open(msg_path) as f:
+            with open(msg_path, encoding="utf-8") as f:
                 existing = yaml.safe_load(f) or []
         existing.append(msg.to_dict())
-        with open(msg_path, "w") as f:
+        with open(msg_path, "w", encoding="utf-8") as f:
             yaml.dump(existing, f, allow_unicode=True)
     logger.debug("[conversation] appended message from {} in {}", msg.sender, conv_dir.name)
 
@@ -134,7 +134,7 @@ def load_messages(conv_dir: Path) -> list[Message]:
     msg_path = conv_dir / CONVERSATION_MESSAGES_FILENAME
     if not msg_path.exists():
         return []
-    with open(msg_path) as f:
+    with open(msg_path, encoding="utf-8") as f:
         data = yaml.safe_load(f) or []
     return [Message.from_dict(m) for m in data]
 

--- a/src/onemancompany/core/conversation_adapters.py
+++ b/src/onemancompany/core/conversation_adapters.py
@@ -131,7 +131,7 @@ def _build_conversation_prompt(
 
 def _load_oneonone_workspace_shared_prompt() -> str:
     """Load workspace policy prompt for one-on-one from shared_prompts."""
-    from onemancompany.core.config import SHARED_PROMPTS_DIR, SOURCE_ROOT
+    from onemancompany.core.config import SHARED_PROMPTS_DIR, SOURCE_ROOT, read_text_utf
 
     candidates = [
         SHARED_PROMPTS_DIR / "oneonone_workspace_policy.md",
@@ -140,7 +140,7 @@ def _load_oneonone_workspace_shared_prompt() -> str:
     for path in candidates:
         try:
             if path.exists():
-                return path.read_text(encoding="utf-8").strip()
+                return read_text_utf(path).strip()
         except OSError:
             logger.warning("[conversation] failed to read workspace policy prompt: {}", path)
     return ""

--- a/src/onemancompany/core/file_editor.py
+++ b/src/onemancompany/core/file_editor.py
@@ -9,7 +9,7 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 
-from onemancompany.core.config import COMPANY_DIR, EMPLOYEES_DIR, ENCODING_UTF8, PROJECTS_DIR, SOURCE_ROOT, SRC_DIR_NAME
+from onemancompany.core.config import COMPANY_DIR, EMPLOYEES_DIR, PROJECTS_DIR, SOURCE_ROOT, SRC_DIR_NAME, read_text_utf, write_text_utf
 from onemancompany.core.events import CompanyEvent, event_bus
 from onemancompany.core.models import DecisionStatus
 
@@ -102,7 +102,7 @@ def propose_edit(
     old_content = ""
     if resolved.exists():
         try:
-            old_content = resolved.read_text(encoding=ENCODING_UTF8)
+            old_content = read_text_utf(resolved)
         except Exception:
             old_content = "(unable to read original file)"
 
@@ -149,7 +149,7 @@ def execute_edit(edit_id: str) -> dict:
 
     # Write new content
     file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_path.write_text(edit["new_content"], encoding=ENCODING_UTF8)
+    write_text_utf(file_path, edit["new_content"])
 
     # Request soft-reload — runs immediately if idle, defers if agents are busy
     from onemancompany.core.state import request_reload

--- a/src/onemancompany/core/heartbeat.py
+++ b/src/onemancompany/core/heartbeat.py
@@ -27,6 +27,7 @@ from onemancompany.core.config import (
     load_manifest,
     settings,
     FOUNDING_LEVEL,
+    read_text_utf,
 )
 from onemancompany.core import store as _store
 from onemancompany.core.models import AuthMethod, HostingMode
@@ -120,7 +121,7 @@ def _check_self_hosted_pid(emp_id: str) -> bool:
     if not pid_file.exists():
         return False
     try:
-        pid = int(pid_file.read_text(encoding="utf-8").strip())
+        pid = int(read_text_utf(pid_file).strip())
         os.kill(pid, 0)  # signal 0: check existence without killing
         return True
     except (ValueError, ProcessLookupError, PermissionError, OSError):

--- a/src/onemancompany/core/heartbeat.py
+++ b/src/onemancompany/core/heartbeat.py
@@ -120,7 +120,7 @@ def _check_self_hosted_pid(emp_id: str) -> bool:
     if not pid_file.exists():
         return False
     try:
-        pid = int(pid_file.read_text().strip())
+        pid = int(pid_file.read_text(encoding="utf-8").strip())
         os.kill(pid, 0)  # signal 0: check existence without killing
         return True
     except (ValueError, ProcessLookupError, PermissionError, OSError):

--- a/src/onemancompany/core/journal.py
+++ b/src/onemancompany/core/journal.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from loguru import logger
 from pydantic import BaseModel, Field
 
-from onemancompany.core.config import COMPANY_DIR, ENCODING_UTF8
+from onemancompany.core.config import COMPANY_DIR, read_text_utf, write_text_utf
 
 # Single-file constants
 JOURNAL_DIR_NAME = "journal"
@@ -66,7 +66,7 @@ class Journal:
         filename = f"{record.kind.value}-{ts}-{digest}.json"
 
         file_path = dir_path / filename
-        file_path.write_text(content, encoding=ENCODING_UTF8)
+        write_text_utf(file_path, content)
         return str(file_path)
 
     def query(
@@ -85,7 +85,7 @@ class Journal:
             if kind and not f.name.startswith(kind.value):
                 continue
             try:
-                record = EvidenceRecord.model_validate_json(f.read_text(encoding=ENCODING_UTF8))
+                record = EvidenceRecord.model_validate_json(read_text_utf(f))
                 results.append(record)
             except Exception as _e:
                 logger.debug("Skipping corrupted evidence record {}: {}", f.name, _e)

--- a/src/onemancompany/core/layout.py
+++ b/src/onemancompany/core/layout.py
@@ -168,11 +168,11 @@ def _persist_positions(position_updates: dict[str, list[int]]) -> None:
         profile_path = EMPLOYEES_DIR / emp_id / PROFILE_FILENAME
         if not profile_path.exists():
             continue
-        with open(profile_path) as f:
+        with open(profile_path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         if data.get(PF_DESK_POSITION) != pos:
             data[PF_DESK_POSITION] = pos
-            with open(profile_path, "w") as f:
+            with open(profile_path, "w", encoding="utf-8") as f:
                 yaml.dump(data, f, allow_unicode=True, default_flow_style=False)
 
 

--- a/src/onemancompany/core/layout.py
+++ b/src/onemancompany/core/layout.py
@@ -33,6 +33,7 @@ from onemancompany.core.config import (
     PF_LEVEL,
     PF_REMOTE,
     PROFILE_FILENAME,
+    open_utf,
 )
 
 # ---------------------------------------------------------------------------
@@ -168,11 +169,11 @@ def _persist_positions(position_updates: dict[str, list[int]]) -> None:
         profile_path = EMPLOYEES_DIR / emp_id / PROFILE_FILENAME
         if not profile_path.exists():
             continue
-        with open(profile_path, encoding="utf-8") as f:
+        with open_utf(profile_path) as f:
             data = yaml.safe_load(f) or {}
         if data.get(PF_DESK_POSITION) != pos:
             data[PF_DESK_POSITION] = pos
-            with open(profile_path, "w", encoding="utf-8") as f:
+            with open_utf(profile_path, "w") as f:
                 yaml.dump(data, f, allow_unicode=True, default_flow_style=False)
 
 

--- a/src/onemancompany/core/meeting_minutes.py
+++ b/src/onemancompany/core/meeting_minutes.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from loguru import logger
 
-from onemancompany.core.config import COMPANY_DIR, ENCODING_UTF8
+from onemancompany.core.config import COMPANY_DIR, read_text_utf, write_text_utf
 
 MINUTES_DIR = COMPANY_DIR / "meeting_minutes"
 
@@ -37,10 +37,7 @@ def archive_meeting(
         "conclusion": conclusion,
     }
     path = MINUTES_DIR / f"{minute_id}.yaml"
-    path.write_text(
-        yaml.dump(doc, allow_unicode=True, default_flow_style=False),
-        encoding=ENCODING_UTF8,
-    )
+    write_text_utf(path, yaml.dump(doc, allow_unicode=True, default_flow_style=False))
     logger.info(
         "[meeting_minutes] Archived meeting {} ({} messages)",
         minute_id,
@@ -54,7 +51,7 @@ def load_minute(minute_id: str) -> dict:
     path = MINUTES_DIR / f"{minute_id}.yaml"
     if not path.exists():
         return {}
-    return yaml.safe_load(path.read_text(encoding=ENCODING_UTF8)) or {}
+    return yaml.safe_load(read_text_utf(path)) or {}
 
 
 def query_minutes(
@@ -70,7 +67,7 @@ def query_minutes(
     for f in sorted(MINUTES_DIR.iterdir(), reverse=True):
         if f.suffix != ".yaml":
             continue
-        doc = yaml.safe_load(f.read_text(encoding=ENCODING_UTF8)) or {}
+        doc = yaml.safe_load(read_text_utf(f)) or {}
         if room_id and doc.get("room_id") != room_id:
             continue
         if project_id and doc.get("project_id") != project_id:

--- a/src/onemancompany/core/oauth.py
+++ b/src/onemancompany/core/oauth.py
@@ -96,7 +96,7 @@ def _load_tokens(service_name: str) -> dict:
     path = _token_cache_path(service_name)
     if path.exists():
         try:
-            return json.loads(path.read_text())
+            return json.loads(path.read_text(encoding="utf-8"))
         except Exception:
             return {}
     return {}
@@ -104,7 +104,7 @@ def _load_tokens(service_name: str) -> dict:
 
 def _save_tokens(service_name: str, data: dict) -> None:
     path = _token_cache_path(service_name)
-    path.write_text(json.dumps(data, indent=2))
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
 
 def _generate_pkce() -> tuple[str, str]:

--- a/src/onemancompany/core/oauth.py
+++ b/src/onemancompany/core/oauth.py
@@ -37,7 +37,7 @@ from pathlib import Path
 from urllib.parse import urlencode, urlparse, parse_qs
 
 # Avoid importing heavy deps at module level
-from onemancompany.core.config import ASSETS_DIR as _ASSETS_DIR, ENCODING_UTF8, SYSTEM_AGENT
+from onemancompany.core.config import ASSETS_DIR as _ASSETS_DIR, SYSTEM_AGENT, read_text_utf, write_text_utf
 _TOKEN_DIR = _ASSETS_DIR / ".oauth_cache"
 
 # Track active authorization flows to avoid duplicate popups
@@ -96,7 +96,7 @@ def _load_tokens(service_name: str) -> dict:
     path = _token_cache_path(service_name)
     if path.exists():
         try:
-            return json.loads(path.read_text(encoding="utf-8"))
+            return json.loads(read_text_utf(path))
         except Exception:
             return {}
     return {}
@@ -104,7 +104,7 @@ def _load_tokens(service_name: str) -> dict:
 
 def _save_tokens(service_name: str, data: dict) -> None:
     path = _token_cache_path(service_name)
-    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    write_text_utf(path, json.dumps(data, indent=2))
 
 
 def _generate_pkce() -> tuple[str, str]:

--- a/src/onemancompany/core/plugin_registry.py
+++ b/src/onemancompany/core/plugin_registry.py
@@ -10,7 +10,7 @@ from typing import Any, Callable
 import yaml
 from loguru import logger
 
-from onemancompany.core.config import PLUGINS_DIR
+from onemancompany.core.config import PLUGINS_DIR, open_utf
 
 # Single-file constants
 PLUGIN_YAML_FILENAME = "plugin.yaml"
@@ -91,7 +91,7 @@ class PluginRegistry:
         logger.info("Loaded {} plugin(s): {}", len(self._plugins), list(self._plugins.keys()))
 
     def _load_plugin(self, plugin_dir: Path, manifest_path: Path) -> None:
-        with open(manifest_path, encoding="utf-8") as f:
+        with open_utf(manifest_path) as f:
             data = yaml.safe_load(f) or {}
 
         manifest = PluginManifest.from_yaml(data)

--- a/src/onemancompany/core/plugin_registry.py
+++ b/src/onemancompany/core/plugin_registry.py
@@ -91,7 +91,7 @@ class PluginRegistry:
         logger.info("Loaded {} plugin(s): {}", len(self._plugins), list(self._plugins.keys()))
 
     def _load_plugin(self, plugin_dir: Path, manifest_path: Path) -> None:
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
 
         manifest = PluginManifest.from_yaml(data)

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -21,7 +21,6 @@ from pathlib import Path
 import yaml
 
 from onemancompany.core.config import (
-    ENCODING_UTF8,
     NODES_DIR_NAME,
     PROJECT_YAML_FILENAME,
     PROJECTS_DIR,
@@ -31,6 +30,7 @@ from onemancompany.core.config import (
     open_utf,
     TL_FIELD_EMPLOYEE_ID,
     TL_FIELD_TIME,
+    write_text_utf,
 )
 
 ITERATIONS_DIR_NAME = "iterations"
@@ -634,7 +634,7 @@ def save_project_file(project_id: str, filename: str, content: str | bytes) -> d
     if isinstance(content, bytes):
         file_path.write_bytes(content)
     else:
-        file_path.write_text(content, encoding=ENCODING_UTF8)
+        write_text_utf(file_path, content)
 
     return {"status": "ok", "path": str(file_path), "relative": filename}
 

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -293,10 +293,10 @@ def update_project_name(project_id: str, new_name: str) -> None:
     with lock:
         if not path.exists():
             return
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             doc = yaml.safe_load(f) or {}
         doc["name"] = new_name
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             yaml.dump(doc, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -340,7 +340,7 @@ def create_named_project(name: str) -> str:
     }
     path = proj_dir / PROJECT_YAML_FILENAME
     lock = _get_project_lock(slug)
-    with lock, open(path, "w") as f:
+    with lock, open(path, "w", encoding="utf-8") as f:
         yaml.dump(doc, f, allow_unicode=True, default_flow_style=False)
     return slug
 
@@ -412,7 +412,7 @@ def create_iteration(project_id: str, task: str, routed_to: str) -> str:
     proj[ITERATIONS_DIR_NAME] = existing + [iter_id]
     path = PROJECTS_DIR / project_id / PROJECT_YAML_FILENAME
     lock = _get_project_lock(project_id)
-    with lock, open(path, "w") as f:
+    with lock, open(path, "w", encoding="utf-8") as f:
         yaml.dump(proj, f, allow_unicode=True, default_flow_style=False)
 
     # Trigger 1: dispatch → in_progress — notify sync tick
@@ -430,7 +430,7 @@ def load_iteration(project_id: str, iteration_id: str) -> dict | None:
         return None
     lock_key = f"{project_id}/{iteration_id}"
     lock = _get_project_lock(lock_key)
-    with lock, open(path) as f:
+    with lock, open(path, encoding="utf-8") as f:
         return yaml.safe_load(f) or {}
 
 
@@ -441,7 +441,7 @@ def _save_iteration(project_id: str, iteration_id: str, doc: dict) -> None:
     path = iter_dir / f"{iteration_id}.yaml"
     lock_key = f"{project_id}/{iteration_id}"
     lock = _get_project_lock(lock_key)
-    with lock, open(path, "w") as f:
+    with lock, open(path, "w", encoding="utf-8") as f:
         yaml.dump(doc, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -451,7 +451,7 @@ def load_named_project(project_id: str) -> dict | None:
     if not path.exists():
         return None
     lock = _get_project_lock(project_id)
-    with lock, open(path) as f:
+    with lock, open(path, encoding="utf-8") as f:
         doc = yaml.safe_load(f) or {}
     # Distinguish v2 by checking for 'iterations' key
     if ITERATIONS_DIR_NAME not in doc:
@@ -470,7 +470,7 @@ def list_named_projects() -> list[dict]:
         if not yaml_path.exists():
             continue
         try:
-            with open(yaml_path) as fh:
+            with open(yaml_path, encoding="utf-8") as fh:
                 doc = yaml.safe_load(fh) or {}
         except Exception as _e:
             logger.warning("Failed to load {}: {}", yaml_path, _e)
@@ -500,7 +500,7 @@ def archive_project(project_id: str) -> None:
     proj["archived_at"] = datetime.now().isoformat()
     path = PROJECTS_DIR / project_id / PROJECT_YAML_FILENAME
     lock = _get_project_lock(project_id)
-    with lock, open(path, "w") as f:
+    with lock, open(path, "w", encoding="utf-8") as f:
         yaml.dump(proj, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -694,7 +694,7 @@ def list_projects() -> list[dict]:
         if not yaml_path.exists():
             continue
         try:
-            with open(yaml_path) as fh:
+            with open(yaml_path, encoding="utf-8") as fh:
                 doc = yaml.safe_load(fh) or {}
         except Exception as _e:
             logger.warning("Failed to load {}: {}", yaml_path, _e)
@@ -813,7 +813,7 @@ def get_cost_summary() -> dict:
         if not yaml_path.exists():
             continue
         try:
-            with open(yaml_path) as fh:
+            with open(yaml_path, encoding="utf-8") as fh:
                 doc = yaml.safe_load(fh) or {}
         except Exception as _e:
             logger.warning("Failed to load {}: {}", yaml_path, _e)

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -28,6 +28,7 @@ from onemancompany.core.config import (
     TASK_TREE_FILENAME,
     TL_FIELD_ACTION,
     TL_FIELD_DETAIL,
+    open_utf,
     TL_FIELD_EMPLOYEE_ID,
     TL_FIELD_TIME,
 )
@@ -293,10 +294,10 @@ def update_project_name(project_id: str, new_name: str) -> None:
     with lock:
         if not path.exists():
             return
-        with open(path, encoding="utf-8") as f:
+        with open_utf(path) as f:
             doc = yaml.safe_load(f) or {}
         doc["name"] = new_name
-        with open(path, "w", encoding="utf-8") as f:
+        with open_utf(path, "w") as f:
             yaml.dump(doc, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -340,7 +341,7 @@ def create_named_project(name: str) -> str:
     }
     path = proj_dir / PROJECT_YAML_FILENAME
     lock = _get_project_lock(slug)
-    with lock, open(path, "w", encoding="utf-8") as f:
+    with lock, open_utf(path, "w") as f:
         yaml.dump(doc, f, allow_unicode=True, default_flow_style=False)
     return slug
 
@@ -412,7 +413,7 @@ def create_iteration(project_id: str, task: str, routed_to: str) -> str:
     proj[ITERATIONS_DIR_NAME] = existing + [iter_id]
     path = PROJECTS_DIR / project_id / PROJECT_YAML_FILENAME
     lock = _get_project_lock(project_id)
-    with lock, open(path, "w", encoding="utf-8") as f:
+    with lock, open_utf(path, "w") as f:
         yaml.dump(proj, f, allow_unicode=True, default_flow_style=False)
 
     # Trigger 1: dispatch → in_progress — notify sync tick
@@ -430,7 +431,7 @@ def load_iteration(project_id: str, iteration_id: str) -> dict | None:
         return None
     lock_key = f"{project_id}/{iteration_id}"
     lock = _get_project_lock(lock_key)
-    with lock, open(path, encoding="utf-8") as f:
+    with lock, open_utf(path) as f:
         return yaml.safe_load(f) or {}
 
 
@@ -441,7 +442,7 @@ def _save_iteration(project_id: str, iteration_id: str, doc: dict) -> None:
     path = iter_dir / f"{iteration_id}.yaml"
     lock_key = f"{project_id}/{iteration_id}"
     lock = _get_project_lock(lock_key)
-    with lock, open(path, "w", encoding="utf-8") as f:
+    with lock, open_utf(path, "w") as f:
         yaml.dump(doc, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -451,7 +452,7 @@ def load_named_project(project_id: str) -> dict | None:
     if not path.exists():
         return None
     lock = _get_project_lock(project_id)
-    with lock, open(path, encoding="utf-8") as f:
+    with lock, open_utf(path) as f:
         doc = yaml.safe_load(f) or {}
     # Distinguish v2 by checking for 'iterations' key
     if ITERATIONS_DIR_NAME not in doc:
@@ -470,7 +471,7 @@ def list_named_projects() -> list[dict]:
         if not yaml_path.exists():
             continue
         try:
-            with open(yaml_path, encoding="utf-8") as fh:
+            with open_utf(yaml_path) as fh:
                 doc = yaml.safe_load(fh) or {}
         except Exception as _e:
             logger.warning("Failed to load {}: {}", yaml_path, _e)
@@ -500,7 +501,7 @@ def archive_project(project_id: str) -> None:
     proj["archived_at"] = datetime.now().isoformat()
     path = PROJECTS_DIR / project_id / PROJECT_YAML_FILENAME
     lock = _get_project_lock(project_id)
-    with lock, open(path, "w", encoding="utf-8") as f:
+    with lock, open_utf(path, "w") as f:
         yaml.dump(proj, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -694,7 +695,7 @@ def list_projects() -> list[dict]:
         if not yaml_path.exists():
             continue
         try:
-            with open(yaml_path, encoding="utf-8") as fh:
+            with open_utf(yaml_path) as fh:
                 doc = yaml.safe_load(fh) or {}
         except Exception as _e:
             logger.warning("Failed to load {}: {}", yaml_path, _e)
@@ -813,7 +814,7 @@ def get_cost_summary() -> dict:
         if not yaml_path.exists():
             continue
         try:
-            with open(yaml_path, encoding="utf-8") as fh:
+            with open_utf(yaml_path) as fh:
                 doc = yaml.safe_load(fh) or {}
         except Exception as _e:
             logger.warning("Failed to load {}: {}", yaml_path, _e)

--- a/src/onemancompany/core/resolutions.py
+++ b/src/onemancompany/core/resolutions.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import yaml
 
-from onemancompany.core.config import ENCODING_UTF8, RESOLUTIONS_DIR
+from onemancompany.core.config import ENCODING_UTF8, RESOLUTIONS_DIR, open_utf
 from onemancompany.core.models import DecisionStatus
 
 # ---------------------------------------------------------------------------
@@ -83,7 +83,7 @@ def create_resolution(project_id: str, task_description: str) -> dict | None:
     }
 
     path = RESOLUTIONS_DIR / f"{resolution_id}.yaml"
-    with open(path, "w", encoding="utf-8") as f:
+    with open_utf(path, "w") as f:
         yaml.dump(resolution, f, allow_unicode=True, default_flow_style=False)
 
     return resolution
@@ -94,14 +94,14 @@ def load_resolution(resolution_id: str) -> dict | None:
     path = RESOLUTIONS_DIR / f"{resolution_id}.yaml"
     if not path.exists():
         return None
-    with open(path, encoding="utf-8") as f:
+    with open_utf(path) as f:
         return yaml.safe_load(f)
 
 
 def _save_resolution(resolution: dict) -> None:
     """Persist a resolution dict back to its YAML file."""
     path = RESOLUTIONS_DIR / f"{resolution['resolution_id']}.yaml"
-    with open(path, "w", encoding="utf-8") as f:
+    with open_utf(path, "w") as f:
         yaml.dump(resolution, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -113,7 +113,7 @@ def list_resolutions(status_filter: str | None = None) -> list[dict]:
     for p in sorted(RESOLUTIONS_DIR.iterdir(), reverse=True):
         if p.suffix != ".yaml":
             continue
-        with open(p, encoding="utf-8") as f:
+        with open_utf(p) as f:
             data = yaml.safe_load(f)
         if not data:
             continue
@@ -142,7 +142,7 @@ def list_deferred_edits() -> list[dict]:
     for p in sorted(RESOLUTIONS_DIR.iterdir(), reverse=True):
         if p.suffix != ".yaml":
             continue
-        with open(p, encoding="utf-8") as f:
+        with open_utf(p) as f:
             data = yaml.safe_load(f)
         if not data:
             continue

--- a/src/onemancompany/core/resolutions.py
+++ b/src/onemancompany/core/resolutions.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import yaml
 
-from onemancompany.core.config import ENCODING_UTF8, RESOLUTIONS_DIR, open_utf
+from onemancompany.core.config import ENCODING_UTF8, RESOLUTIONS_DIR, open_utf, read_text_utf
 from onemancompany.core.models import DecisionStatus
 
 # ---------------------------------------------------------------------------
@@ -154,7 +154,7 @@ def list_deferred_edits() -> list[dict]:
             # Check staleness
             file_path = Path(edit.get("file_path", ""))
             if file_path.exists():
-                current_md5 = _compute_md5(file_path.read_text(encoding=ENCODING_UTF8))
+                current_md5 = _compute_md5(read_text_utf(file_path))
                 edit["expired"] = current_md5 != edit.get("original_md5", "")
             else:
                 edit["expired"] = True
@@ -222,7 +222,7 @@ def decide_resolution(resolution_id: str, decisions: dict[str, str]) -> dict:
             file_path = Path(edit["file_path"])
             if file_path.exists():
                 edit["original_md5"] = _compute_md5(
-                    file_path.read_text(encoding=ENCODING_UTF8)
+                    read_text_utf(file_path)
                 )
             results.append({"edit_id": eid, "decision": "defer", "status": DecisionStatus.DEFERRED.value})
 
@@ -262,7 +262,7 @@ def execute_deferred_edit(resolution_id: str, edit_id: str) -> dict:
     # Check staleness
     file_path = Path(edit["file_path"])
     if file_path.exists():
-        current_md5 = _compute_md5(file_path.read_text(encoding=ENCODING_UTF8))
+        current_md5 = _compute_md5(read_text_utf(file_path))
         if current_md5 != edit.get("original_md5", ""):
             edit["expired"] = True
             _save_resolution(resolution)

--- a/src/onemancompany/core/resolutions.py
+++ b/src/onemancompany/core/resolutions.py
@@ -83,7 +83,7 @@ def create_resolution(project_id: str, task_description: str) -> dict | None:
     }
 
     path = RESOLUTIONS_DIR / f"{resolution_id}.yaml"
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         yaml.dump(resolution, f, allow_unicode=True, default_flow_style=False)
 
     return resolution
@@ -94,14 +94,14 @@ def load_resolution(resolution_id: str) -> dict | None:
     path = RESOLUTIONS_DIR / f"{resolution_id}.yaml"
     if not path.exists():
         return None
-    with open(path) as f:
+    with open(path, encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 
 def _save_resolution(resolution: dict) -> None:
     """Persist a resolution dict back to its YAML file."""
     path = RESOLUTIONS_DIR / f"{resolution['resolution_id']}.yaml"
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         yaml.dump(resolution, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -113,7 +113,7 @@ def list_resolutions(status_filter: str | None = None) -> list[dict]:
     for p in sorted(RESOLUTIONS_DIR.iterdir(), reverse=True):
         if p.suffix != ".yaml":
             continue
-        with open(p) as f:
+        with open(p, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         if not data:
             continue
@@ -142,7 +142,7 @@ def list_deferred_edits() -> list[dict]:
     for p in sorted(RESOLUTIONS_DIR.iterdir(), reverse=True):
         if p.suffix != ".yaml":
             continue
-        with open(p) as f:
+        with open(p, encoding="utf-8") as f:
             data = yaml.safe_load(f)
         if not data:
             continue

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -1270,7 +1270,7 @@ def _load_past_action_items() -> list[dict]:
         return items
     for report_path in REPORTS_DIR.glob("*.yaml"):
         try:
-            with open(report_path) as f:
+            with open(report_path, encoding="utf-8") as f:
                 doc = yaml.safe_load(f)
             if not doc or not isinstance(doc, dict):
                 continue
@@ -1919,7 +1919,7 @@ def _save_report(report_id: str, doc: dict) -> None:
     """Save meeting report to meeting_reports/ directory."""
     REPORTS_DIR.mkdir(parents=True, exist_ok=True)
     report_path = REPORTS_DIR / f"{report_id}.yaml"
-    with open(report_path, "w") as f:
+    with open(report_path, "w", encoding="utf-8") as f:
         yaml.dump(doc, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -1934,7 +1934,7 @@ async def execute_approved_actions(report_id: str, approved_indices: list[int]) 
         # Fallback: try loading from disk (survives server restart)
         report_path = REPORTS_DIR / f"{report_id}.yaml"
         if report_path.exists():
-            with open(report_path) as f:
+            with open(report_path, encoding="utf-8") as f:
                 doc = yaml.safe_load(f)
     if not doc:
         return "Report not found."

--- a/src/onemancompany/core/routine.py
+++ b/src/onemancompany/core/routine.py
@@ -54,6 +54,7 @@ from onemancompany.core.config import (
     TASK_TREE_FILENAME,
     TASKS_PER_QUARTER,
     load_workflows,
+    open_utf,
 )
 from onemancompany.core.events import CompanyEvent, event_bus
 from onemancompany.core.models import EventType
@@ -1270,7 +1271,7 @@ def _load_past_action_items() -> list[dict]:
         return items
     for report_path in REPORTS_DIR.glob("*.yaml"):
         try:
-            with open(report_path, encoding="utf-8") as f:
+            with open_utf(report_path) as f:
                 doc = yaml.safe_load(f)
             if not doc or not isinstance(doc, dict):
                 continue
@@ -1919,7 +1920,7 @@ def _save_report(report_id: str, doc: dict) -> None:
     """Save meeting report to meeting_reports/ directory."""
     REPORTS_DIR.mkdir(parents=True, exist_ok=True)
     report_path = REPORTS_DIR / f"{report_id}.yaml"
-    with open(report_path, "w", encoding="utf-8") as f:
+    with open_utf(report_path, "w") as f:
         yaml.dump(doc, f, allow_unicode=True, default_flow_style=False)
 
 
@@ -1934,7 +1935,7 @@ async def execute_approved_actions(report_id: str, approved_indices: list[int]) 
         # Fallback: try loading from disk (survives server restart)
         report_path = REPORTS_DIR / f"{report_id}.yaml"
         if report_path.exists():
-            with open(report_path, encoding="utf-8") as f:
+            with open_utf(report_path) as f:
                 doc = yaml.safe_load(f)
     if not doc:
         return "Report not found."

--- a/src/onemancompany/core/snapshot.py
+++ b/src/onemancompany/core/snapshot.py
@@ -30,7 +30,7 @@ from typing import Protocol
 
 from loguru import logger
 
-from onemancompany.core.config import COMPANY_DIR as _COMPANY_DIR, ENCODING_UTF8
+from onemancompany.core.config import COMPANY_DIR as _COMPANY_DIR, read_text_utf, write_text_utf
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -94,7 +94,7 @@ def save_snapshot() -> None:
 
     try:
         SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
-        SNAPSHOT_PATH.write_text(json.dumps(snapshot, default=str), encoding=ENCODING_UTF8)
+        write_text_utf(SNAPSHOT_PATH, json.dumps(snapshot, default=str))
         provider_names = [n for n in snapshot["providers"]]
         logger.info("Saved snapshot: {} provider(s) [{}]", len(provider_names), ", ".join(provider_names))
     except Exception as e:
@@ -106,7 +106,7 @@ def restore_snapshot() -> None:
     if not SNAPSHOT_PATH.exists():
         return
     try:
-        raw = json.loads(SNAPSHOT_PATH.read_text(encoding=ENCODING_UTF8))
+        raw = json.loads(read_text_utf(SNAPSHOT_PATH))
         saved_at = raw.get("saved_at", 0)
         age = time.time() - saved_at
         if age > SNAPSHOT_MAX_AGE_SECONDS:

--- a/src/onemancompany/core/standalone_runner.py
+++ b/src/onemancompany/core/standalone_runner.py
@@ -13,7 +13,7 @@ Usage:
 
 from pathlib import Path
 
-from onemancompany.core.config import ENCODING_UTF8
+from onemancompany.core.config import write_text_utf
 
 
 TEMPLATE = r'''#!/usr/bin/env python3
@@ -307,6 +307,6 @@ def generate_run_py(employee_dir: str | Path, employee_name: str, employee_id: s
     """Generate a standalone run.py in the employee directory."""
     dest = Path(employee_dir) / "run.py"
     content = TEMPLATE.format(employee_name=employee_name, employee_id=employee_id)
-    dest.write_text(content, encoding=ENCODING_UTF8)
+    write_text_utf(dest, content)
     dest.chmod(0o755)
     return dest

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -25,7 +25,7 @@ from typing import Any, Callable, Coroutine, Literal, TypedDict
 
 from loguru import logger
 
-from onemancompany.core.config import SYSTEM_SENDER
+from onemancompany.core.config import SYSTEM_SENDER, read_text_utf, write_text_utf
 from onemancompany.core.interval import parse_interval
 from onemancompany.core.models import EventType
 
@@ -117,7 +117,7 @@ class SystemCronManager:
         if not path.exists():
             return
         try:
-            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            data = yaml.safe_load(read_text_utf(path)) or {}
             self._disabled = set(data.get("disabled", []))
             # Restore custom intervals
             for name, interval in data.get("intervals", {}).items():
@@ -147,7 +147,7 @@ class SystemCronManager:
         }
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(yaml.dump(data, allow_unicode=True, default_flow_style=False), encoding="utf-8")
+            write_text_utf(path, yaml.dump(data, allow_unicode=True, default_flow_style=False))
         except Exception as e:
             logger.error("[system_cron] Failed to persist state: {}", e)
 

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -117,7 +117,7 @@ class SystemCronManager:
         if not path.exists():
             return
         try:
-            data = yaml.safe_load(path.read_text()) or {}
+            data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
             self._disabled = set(data.get("disabled", []))
             # Restore custom intervals
             for name, interval in data.get("intervals", {}).items():
@@ -147,7 +147,7 @@ class SystemCronManager:
         }
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(yaml.dump(data, allow_unicode=True, default_flow_style=False))
+            path.write_text(yaml.dump(data, allow_unicode=True, default_flow_style=False), encoding="utf-8")
         except Exception as e:
             logger.error("[system_cron] Failed to persist state: {}", e)
 

--- a/src/onemancompany/core/system_tasks.py
+++ b/src/onemancompany/core/system_tasks.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import yaml
 from loguru import logger
 
-from onemancompany.core.config import ENCODING_UTF8
+from onemancompany.core.config import read_text_utf, write_text_utf
 from onemancompany.core.task_lifecycle import NodeType, TaskPhase, RESOLVED
 from onemancompany.core.task_tree import TaskNode
 
@@ -50,11 +50,11 @@ class SystemTaskTree:
             "employee_id": self.employee_id,
             "nodes": [n.to_dict() for n in self._nodes.values()],
         }
-        path.write_text(yaml.dump(data, allow_unicode=True, sort_keys=False), encoding=ENCODING_UTF8)
+        write_text_utf(path, yaml.dump(data, allow_unicode=True, sort_keys=False))
 
     @classmethod
     def load(cls, path: Path, employee_id: str = "") -> SystemTaskTree:
-        data = yaml.safe_load(path.read_text(encoding=ENCODING_UTF8)) or {}
+        data = yaml.safe_load(read_text_utf(path)) or {}
         tree = cls(employee_id=employee_id or data.get("employee_id", ""))
         for nd in data.get("nodes", []):
             node = TaskNode.from_dict(nd)

--- a/src/onemancompany/core/task_persistence.py
+++ b/src/onemancompany/core/task_persistence.py
@@ -13,7 +13,7 @@ from loguru import logger
 
 import yaml
 
-from onemancompany.core.config import EMPLOYEES_DIR, PROJECT_YAML_FILENAME, TASK_TREE_FILENAME
+from onemancompany.core.config import EMPLOYEES_DIR, PROJECT_YAML_FILENAME, TASK_TREE_FILENAME, read_text_utf
 from onemancompany.core.task_lifecycle import RESOLVED, TaskPhase
 
 
@@ -23,7 +23,7 @@ def _is_project_archived(tree_path: Path) -> bool:
     if not project_yaml.exists():
         return False
     try:
-        doc = yaml.safe_load(project_yaml.read_text(encoding="utf-8")) or {}
+        doc = yaml.safe_load(read_text_utf(project_yaml)) or {}
         return doc.get("status") == "archived"
     except Exception:
         return False

--- a/src/onemancompany/core/task_persistence.py
+++ b/src/onemancompany/core/task_persistence.py
@@ -23,7 +23,7 @@ def _is_project_archived(tree_path: Path) -> bool:
     if not project_yaml.exists():
         return False
     try:
-        doc = yaml.safe_load(project_yaml.read_text()) or {}
+        doc = yaml.safe_load(project_yaml.read_text(encoding="utf-8")) or {}
         return doc.get("status") == "archived"
     except Exception:
         return False

--- a/src/onemancompany/core/tool_registry.py
+++ b/src/onemancompany/core/tool_registry.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 
 from loguru import logger
 
-from onemancompany.core.config import TOOL_YAML_FILENAME
+from onemancompany.core.config import TOOL_YAML_FILENAME, open_utf
 
 
 
@@ -160,7 +160,7 @@ class ToolRegistry:
             if not tool_yaml_path.exists():
                 continue
 
-            with open(tool_yaml_path, encoding="utf-8") as f:
+            with open_utf(tool_yaml_path) as f:
                 tool_conf = yaml.safe_load(f) or {}
 
             # Only load Python-based tool modules

--- a/src/onemancompany/core/tool_registry.py
+++ b/src/onemancompany/core/tool_registry.py
@@ -160,7 +160,7 @@ class ToolRegistry:
             if not tool_yaml_path.exists():
                 continue
 
-            with open(tool_yaml_path) as f:
+            with open(tool_yaml_path, encoding="utf-8") as f:
                 tool_conf = yaml.safe_load(f) or {}
 
             # Only load Python-based tool modules

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -52,6 +52,8 @@ from onemancompany.core.config import (
     TL_FIELD_DETAIL,
     TL_FIELD_EMPLOYEE_ID,
     TL_FIELD_TIME,
+    read_text_utf,
+    write_text_utf,
 )
 from onemancompany.core.project_archive import ITER_STATUS_FAILED, PA_TOKEN_USAGE
 from onemancompany.core.events import CompanyEvent, event_bus
@@ -205,7 +207,7 @@ def build_role_identity(employee_id: str) -> str:
     """
     from onemancompany.core.config import (
         FOUNDING_IDS, PF_NAME, PF_NICKNAME, PF_ROLE, PF_DEPARTMENT, PF_LEVEL,
-        EMPLOYEES_DIR, ENCODING_UTF8, load_employee_profile_yaml,
+        EMPLOYEES_DIR, load_employee_profile_yaml, read_text_utf,
     )
     if employee_id in FOUNDING_IDS:
         return ""
@@ -213,7 +215,7 @@ def build_role_identity(employee_id: str) -> str:
     # Check for role_guide.md first (per-employee override)
     guide_path = EMPLOYEES_DIR / employee_id / "role_guide.md"
     if guide_path.exists():
-        return guide_path.read_text(encoding=ENCODING_UTF8)
+        return read_text_utf(guide_path)
 
     profile = load_employee_profile_yaml(employee_id)
     name = profile.get(PF_NAME, "Employee")
@@ -361,7 +363,7 @@ def _load_task_history(employee_id: str) -> tuple[list[dict], str]:
     if not path.exists():
         return [], ""
     try:
-        data = json.loads(path.read_text(encoding=ENCODING_UTF8))
+        data = json.loads(read_text_utf(path))
         return data.get("entries", []), data.get("summary", "")
     except Exception as e:
         logger.warning("Failed to load task history for {}: {}", employee_id, e)
@@ -373,10 +375,10 @@ def _save_task_history(employee_id: str, entries: list[dict], summary: str) -> N
     path = _history_path(employee_id)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps({
+        write_text_utf(path, json.dumps({
             "entries": entries,
             "summary": summary,
-        }, ensure_ascii=False, indent=2), encoding=ENCODING_UTF8)
+        }, ensure_ascii=False, indent=2))
     except Exception as e:
         logger.warning("Failed to save task history for {}: {}", employee_id, e)
 
@@ -673,7 +675,7 @@ def _load_progress(employee_id: str, max_lines: int = PROGRESS_LOG_MAX_LINES) ->
     if not path.exists():
         return ""
     try:
-        lines = path.read_text(encoding=ENCODING_UTF8).strip().split("\n")
+        lines = read_text_utf(path).strip().split("\n")
         return "\n".join(lines[-max_lines:])
     except Exception:
         return ""
@@ -1961,9 +1963,9 @@ class EmployeeManager:
         talent_persona_path = EMPLOYEES_DIR / employee_id / "prompts" / "talent_persona.md"
         persona_content = ""
         if claude_md_path.exists():
-            persona_content = claude_md_path.read_text(encoding="utf-8").strip()
+            persona_content = read_text_utf(claude_md_path).strip()
         elif talent_persona_path.exists():
-            persona_content = talent_persona_path.read_text(encoding="utf-8").strip()
+            persona_content = read_text_utf(talent_persona_path).strip()
         if persona_content:
             parts.append(f"## Your Persona\n{persona_content}")
 
@@ -2907,7 +2909,7 @@ class EmployeeManager:
         existing = ""
         if soul_path.exists():
             try:
-                existing = soul_path.read_text(encoding=ENCODING_UTF8)
+                existing = read_text_utf(soul_path)
             except Exception as exc:
                 logger.debug("Failed to read SOUL.md for {}: {}", employee_id, exc)
 
@@ -2938,7 +2940,7 @@ class EmployeeManager:
             )
             new_content = result.content.strip()
             if new_content and len(new_content) > 10:
-                soul_path.write_text(new_content, encoding=ENCODING_UTF8)
+                write_text_utf(soul_path, new_content)
                 logger.info(f"[soul] Updated SOUL.md for employee {employee_id}")
         except Exception as e:
             logger.debug(f"[soul] Failed to update SOUL.md for {employee_id}: {e}")

--- a/src/onemancompany/core/vessel_config.py
+++ b/src/onemancompany/core/vessel_config.py
@@ -146,7 +146,7 @@ def _parse_vessel_dict(raw: dict) -> VesselConfig:
 def _load_default_vessel_config() -> VesselConfig:
     """Load the default vessel config from src/onemancompany/core/default_vessel.yaml."""
     if _DEFAULT_VESSEL_YAML.exists():
-        with open(_DEFAULT_VESSEL_YAML) as f:
+        with open(_DEFAULT_VESSEL_YAML, encoding="utf-8") as f:
             raw = yaml.safe_load(f) or {}
         return _parse_vessel_dict(raw)
     return VesselConfig()
@@ -163,7 +163,7 @@ def load_vessel_config(emp_dir: Path) -> VesselConfig:
     vessel_yaml = emp_dir / VESSEL_DIR_NAME / VESSEL_YAML_FILENAME
     if vessel_yaml.exists():
         try:
-            with open(vessel_yaml) as f:
+            with open(vessel_yaml, encoding="utf-8") as f:
                 raw = yaml.safe_load(f) or {}
             return _parse_vessel_dict(raw)
         except yaml.YAMLError:
@@ -211,7 +211,7 @@ def save_vessel_config(emp_dir: Path, config: VesselConfig) -> None:
         },
     }
 
-    with open(vessel_dir / VESSEL_YAML_FILENAME, "w") as f:
+    with open(vessel_dir / VESSEL_YAML_FILENAME, "w", encoding="utf-8") as f:
         yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
 
 

--- a/src/onemancompany/core/vessel_config.py
+++ b/src/onemancompany/core/vessel_config.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import yaml
 
-from onemancompany.core.config import VESSEL_DIR_NAME, VESSEL_YAML_FILENAME
+from onemancompany.core.config import VESSEL_DIR_NAME, VESSEL_YAML_FILENAME, open_utf
 
 # ---------------------------------------------------------------------------
 # Config dataclasses
@@ -146,7 +146,7 @@ def _parse_vessel_dict(raw: dict) -> VesselConfig:
 def _load_default_vessel_config() -> VesselConfig:
     """Load the default vessel config from src/onemancompany/core/default_vessel.yaml."""
     if _DEFAULT_VESSEL_YAML.exists():
-        with open(_DEFAULT_VESSEL_YAML, encoding="utf-8") as f:
+        with open_utf(_DEFAULT_VESSEL_YAML) as f:
             raw = yaml.safe_load(f) or {}
         return _parse_vessel_dict(raw)
     return VesselConfig()
@@ -163,7 +163,7 @@ def load_vessel_config(emp_dir: Path) -> VesselConfig:
     vessel_yaml = emp_dir / VESSEL_DIR_NAME / VESSEL_YAML_FILENAME
     if vessel_yaml.exists():
         try:
-            with open(vessel_yaml, encoding="utf-8") as f:
+            with open_utf(vessel_yaml) as f:
                 raw = yaml.safe_load(f) or {}
             return _parse_vessel_dict(raw)
         except yaml.YAMLError:
@@ -211,7 +211,7 @@ def save_vessel_config(emp_dir: Path, config: VesselConfig) -> None:
         },
     }
 
-    with open(vessel_dir / VESSEL_YAML_FILENAME, "w", encoding="utf-8") as f:
+    with open_utf(vessel_dir / VESSEL_YAML_FILENAME, "w") as f:
         yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
 
 

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -24,7 +24,6 @@ SOURCE_ROOT = Path(__file__).parent.parent.parent
 from onemancompany.core.config import (
     COMPANY_TEMPLATE_DIR, CONFIG_YAML_FILENAME,
     DATA_DIR_NAME, DOT_ENV_FILENAME, EMPLOYEES_DIR,
-    ENCODING_UTF8,
     ENV_KEY_ANTHROPIC, ENV_KEY_ANTHROPIC_AUTH, ENV_KEY_DEFAULT_MODEL,
     ENV_KEY_DEFAULT_PROVIDER, ENV_KEY_HOST, ENV_KEY_OPENROUTER,
     ENV_KEY_PORT, ENV_KEY_SANDBOX_ENABLED, ENV_KEY_SKILLSMP,
@@ -33,6 +32,8 @@ from onemancompany.core.config import (
     ENV_OMC_SERVER_URL, ENV_OMC_TASK_ID, HR_DIR, MCP_CONFIG_FILENAME,
     PROVIDER_ANTHROPIC, PROVIDER_OPENROUTER, TOOLS_DIR,
     WORKSPACE_DIR_NAME,
+    read_text_utf,
+    write_text_utf,
 )
 from onemancompany.core.models import AuthMethod
 DATA_ROOT = Path.cwd() / DATA_DIR_NAME
@@ -640,7 +641,7 @@ def _step_execute(
         env_lines.append(f"{ENV_KEY_SKILLSMP}={extras[ENV_KEY_SKILLSMP]}")
 
     env_path = DATA_ROOT / DOT_ENV_FILENAME
-    env_path.write_text("\n".join(env_lines) + "\n", encoding=ENCODING_UTF8)
+    write_text_utf(env_path, "\n".join(env_lines) + "\n")
     console.print("  [green]\u2714[/green] .env written")
 
     # 3. Copy config.yaml and inject Talent Market API key if provided
@@ -652,14 +653,14 @@ def _step_execute(
     # Patch config.yaml with user choices
     if dst_config.exists():
         import yaml
-        cfg = yaml.safe_load(dst_config.read_text(encoding=ENCODING_UTF8)) or {}
+        cfg = yaml.safe_load(read_text_utf(dst_config)) or {}
         # Sandbox toggle
         cfg.setdefault("tools", {}).setdefault("sandbox", {})["enabled"] = sandbox_enabled
         # Talent Market API key
         tm_key = extras.get(ENV_KEY_TALENT_MARKET, "")
         if tm_key:
             cfg.setdefault("talent_market", {})["api_key"] = tm_key
-        dst_config.write_text(yaml.dump(cfg, default_flow_style=False, allow_unicode=True), encoding=ENCODING_UTF8)
+        write_text_utf(dst_config, yaml.dump(cfg, default_flow_style=False, allow_unicode=True))
         if sandbox_enabled:
             console.print("  [green]\u2714[/green] Sandbox tools enabled")
         if tm_key:
@@ -672,10 +673,10 @@ def _step_execute(
     for _fid in FOUNDING_IDS:
         _profile = EMPLOYEES_DIR / _fid / "profile.yaml"
         if _profile.exists():
-            _pdata = _yaml.safe_load(_profile.read_text(encoding=ENCODING_UTF8)) or {}
+            _pdata = _yaml.safe_load(read_text_utf(_profile)) or {}
             if _pdata.get("llm_model") != model:
                 _pdata["llm_model"] = model
-                _profile.write_text(_yaml.dump(_pdata, default_flow_style=False, allow_unicode=True), encoding=ENCODING_UTF8)
+                write_text_utf(_profile, _yaml.dump(_pdata, default_flow_style=False, allow_unicode=True))
                 _synced += 1
     if _synced:
         console.print(f"  [green]\u2714[/green] Founding employees model set to {model}")
@@ -723,13 +724,10 @@ def _apply_founder_families(console: Console, founder_families: dict[str, str]) 
         profile_path = EMPLOYEES_DIR / emp_id / "profile.yaml"
         if not profile_path.exists():
             continue
-        data = _yaml.safe_load(profile_path.read_text(encoding=ENCODING_UTF8)) or {}
+        data = _yaml.safe_load(read_text_utf(profile_path)) or {}
         if data.get("hosting") != hosting:
             data["hosting"] = hosting
-            profile_path.write_text(
-                _yaml.dump(data, default_flow_style=False, allow_unicode=True),
-                encoding=ENCODING_UTF8,
-            )
+            write_text_utf(profile_path, _yaml.dump(data, default_flow_style=False, allow_unicode=True))
             changed += 1
 
     if changed:
@@ -825,10 +823,7 @@ def _generate_mcp_configs(skillsmp_key: str) -> None:
             }
 
         config_path = emp_dir / MCP_CONFIG_FILENAME
-        config_path.write_text(
-            json.dumps({"mcpServers": servers}, indent=2),
-            encoding=ENCODING_UTF8,
-        )
+        write_text_utf(config_path, json.dumps({"mcpServers": servers}, indent=2))
 
 
 def _step_done(console: Console, host: str, port: int) -> None:
@@ -918,7 +913,7 @@ def run_auto(*, skip_confirm: bool = False) -> None:
 
     # Parse .env
     env = {}
-    for line in env_path.read_text(encoding=ENCODING_UTF8).splitlines():
+    for line in read_text_utf(env_path).splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
             continue

--- a/src/onemancompany/tools/mcp/config_builder.py
+++ b/src/onemancompany/tools/mcp/config_builder.py
@@ -12,9 +12,10 @@ import sys
 from pathlib import Path
 
 from onemancompany.core.config import (
-    EMPLOYEES_DIR, ENCODING_UTF8, ENV_OMC_EMPLOYEE_ID, ENV_OMC_PROJECT_DIR,
+    EMPLOYEES_DIR, ENV_OMC_EMPLOYEE_ID, ENV_OMC_PROJECT_DIR,
     ENV_OMC_PROJECT_ID, ENV_OMC_SERVER_URL, ENV_OMC_TASK_ID,
     MCP_CONFIG_FILENAME, TOOLS_DIR, WORKSPACE_DIR_NAME,
+    write_text_utf,
 )
 
 
@@ -89,5 +90,5 @@ def write_mcp_config(
     config = build_mcp_config(employee_id, task_id, project_id, project_dir, server_url)
     config_path = EMPLOYEES_DIR / employee_id / MCP_CONFIG_FILENAME
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    config_path.write_text(json.dumps(config, indent=2), encoding=ENCODING_UTF8)
+    write_text_utf(config_path, json.dumps(config, indent=2))
     return config_path


### PR DESCRIPTION
## Summary
- Windows uses GBK as default encoding. `open()` and `.read_text()` without explicit `encoding="utf-8"` fail on Chinese content (employee nicknames, culture items, etc.) with `UnicodeDecodeError: 'gbk' codec can't decode byte 0xa0`
- Fixed **82 call sites** across **18 files** — every `open()`, `.read_text()`, and `.write_text()` now specifies `encoding="utf-8"`
- `store.py` and `task_tree.py` already used `ENCODING_UTF8` — this brings the rest of the codebase in line

## Test plan
- [x] Verified zero remaining `open()` or `.read_text()` without encoding in core modules
- [x] Full test suite passes (2240 tests)
- [x] Compilation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)