### PR TITLE
fix: CEO report truncated — used description_preview instead of full description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.733",
+  "version": "0.2.734",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.733"
+version = "0.2.734"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2605,12 +2605,13 @@ class EmployeeManager:
         """
         # Build completion summary from all children (skip CEO info nodes)
         _pdir = node.project_dir or str(Path(entry.tree_path).parent)
+        node.load_content(_pdir)
         children = [c for c in tree.get_children(node.id) if not c.is_ceo_node]
-        lines = [f"Project Completion Report — {node.description_preview}", ""]
+        lines = [f"Project Completion Report — {node.description}", ""]
         for i, child in enumerate(children, 1):
             status_icon = "✓" if child.status == TaskPhase.ACCEPTED else "●"
-            lines.append(f"{status_icon} Subtask {i} ({child.employee_id}): {child.title or child.description_preview}")
             child.load_content(_pdir)
+            lines.append(f"{status_icon} Subtask {i} ({child.employee_id}): {child.title or child.description}")
             lines.append(f"  Result: {child.result or 'None'}")
             lines.append("")
         summary = "\n".join(lines)


### PR DESCRIPTION
## Summary
- `_request_ceo_confirmation` built the report using `node.description_preview` (capped at 200 chars) and `child.description_preview`, truncating content mid-sentence
- Fix: call `load_content()` to populate the full `description` field, use `node.description` and `child.description` instead

## Test plan
- [x] Full test suite passes (2240 tests)
- [ ] Manual: complete a project → CEO report shows full task descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)