### PR TITLE
fix: banner ASCII art alignment — short lines shift right

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.731",
+  "version": "0.2.732",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.731"
+version = "0.2.732"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -123,9 +123,16 @@ def _print_step(console: Console, num: int, codename: str, subtitle: str) -> Non
         padding=(0, 1),
     ))
 
+def _pad_art(text: str) -> str:
+    """Pad all lines in ASCII art to equal width so centering is uniform."""
+    lines = text.splitlines()
+    max_len = max((len(l) for l in lines), default=0)
+    return "\n".join(l.ljust(max_len) for l in lines)
+
+
 def _step_welcome(console: Console) -> None:
     console.print(Panel(
-        Text(LOGO, style="bold bright_cyan", justify="center"),
+        Text(_pad_art(LOGO), style="bold bright_cyan", justify="center"),
         border_style="bright_magenta",
         padding=(1, 2),
         expand=True,
@@ -830,14 +837,16 @@ def _step_done(console: Console, host: str, port: int) -> None:
     console.print()
     url = f"http://{'localhost' if host == '0.0.0.0' else host}:{port}"
     genesis_art = Text(
-        "░▒▓  ██████╗ ███████╗███╗   ██╗███████╗\n"
-        "░▒▓ ██╔════╝ ██╔════╝████╗  ██║██╔════╝\n"
-        "░▒▓ ██║  ███╗█████╗  ██╔██╗ ██║█████╗\n"
-        "░▒▓ ██║   ██║██╔══╝  ██║╚██╗██║██╔══╝\n"
-        "░▒▓ ╚██████╔╝███████╗██║ ╚████║███████╗\n"
-        "░▒▓  ╚═════╝ ╚══════╝╚═╝  ╚═══╝╚══════╝\n"
-        "\n"
-        "░▒▓  G E N E S I S   C O M P L E T E",
+        _pad_art(
+            "░▒▓  ██████╗ ███████╗███╗   ██╗███████╗\n"
+            "░▒▓ ██╔════╝ ██╔════╝████╗  ██║██╔════╝\n"
+            "░▒▓ ██║  ███╗█████╗  ██╔██╗ ██║█████╗\n"
+            "░▒▓ ██║   ██║██╔══╝  ██║╚██╗██║██╔══╝\n"
+            "░▒▓ ╚██████╔╝███████╗██║ ╚████║███████╗\n"
+            "░▒▓  ╚═════╝ ╚══════╝╚═╝  ╚═══╝╚══════╝\n"
+            "\n"
+            "░▒▓  G E N E S I S   C O M P L E T E"
+        ),
         style="bold bright_green",
         justify="center",
     )


### PR DESCRIPTION
## Summary
- LOGO and GENESIS banners have lines of different lengths
- Rich `justify="center"` centers each line independently, so shorter lines shift right
- Added `_pad_art()` helper that pads all lines to equal width with `ljust()` before rendering

## Test plan
- [x] Verified all lines now equal length (35 chars for LOGO, 39 for GENESIS)
- [x] Full test suite passes (2240 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)