### PR TITLE
perf: parallelize WebSocket broadcast + 5s send timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.737",
+  "version": "0.2.738",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.737"
+version = "0.2.738"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/websocket.py
+++ b/src/onemancompany/api/websocket.py
@@ -25,13 +25,20 @@ class WebSocketManager:
     def disconnect(self, ws: WebSocket) -> None:
         self.connections.discard(ws)
 
+    _SEND_TIMEOUT = 5  # seconds — drop clients that stall beyond this
+
     async def broadcast(self, message: dict) -> None:
+        if not self.connections:
+            return
         dead: set[WebSocket] = set()
-        for ws in self.connections:
+
+        async def _send(ws: WebSocket):
             try:
-                await ws.send_json(message)
+                await asyncio.wait_for(ws.send_json(message), timeout=self._SEND_TIMEOUT)
             except Exception:
                 dead.add(ws)
+
+        await asyncio.gather(*[_send(ws) for ws in self.connections])
         self.connections -= dead
 
     async def event_broadcaster(self) -> None:

--- a/tests/unit/api/test_ws_broadcast_parallel.py
+++ b/tests/unit/api/test_ws_broadcast_parallel.py
@@ -1,0 +1,77 @@
+"""Test that WebSocket broadcast sends to all clients in parallel."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from onemancompany.api.websocket import WebSocketManager
+
+_WS_SEND_TIMEOUT = 5  # must match the constant in websocket.py
+
+
+@pytest.mark.asyncio
+async def test_broadcast_sends_in_parallel():
+    """Slow client should not block fast clients. All sends run concurrently."""
+    call_times = []
+
+    async def slow_send(msg):
+        call_times.append(time.monotonic())
+        await asyncio.sleep(0.1)
+
+    mgr = WebSocketManager()
+    for _ in range(3):
+        ws = MagicMock()
+        ws.send_json = AsyncMock(side_effect=slow_send)
+        mgr.connections.add(ws)
+
+    await mgr.broadcast({"type": "test"})
+
+    assert len(call_times) == 3
+    spread = max(call_times) - min(call_times)
+    assert spread < 0.05, f"Sends started {spread:.3f}s apart — not concurrent"
+
+
+@pytest.mark.asyncio
+async def test_broadcast_removes_dead_connections():
+    """Failed sends should remove the dead connection, not crash."""
+    mgr = WebSocketManager()
+
+    good_ws = MagicMock()
+    good_ws.send_json = AsyncMock()
+
+    bad_ws = MagicMock()
+    bad_ws.send_json = AsyncMock(side_effect=ConnectionError("gone"))
+
+    mgr.connections.add(good_ws)
+    mgr.connections.add(bad_ws)
+
+    await mgr.broadcast({"type": "test"})
+
+    assert good_ws in mgr.connections
+    assert bad_ws not in mgr.connections
+    good_ws.send_json.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_timeout_removes_stalled_connection():
+    """A client that stalls beyond timeout should be dropped."""
+    mgr = WebSocketManager()
+
+    stalled_ws = MagicMock()
+
+    async def stall_forever(msg):
+        await asyncio.sleep(100)  # way beyond timeout
+
+    stalled_ws.send_json = AsyncMock(side_effect=stall_forever)
+    mgr.connections.add(stalled_ws)
+
+    start = time.monotonic()
+    await mgr.broadcast({"type": "test"})
+    elapsed = time.monotonic() - start
+
+    assert stalled_ws not in mgr.connections
+    assert elapsed < _WS_SEND_TIMEOUT + 1, f"Broadcast took {elapsed:.1f}s — should timeout at {_WS_SEND_TIMEOUT}s"


### PR DESCRIPTION
## Summary
- Previously `broadcast()` sent to each client sequentially — one slow/stalled client blocked all others
- Now all sends run in parallel via `asyncio.gather()`, with a 5s `wait_for` timeout per client
- Stalled or dead connections are automatically dropped

## Test plan
- [x] 3 tests: parallel send verification, dead connection cleanup, timeout drop
- [x] Full test suite passes (2252 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)