### PR TITLE
fix: review spawn loop — 3 identical reviews then false CEO escalation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.732",
+  "version": "0.2.733",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.732"
+version = "0.2.733"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2124,6 +2124,32 @@ class EmployeeManager:
         if parent_node and parent_node.is_ceo_node:
             logger.debug("[ON_CHILD_COMPLETE] parent {} is CEO node — skipping review/auto-complete", parent_node.id)
             parent_node = None  # Skip propagation, fall through to project completion check
+
+        # --- Auto-accept orphaned COMPLETED children after REVIEW finishes ---
+        # MUST run BEFORE Gate 1/Gate 2 to prevent review spawn loop:
+        # without this, a finished review triggers Gate 2 which sees COMPLETED
+        # children and spawns another review, creating an infinite loop.
+        if node.node_type in SYSTEM_NODE_TYPES and parent_node:
+            completed_siblings = [
+                c for c in tree.get_active_children(parent_node.id)
+                if c.node_type not in SYSTEM_NODE_TYPES
+                and c.status == TaskPhase.COMPLETED.value
+            ]
+            if completed_siblings:
+                has_active_review = any(
+                    c for c in tree.get_active_children(parent_node.id)
+                    if c.node_type == NodeType.REVIEW
+                    and c.status in (TaskPhase.PENDING.value, TaskPhase.PROCESSING.value)
+                )
+                if not has_active_review:
+                    for c in completed_siblings:
+                        c.set_status(TaskPhase.ACCEPTED)
+                        c.acceptance_result = {"passed": True, "notes": "Auto-accepted: review completed without explicit accept/reject."}
+                        c.set_status(TaskPhase.FINISHED)
+                        logger.info("[ON_CHILD_COMPLETE] Auto-accepted orphaned COMPLETED node {} (review finished without tool call)", c.id)
+                    save_tree_async(entry.tree_path)
+                    # Re-check gates below with updated statuses (children now FINISHED).
+
         if parent_node and TaskPhase(parent_node.status) not in RESOLVED:
             children = tree.get_active_children(parent_node.id)
             non_review_children = [c for c in children if c.node_type not in SYSTEM_NODE_TYPES]
@@ -2293,37 +2319,6 @@ class EmployeeManager:
                 else:
                     logger.debug("[ON_CHILD_COMPLETE] parent={} — waiting (needs_review={}, active_review={})",
                                  parent_node.id, needs_review, has_active_review)
-
-        # --- Auto-accept orphaned COMPLETED children after REVIEW finishes ---
-        # If a REVIEW node finishes without explicitly accept_child/reject_child,
-        # the reviewed children stay stuck at COMPLETED forever. Auto-accept them.
-        if node.node_type in SYSTEM_NODE_TYPES and parent_node:
-            completed_siblings = [
-                c for c in tree.get_active_children(parent_node.id)
-                if c.node_type not in SYSTEM_NODE_TYPES
-                and c.status == TaskPhase.COMPLETED.value
-            ]
-            if completed_siblings:
-                has_active_review = any(
-                    c for c in tree.get_active_children(parent_node.id)
-                    if c.node_type == NodeType.REVIEW
-                    and c.status in (TaskPhase.PENDING.value, TaskPhase.PROCESSING.value)
-                )
-                if not has_active_review:
-                    for c in completed_siblings:
-                        c.set_status(TaskPhase.ACCEPTED)
-                        c.acceptance_result = {"passed": True, "notes": "Auto-accepted: review completed without explicit accept/reject."}
-                        c.set_status(TaskPhase.FINISHED)
-                        logger.info("[ON_CHILD_COMPLETE] Auto-accepted orphaned COMPLETED node {} (review finished without tool call)", c.id)
-                    save_tree_async(entry.tree_path)
-                    # Re-run completion check with updated statuses.
-                    # Safe recursion: parent is not a SYSTEM_NODE_TYPE, so the
-                    # auto-accept block above won't trigger again.
-                    parent_entry = ScheduleEntry(node_id=parent_node.id, tree_path=entry.tree_path)
-                    await self._on_child_complete_inner(
-                        parent_node.employee_id, parent_entry, project_id
-                    )
-                    return
 
         # --- Bottom-up project completion check ---
         # After any status change, check if the entire project tree is resolved.


### PR DESCRIPTION
## Summary
- **Root cause**: When a REVIEW node finished, `_on_child_complete_inner` ran Gate 2 (spawn review) BEFORE the auto-accept block. Gate 2 saw COMPLETED children and spawned another review. The auto-accept then ran too late — after the new review was already created.
- **Result**: 3 identical review nodes spawned in a loop, then escalated to CEO as "review deadlock". Also caused COO to dispatch duplicate tasks to employee 00007.
- **Fix**: Moved the auto-accept block BEFORE Gate 1/Gate 2. Now when a review finishes, COMPLETED siblings are accepted (→ FINISHED) first, then gates re-evaluate with correct statuses.

## Test plan
- [x] Full test suite passes (2240 tests)
- [ ] Manual: assign task → COO dispatches to HR → HR completes → single review → auto-accept → parent completes (no loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)