### PR TITLE
fix: orphaned COMPLETED nodes block project completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.734",
+  "version": "0.2.736",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.734"
+version = "0.2.736"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/task_persistence.py
+++ b/src/onemancompany/core/task_persistence.py
@@ -14,7 +14,7 @@ from loguru import logger
 import yaml
 
 from onemancompany.core.config import EMPLOYEES_DIR, PROJECT_YAML_FILENAME, TASK_TREE_FILENAME, read_text_utf
-from onemancompany.core.task_lifecycle import RESOLVED, TaskPhase
+from onemancompany.core.task_lifecycle import RESOLVED, TaskPhase, NodeType
 
 
 def _is_project_archived(tree_path: Path) -> bool:
@@ -79,6 +79,9 @@ def recover_schedule_from_trees(
                 save_tree_async(tree_path)
 
             for node in tree._nodes.values():
+                # CEO_PROMPT nodes are containers, not executable tasks — skip
+                if node.node_type in (NodeType.CEO_PROMPT, NodeType.CEO_PROMPT.value):
+                    continue
                 if node.status == TaskPhase.PENDING.value and tree.all_deps_resolved(node.id):
                     employee_manager.schedule_node(
                         node.employee_id, node.id, str(tree_path),
@@ -100,6 +103,7 @@ def recover_schedule_from_trees(
                 parent = tree.get_node(node.parent_id) if node.parent_id else None
                 if parent and TaskPhase(parent.status) in RESOLVED:
                     node.set_status(TaskPhase.ACCEPTED)
+                    node.acceptance_result = {"passed": True, "notes": "Auto-accepted on recovery: parent already resolved."}
                     node.set_status(TaskPhase.FINISHED)
                     orphan_modified = True
                     logger.info(
@@ -108,6 +112,23 @@ def recover_schedule_from_trees(
                     )
             if orphan_modified:
                 save_tree_async(tree_path)
+
+            # 1c. After orphan cleanup, check if the project is now fully complete.
+            # If so, advance CEO_PROMPT from PENDING → COMPLETED so the completion
+            # flow can pick it up on the next heartbeat or confirmation cycle.
+            if orphan_modified and tree.is_project_complete():
+                ea_node = tree.get_ea_node()
+                if ea_node:
+                    ceo_root = tree.get_node(ea_node.parent_id) if ea_node.parent_id else None
+                    if ceo_root and ceo_root.node_type in (NodeType.CEO_PROMPT, NodeType.CEO_PROMPT.value):
+                        if ceo_root.status == TaskPhase.PENDING.value:
+                            ceo_root.set_status(TaskPhase.PROCESSING)
+                            ceo_root.set_status(TaskPhase.COMPLETED)
+                            logger.info(
+                                "[RECOVERY] Project complete after orphan cleanup — "
+                                "CEO root {} → COMPLETED", ceo_root.id,
+                            )
+                            save_tree_async(tree_path)
 
     # 2. Scan system task trees (legacy system_tasks.yaml)
     if employees_dir.exists():

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2150,6 +2150,21 @@ class EmployeeManager:
                     save_tree_async(entry.tree_path)
                     # Re-check gates below with updated statuses (children now FINISHED).
 
+        # --- Auto-accept orphaned node whose parent is already RESOLVED ---
+        # When a node completes but its parent was already promoted (e.g. review
+        # finished before its dispatched child), the node is orphaned at COMPLETED.
+        # Auto-accept it so is_subtree_resolved() sees it as resolved.
+        if parent_node and TaskPhase(parent_node.status) in RESOLVED:
+            if node.status == TaskPhase.COMPLETED.value:
+                node.set_status(TaskPhase.ACCEPTED)
+                node.acceptance_result = {"passed": True, "notes": "Auto-accepted: parent already resolved."}
+                node.set_status(TaskPhase.FINISHED)
+                logger.info(
+                    "[ON_CHILD_COMPLETE] Auto-accepted orphaned node {} (parent {} already {})",
+                    node.id, parent_node.id, parent_node.status,
+                )
+                save_tree_async(entry.tree_path)
+
         if parent_node and TaskPhase(parent_node.status) not in RESOLVED:
             children = tree.get_active_children(parent_node.id)
             non_review_children = [c for c in children if c.node_type not in SYSTEM_NODE_TYPES]

--- a/tests/unit/core/test_orphan_completion.py
+++ b/tests/unit/core/test_orphan_completion.py
@@ -1,0 +1,269 @@
+"""Tests for orphaned node auto-accept and project completion propagation.
+
+Bug: When a regular task node completes but its parent is already RESOLVED,
+nobody accepts it → it stays COMPLETED forever → is_project_complete() returns
+False → CEO_PROMPT never advances → no retrospective.
+
+Three fixes covered:
+1. _on_child_complete_inner: auto-accept ANY node whose parent is RESOLVED
+2. recover_schedule_from_trees: re-check is_project_complete after orphan cleanup
+3. Recovery should skip CEO_PROMPT nodes from scheduling
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from onemancompany.core.task_lifecycle import NodeType, TaskPhase
+from onemancompany.core.task_tree import TaskTree, TaskNode
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_tree_with_orphan() -> tuple[TaskTree, Path]:
+    """Build tree matching the bug scenario:
+
+    CEO_PROMPT (pending)
+      └── EA task (finished)
+            ├── task_a (finished)
+            │   ├── leaf_1 (finished)
+            │   ├── review_1 (finished)
+            │   │   └── orphan_task (COMPLETED ← the bug)
+            │   └── review_2 (finished)
+            └── review_ea (finished)
+    """
+    tree = TaskTree(project_id="test/iter_001", mode="standard")
+
+    ceo = tree.create_root(employee_id="00001", description="CEO prompt")
+    ceo.node_type = NodeType.CEO_PROMPT.value
+    # CEO stays PENDING — this is the symptom
+
+    ea = tree.add_child(ceo.id, "00004", "EA dispatch", [])
+    ea.node_type = NodeType.TASK.value
+    ea.set_status(TaskPhase.PROCESSING)
+    ea.set_status(TaskPhase.COMPLETED)
+    ea.set_status(TaskPhase.ACCEPTED)
+    ea.set_status(TaskPhase.FINISHED)
+
+    task_a = tree.add_child(ea.id, "00003", "Task A", [])
+    task_a.node_type = NodeType.TASK.value
+    task_a.set_status(TaskPhase.PROCESSING)
+    task_a.set_status(TaskPhase.COMPLETED)
+    task_a.set_status(TaskPhase.ACCEPTED)
+    task_a.set_status(TaskPhase.FINISHED)
+
+    leaf_1 = tree.add_child(task_a.id, "00006", "Leaf task", [])
+    leaf_1.node_type = NodeType.TASK.value
+    leaf_1.set_status(TaskPhase.PROCESSING)
+    leaf_1.set_status(TaskPhase.COMPLETED)
+    leaf_1.set_status(TaskPhase.ACCEPTED)
+    leaf_1.set_status(TaskPhase.FINISHED)
+
+    review_1 = tree.add_child(task_a.id, "00003", "Review 1", [])
+    review_1.node_type = NodeType.REVIEW.value
+    review_1.set_status(TaskPhase.PROCESSING)
+    review_1.set_status(TaskPhase.COMPLETED)
+    review_1.set_status(TaskPhase.ACCEPTED)
+    review_1.set_status(TaskPhase.FINISHED)
+
+    # THE ORPHAN: review_1 dispatched this child, then review_1 was auto-finished.
+    # This task completed AFTER review_1 was already FINISHED.
+    orphan = tree.add_child(review_1.id, "00002", "Orphan task", [])
+    orphan.node_type = NodeType.TASK.value
+    orphan.set_status(TaskPhase.PROCESSING)
+    orphan.set_status(TaskPhase.COMPLETED)
+    # Stays COMPLETED — nobody accepts it because parent is FINISHED
+
+    review_2 = tree.add_child(task_a.id, "00003", "Review 2", [])
+    review_2.node_type = NodeType.REVIEW.value
+    review_2.set_status(TaskPhase.PROCESSING)
+    review_2.set_status(TaskPhase.COMPLETED)
+    review_2.set_status(TaskPhase.ACCEPTED)
+    review_2.set_status(TaskPhase.FINISHED)
+
+    review_ea = tree.add_child(ea.id, "00004", "Review EA", [])
+    review_ea.node_type = NodeType.REVIEW.value
+    review_ea.set_status(TaskPhase.PROCESSING)
+    review_ea.set_status(TaskPhase.COMPLETED)
+    review_ea.set_status(TaskPhase.ACCEPTED)
+    review_ea.set_status(TaskPhase.FINISHED)
+
+    return tree, orphan.id
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: _on_child_complete_inner auto-accepts orphaned non-system nodes
+# ---------------------------------------------------------------------------
+
+class TestOrphanAutoAccept:
+    """When any node completes and its parent is already RESOLVED,
+    auto-accept it to FINISHED."""
+
+    def test_orphan_blocks_project_completion(self):
+        """Verify the bug: orphaned COMPLETED node blocks is_project_complete."""
+        tree, orphan_id = _build_tree_with_orphan()
+        orphan = tree.get_node(orphan_id)
+        assert orphan.status == TaskPhase.COMPLETED.value
+        # The orphan's parent is FINISHED
+        parent = tree.get_node(orphan.parent_id)
+        assert parent.status == TaskPhase.FINISHED.value
+        # Project should NOT be complete because orphan is not RESOLVED
+        assert tree.is_project_complete() is False
+
+    def test_orphan_finished_allows_project_completion(self):
+        """If orphan is promoted to FINISHED, project should be complete."""
+        tree, orphan_id = _build_tree_with_orphan()
+        orphan = tree.get_node(orphan_id)
+        orphan.set_status(TaskPhase.ACCEPTED)
+        orphan.set_status(TaskPhase.FINISHED)
+        assert tree.is_project_complete() is True
+
+    @pytest.mark.asyncio
+    async def test_on_child_complete_auto_accepts_orphan(self):
+        """_on_child_complete_inner should auto-accept a non-system node
+        whose parent is already RESOLVED."""
+        tree, orphan_id = _build_tree_with_orphan()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tree_path = Path(tmpdir) / "task_tree.yaml"
+            tree.save(tree_path)
+
+            # Register tree in cache
+            from onemancompany.core.task_tree import register_tree, _cache
+            register_tree(tree_path, tree)
+
+            orphan = tree.get_node(orphan_id)
+
+            # Build minimal EmployeeManager
+            from onemancompany.core.vessel import EmployeeManager, ScheduleEntry
+            em = EmployeeManager.__new__(EmployeeManager)
+            em._pending_ceo_reports = {}
+            em._running_tasks = {}
+            em._schedule = {}
+            em._restart_pending = False
+            em.executors = {}
+            em._current_entries = {}
+            em._completion_queue = None
+            em._completion_consumer = None
+
+            # Mock methods that have side effects
+            em._publish_node_update = MagicMock()
+            em._request_ceo_confirmation = AsyncMock()
+            em._schedule_next = MagicMock()
+
+            entry = ScheduleEntry(node_id=orphan_id, tree_path=str(tree_path))
+
+            await em._on_child_complete_inner("00002", entry, "test/iter_001")
+
+            # Orphan should now be FINISHED
+            assert orphan.status == TaskPhase.FINISHED.value
+
+            # Clean up cache
+            _cache.pop(str(tree_path.resolve()), None)
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: Recovery triggers project completion check after orphan cleanup
+# ---------------------------------------------------------------------------
+
+class TestRecoveryProjectCompletion:
+    """recover_schedule_from_trees should re-check is_project_complete
+    after auto-finishing orphaned nodes."""
+
+    def test_recovery_auto_finishes_orphan(self):
+        """Existing behavior: recovery auto-finishes COMPLETED nodes with RESOLVED parent."""
+        tree, orphan_id = _build_tree_with_orphan()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tree_path = Path(tmpdir) / "iter_001" / "task_tree.yaml"
+            tree_path.parent.mkdir(parents=True)
+            tree.save(tree_path)
+
+            from onemancompany.core.task_tree import _cache
+            _cache.clear()
+
+            em = MagicMock()
+            em.schedule_node = MagicMock()
+
+            from onemancompany.core.task_persistence import recover_schedule_from_trees
+            recover_schedule_from_trees(em, Path(tmpdir), Path("/nonexistent"))
+
+            # Reload and check orphan is now finished
+            from onemancompany.core.task_tree import get_tree
+            reloaded = get_tree(tree_path)
+            orphan = reloaded.get_node(orphan_id)
+            assert orphan.status == TaskPhase.FINISHED.value
+
+            _cache.clear()
+
+    def test_recovery_triggers_completion_for_now_complete_project(self):
+        """After orphan cleanup, if project is now complete,
+        recovery should advance CEO_PROMPT and trigger completion flow."""
+        tree, orphan_id = _build_tree_with_orphan()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tree_path = Path(tmpdir) / "iter_001" / "task_tree.yaml"
+            tree_path.parent.mkdir(parents=True)
+            tree.save(tree_path)
+
+            from onemancompany.core.task_tree import _cache
+            _cache.clear()
+
+            em = MagicMock()
+            em.schedule_node = MagicMock()
+
+            from onemancompany.core.task_persistence import recover_schedule_from_trees
+            recover_schedule_from_trees(em, Path(tmpdir), Path("/nonexistent"))
+
+            # After recovery, project should be complete
+            from onemancompany.core.task_tree import get_tree
+            reloaded = get_tree(tree_path)
+            assert reloaded.is_project_complete() is True
+
+            # CEO_PROMPT should have been advanced past PENDING
+            ceo = reloaded.get_node(reloaded.root_id)
+            assert ceo.status != TaskPhase.PENDING.value, \
+                "CEO_PROMPT should not remain PENDING after project is complete"
+
+            _cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: Skip CEO_PROMPT nodes from scheduling
+# ---------------------------------------------------------------------------
+
+class TestRecoverySkipsCeoPrompt:
+    """CEO_PROMPT nodes should not be scheduled — they are containers."""
+
+    def test_recovery_does_not_schedule_ceo_prompt(self):
+        """CEO_PROMPT PENDING node should NOT be passed to schedule_node."""
+        tree, _ = _build_tree_with_orphan()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tree_path = Path(tmpdir) / "iter_001" / "task_tree.yaml"
+            tree_path.parent.mkdir(parents=True)
+            tree.save(tree_path)
+
+            from onemancompany.core.task_tree import _cache
+            _cache.clear()
+
+            em = MagicMock()
+            em.schedule_node = MagicMock()
+
+            from onemancompany.core.task_persistence import recover_schedule_from_trees
+            recover_schedule_from_trees(em, Path(tmpdir), Path("/nonexistent"))
+
+            # Check that schedule_node was never called with CEO employee ID
+            for call in em.schedule_node.call_args_list:
+                emp_id = call[0][0]  # First positional arg
+                assert emp_id != "00001", \
+                    f"schedule_node should not be called for CEO (00001), got: {call}"
+
+            _cache.clear()


### PR DESCRIPTION
## Summary
- **Root cause**: when a regular task node completes but its parent is already RESOLVED (e.g. review finished before its dispatched child), nobody accepts it — stays COMPLETED forever → `is_subtree_resolved()` returns False → `is_project_complete()` never True → CEO_PROMPT stays pending → no retrospective
- **Fix 1** (vessel.py): auto-accept ANY node whose parent is already RESOLVED, not just SYSTEM_NODE_TYPES
- **Fix 2** (task_persistence.py): after recovery auto-finishes orphaned nodes, re-check `is_project_complete()` and advance CEO_PROMPT
- **Fix 3** (task_persistence.py): skip CEO_PROMPT nodes from `schedule_node()` — they are containers, not executable tasks

## Evidence
Traced from omc-test-2 logs: node `bcd570ff49a2` completed at 14:38:08 but parent review `766bc61e99fe` was already FINISHED at 14:37:23. Gate 1/2 skipped because parent in RESOLVED. Orphan blocked `is_subtree_resolved()` → project never completed.

## Test plan
- [x] 6 new regression tests in `test_orphan_completion.py`
- [x] Full suite: 2245 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)