### PR TITLE
fix: schedule_node dedup + resume_held_task guard (P2.3 + P2.4)

### DIFF
--- a/docs/superpowers/specs/2026-03-29-ceo-executor-audit.md
+++ b/docs/superpowers/specs/2026-03-29-ceo-executor-audit.md
@@ -1,0 +1,74 @@
+# CEO Interaction Audit — Complete Pathway Map
+
+> Generated 2026-03-29. Reference doc for CeoExecutor unified conversation redesign.
+> Check off each item as it's migrated to the new system.
+
+## OUTPUT (CEO -> System) — 5 paths
+
+| # | Path | Entry Point | Current Implementation | Migrated? |
+|---|------|-------------|------------------------|-----------|
+| 1 | **Submit new task** | `POST /api/ceo/task` (routes.py:465-525) | Creates CEO_PROMPT + EA child | [ ] |
+| 2 | **Reply to CEO_REQUEST** | `POST /api/ceo/inbox/{id}/open` -> `/message` -> `/complete` (routes.py:5926-6230) | ConversationSession dialog | [ ] |
+| 3 | **Confirm project completion** | `POST /api/ceo/report/{pid}/confirm` (routes.py:6303-6335) | `_confirm_ceo_report` | [ ] |
+| 4 | **Follow-up instruction** | `POST /api/iteration/{id}/continue` (routes.py:2860-2905) | Creates CEO_FOLLOWUP node | [ ] |
+| 5 | **1-on-1 meeting** | `POST /api/conversation/create` type=oneonone | conversation_adapters | [ ] |
+
+## INPUT (System -> CEO) — 4 paths
+
+| # | Path | Trigger | Current Implementation | Migrated? |
+|---|------|---------|------------------------|-----------|
+| A | **CEO_INBOX_UPDATED** | dispatch_child(CEO_ID) / circuit breaker | WebSocket event | [ ] |
+| B | **CEO_REPORT** | `_request_ceo_confirmation` (vessel.py:2608-2677) | WebSocket event + 120s auto-confirm | [ ] |
+| C | **CEO_TASK_SUBMITTED** | After CEO submits task | WebSocket event (activity log) | [ ] |
+| D | **EA auto-reply** | CEO response timeout | `_ea_auto_reply` decides on behalf of CEO | [ ] |
+
+## Special-case code to refactor
+
+| Location | Special Logic | Migrated? |
+|----------|---------------|-----------|
+| `tree_tools.py:165-180` | `dispatch_child(CEO_ID)` bypasses schedule_node, uses dedicated path | [ ] |
+| `vessel.py:2608-2677` | `_request_ceo_confirmation` + 120s auto-confirm timer | [ ] |
+| `vessel.py:2679-2690` | `_ceo_report_auto_confirm` timer task | [ ] |
+| `vessel.py:2706-2750` | `_confirm_ceo_report` advances CEO_PROMPT | [ ] |
+| `ceo_conversation.py` (entire module) | Independent ConversationSession system | [ ] |
+| `routes.py` 6 CEO endpoints | inbox CRUD + report confirm | [ ] |
+| `conversation_hooks.py:63-77` | `_close_ceo_inbox` hook | [ ] |
+
+## EventTypes to consolidate
+
+| EventType | File:Line | Current Use | Keep/Replace? |
+|-----------|-----------|-------------|---------------|
+| `CEO_TASK_SUBMITTED` | models.py:93 | Activity log when CEO submits task | [ ] |
+| `CEO_INBOX_UPDATED` | models.py:94 | Inbox refresh when CEO_REQUEST created | [ ] |
+| `CEO_REPORT` | models.py:95 | Project completion report | [ ] |
+
+## NodeTypes (keep as-is, handled by CeoExecutor)
+
+| NodeType | Meaning | CeoExecutor behavior |
+|----------|---------|---------------------|
+| `CEO_PROMPT` | Root container when CEO submits task | Skip execution (container) |
+| `CEO_FOLLOWUP` | CEO follow-up in existing tree | Route as new instruction |
+| `CEO_REQUEST` | Employee escalation to CEO | FIFO queue, wait for CEO reply |
+
+## No changes needed
+
+| Location | Reason |
+|----------|--------|
+| 1-on-1 meetings (routine.py) | Independent flow, not task-based |
+| CEO roster display (frontend) | Pure UI |
+| task-tree.js CEO node rendering | Display only |
+| FOUNDING_IDS config | Unchanged |
+| layout.py CEO_ID import | Color coding only |
+| agents/base.py:513 CEO escalation prompt | Agents still use dispatch_child("00001") |
+
+## Key files to modify
+
+| File | Changes |
+|------|---------|
+| `src/onemancompany/core/vessel.py` | Add CeoExecutor; register at startup; remove auto-confirm timer path |
+| `src/onemancompany/core/ceo_broker.py` (new) | FIFO queue, routing logic, Future resolution |
+| `src/onemancompany/core/ceo_conversation.py` | Refactor or replace — ConversationSession merges into CeoBroker |
+| `src/onemancompany/agents/tree_tools.py` | dispatch_child(CEO_ID) uses normal schedule_node path |
+| `src/onemancompany/api/routes.py` | Unified CEO conversation endpoint; deprecate separate inbox/report endpoints |
+| `src/onemancompany/core/task_persistence.py` | Recovery rebuilds CeoBroker pending queue from trees |
+| `frontend/app.js` | TUI conversation view |

--- a/docs/superpowers/specs/2026-03-29-ceo-executor-design.md
+++ b/docs/superpowers/specs/2026-03-29-ceo-executor-design.md
@@ -1,0 +1,208 @@
+# CEO Unified Conversation Model — Design Spec
+
+> Date: 2026-03-29
+> Status: Approved by CEO
+> Audit reference: `docs/superpowers/specs/2026-03-29-ceo-executor-audit.md`
+
+## Overview
+
+Replace all CEO interaction paths with a unified, per-project conversation model. CEO's interface becomes a multi-session TUI (like Claude Code), where each project has its own conversation session. System messages (employee requests, project reports) and CEO replies flow through the same conversation.
+
+## Core Model
+
+CEO interaction = multi-session conversation:
+- Each project has one `CeoSession` (independent conversation history + pending queue)
+- "New Task" creates a new project and session
+- System pushes messages INTO sessions (employee requests, completion reports)
+- CEO replies WITHIN sessions (responses route to the correct handler)
+
+## Architecture
+
+```
+CEO TUI
+├── Project list (left panel, sorted by pending-first)
+│   ├── ● Project A (has pending request)
+│   ├── Project B
+│   ├── ──────────
+│   ├── + New Task
+│   └── + Simple Task
+│
+└── Conversation panel (right, per-project)
+    ├── Message history (system + CEO messages)
+    └── Input box
+```
+
+### Components
+
+#### 1. CeoExecutor (vessel.py, implements Launcher)
+
+Registered for CEO_ID ("00001") at startup via `register()`.
+
+```
+execute(task_description, context) -> LaunchResult:
+  1. Resolve project_id from context
+  2. Build display message from task_description + source employee context
+  3. Create asyncio.Future
+  4. session = broker.get_or_create_session(project_id)
+  5. session.enqueue(CeoInteraction(message, future, node_id, ...))
+  6. Broadcast to frontend: new message in session
+  7. await future
+  8. return LaunchResult(output=ceo_response)
+```
+
+When a task is scheduled on CEO (via normal `schedule_node`), the executor:
+- Does NOT call any LLM
+- Pushes the request into the project's session as a system message
+- Waits for CEO to respond in the TUI
+- Returns CEO's text as the execution result
+
+#### 2. CeoBroker (new: ceo_broker.py)
+
+Central manager for all CEO sessions.
+
+```python
+class CeoBroker:
+    sessions: dict[str, CeoSession]  # project_id -> session
+
+    def get_or_create_session(project_id) -> CeoSession
+    def handle_input(project_id, text) -> None  # CEO typed something
+    def handle_new_task(text, attachments) -> str  # Returns project_id
+    def recover() -> None  # Rebuild from disk on restart
+    def list_sessions() -> list[SessionSummary]  # For project list UI
+```
+
+Singleton, accessible like `employee_manager`.
+
+#### 3. CeoSession (per-project conversation)
+
+```python
+class CeoSession:
+    project_id: str
+    pending: deque[CeoInteraction]  # FIFO queue of system requests
+    history: list[dict]  # Persisted conversation messages
+
+    def enqueue(interaction: CeoInteraction) -> None
+    def handle_input(text: str) -> None:
+        if pending:
+            interaction = pending.popleft()
+            interaction.future.set_result(text)
+            append_to_history("ceo", text)
+            broadcast_to_frontend()
+        else:
+            # No pending request — treat as follow-up instruction
+            dispatch_followup(text)
+
+    def push_system_message(message: str, source: str) -> None:
+        append_to_history("system", message, source=source)
+        broadcast_to_frontend()
+```
+
+#### 4. CeoInteraction (data structure)
+
+```python
+@dataclass
+class CeoInteraction:
+    node_id: str              # TaskNode being executed
+    tree_path: str
+    project_id: str
+    source_employee: str      # Who initiated the request
+    interaction_type: str     # "ceo_request" | "project_confirm"
+    message: str              # Display message for CEO
+    future: asyncio.Future    # Resolved when CEO replies
+    created_at: str
+```
+
+### Routing Logic
+
+```
+CEO input arrives with project_id:
+  │
+  ├─ project_id exists, session has pending queue:
+  │   → pop front of queue, resolve Future with CEO's text
+  │   → CeoExecutor.execute() returns, node completes normally
+  │
+  ├─ project_id exists, no pending queue:
+  │   → treat as CEO_FOLLOWUP instruction
+  │   → create followup node in project tree
+  │
+  └─ "New Task" (no project_id):
+      → create new project via existing _dispatch_ceo_task logic
+      → new CeoSession created automatically
+```
+
+### Project List UI State
+
+Each project in the left panel shows:
+- `●` (dot indicator) — has pending CeoInteraction(s) needing CEO attention
+- No indicator — running normally, CEO can still send follow-up instructions
+- Sorted: pending-first, then by recency
+
+## Migration Plan
+
+### Paths replaced by CeoExecutor + CeoBroker
+
+| Current path | New path |
+|-------------|----------|
+| `dispatch_child(CEO_ID)` special case in tree_tools.py | Normal `schedule_node` → CeoExecutor → CeoBroker session |
+| Circuit breaker CEO escalation (vessel.py:2413-2482) | Normal `schedule_node` → CeoExecutor → CeoBroker session |
+| `_request_ceo_confirmation` + 120s auto-confirm timer | CeoExecutor scheduled for project confirm → CeoBroker session |
+| `POST /api/ceo/inbox/{id}/open,message,complete,dismiss` | `POST /api/ceo/session/{project_id}/message` (unified) |
+| `POST /api/ceo/report/{pid}/confirm` | CEO replies in session (same input path) |
+| `POST /api/ceo/task` | `POST /api/ceo/session/new` or "New Task" button |
+| `ceo_conversation.py` ConversationSession | Replaced by CeoSession |
+
+### Code to remove after migration
+
+- `ceo_conversation.py` — entire module (ConversationSession, _ea_auto_reply, etc.)
+- `vessel.py` — `_request_ceo_confirmation`, `_ceo_report_auto_confirm`, `_confirm_ceo_report`, `CEO_REPORT_CONFIRM_DELAY`, `_pending_ceo_reports`
+- `routes.py` — 6 CEO inbox endpoints, report confirm endpoint
+- `conversation_hooks.py` — `_close_ceo_inbox` hook
+- `tree_tools.py:165-180` — CEO_ID special path in dispatch_child
+
+### Code to keep as-is
+
+- 1-on-1 meetings (independent system, not task-based)
+- CEO roster display (pure UI)
+- task-tree.js CEO node rendering (display only)
+- `agents/base.py` CEO escalation prompt (agents still call dispatch_child("00001"))
+
+### EventTypes
+
+| Event | Action |
+|-------|--------|
+| `CEO_TASK_SUBMITTED` | Keep — activity log |
+| `CEO_INBOX_UPDATED` | Replace with `CEO_SESSION_MESSAGE` (per-session message event) |
+| `CEO_REPORT` | Remove — project reports go through CeoSession |
+
+### Persistence
+
+Session history persisted as YAML per project:
+```
+{project_dir}/ceo_session.yaml
+```
+
+Contains conversation messages (system + CEO), not pending Futures (those are in-memory, rebuilt from tree state on restart).
+
+### Restart Recovery
+
+`CeoBroker.recover()` called during startup:
+1. Scan all non-archived project trees
+2. For each tree, find PENDING CEO_REQUEST/CEO_PROMPT nodes assigned to CEO_ID
+3. Rebuild CeoInteraction for each → enqueue in corresponding CeoSession
+4. Project confirm: find trees where `is_project_complete()` and CEO_PROMPT is COMPLETED → enqueue confirm interaction
+
+### EA Auto-Reply
+
+EA auto-reply behavior changes:
+- Currently: EA replies on CEO's behalf after timeout in ConversationSession
+- New: configurable per-session timeout in CeoBroker; if CEO doesn't respond within N seconds, CeoBroker auto-resolves the Future with EA's decision
+- Implementation: `CeoSession.set_auto_reply(timeout_seconds)` starts a timer per pending interaction
+
+## Success Criteria
+
+1. All CEO interactions go through TUI conversation (zero separate endpoints)
+2. Each project has independent conversation context
+3. Pending requests are FIFO within each session
+4. System survives restart — pending queue rebuilt from tree state
+5. No duplicate systems — old paths fully removed
+6. All existing tests pass + new tests for CeoExecutor, CeoBroker, CeoSession

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.741",
+  "version": "0.2.742",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.739",
+  "version": "0.2.740",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.738",
+  "version": "0.2.739",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.740",
+  "version": "0.2.741",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.740"
+version = "0.2.741"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.739"
+version = "0.2.740"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.738"
+version = "0.2.739"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.741"
+version = "0.2.742"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -722,7 +722,7 @@ class EmployeeManager:
     # ------------------------------------------------------------------
 
     def schedule_node(self, employee_id: str, node_id: str, tree_path: str) -> None:
-        """Add a node to the employee's schedule."""
+        """Add a node to the employee's schedule (idempotent — skips duplicates)."""
         # Always persist to task index for taskboard visibility
         from onemancompany.core.store import append_task_index_entry
         append_task_index_entry(employee_id, node_id, tree_path)
@@ -734,8 +734,11 @@ class EmployeeManager:
                 employee_id, node_id,
             )
             return
-        entry = ScheduleEntry(node_id=node_id, tree_path=tree_path)
-        self._schedule.setdefault(employee_id, []).append(entry)
+        entries = self._schedule.setdefault(employee_id, [])
+        if any(e.node_id == node_id for e in entries):
+            logger.debug("[SCHEDULE] node {} already in schedule for {}, skipping", node_id, employee_id)
+            return
+        entries.append(ScheduleEntry(node_id=node_id, tree_path=tree_path))
 
     def unschedule(self, employee_id: str, node_id: str) -> None:
         """Remove a completed/failed node from schedule."""

--- a/tests/unit/core/test_schedule_dedup.py
+++ b/tests/unit/core/test_schedule_dedup.py
@@ -17,7 +17,7 @@ class TestScheduleNodeDedup:
         em._schedule = {}
         em.executors = {"emp1": MagicMock()}
 
-        with patch("onemancompany.core.vessel._store"):
+        with patch("onemancompany.core.store.append_task_index_entry"):
             em.schedule_node("emp1", "node1", "/path/tree.yaml")
             em.schedule_node("emp1", "node1", "/path/tree.yaml")
 
@@ -30,13 +30,26 @@ class TestScheduleNodeDedup:
         em._schedule = {}
         em.executors = {"emp1": MagicMock()}
 
-        with patch("onemancompany.core.vessel._store"):
+        with patch("onemancompany.core.store.append_task_index_entry"):
             em.schedule_node("emp1", "node1", "/path/tree.yaml")
             em.schedule_node("emp1", "node2", "/path/tree.yaml")
 
         entries = em._schedule["emp1"]
         node_ids = [e.node_id for e in entries]
         assert node_ids == ["node1", "node2"]
+
+    def test_same_node_different_tree_path_still_deduped(self):
+        """node_id is globally unique — different tree_path should not create duplicate."""
+        em = EmployeeManager.__new__(EmployeeManager)
+        em._schedule = {}
+        em.executors = {"emp1": MagicMock()}
+
+        with patch("onemancompany.core.store.append_task_index_entry"):
+            em.schedule_node("emp1", "node1", "/path/tree_v1.yaml")
+            em.schedule_node("emp1", "node1", "/path/tree_v2.yaml")
+
+        entries = em._schedule["emp1"]
+        assert len(entries) == 1
 
 
 class TestResumeHeldTaskGuard:

--- a/tests/unit/core/test_schedule_dedup.py
+++ b/tests/unit/core/test_schedule_dedup.py
@@ -1,0 +1,72 @@
+"""Tests for schedule_node dedup and resume_held_task double-call guard."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from onemancompany.core.vessel import EmployeeManager, ScheduleEntry
+
+
+class TestScheduleNodeDedup:
+    """schedule_node must not create duplicate entries for the same node_id."""
+
+    def test_no_duplicate_entries(self):
+        em = EmployeeManager.__new__(EmployeeManager)
+        em._schedule = {}
+        em.executors = {"emp1": MagicMock()}
+
+        with patch("onemancompany.core.vessel._store"):
+            em.schedule_node("emp1", "node1", "/path/tree.yaml")
+            em.schedule_node("emp1", "node1", "/path/tree.yaml")
+
+        entries = em._schedule["emp1"]
+        node_ids = [e.node_id for e in entries]
+        assert node_ids == ["node1"], f"Expected 1 entry, got {len(node_ids)}: {node_ids}"
+
+    def test_different_nodes_both_added(self):
+        em = EmployeeManager.__new__(EmployeeManager)
+        em._schedule = {}
+        em.executors = {"emp1": MagicMock()}
+
+        with patch("onemancompany.core.vessel._store"):
+            em.schedule_node("emp1", "node1", "/path/tree.yaml")
+            em.schedule_node("emp1", "node2", "/path/tree.yaml")
+
+        entries = em._schedule["emp1"]
+        node_ids = [e.node_id for e in entries]
+        assert node_ids == ["node1", "node2"]
+
+
+class TestResumeHeldTaskGuard:
+    """resume_held_task must guard against double-resume (idempotent)."""
+
+    @pytest.mark.asyncio
+    async def test_second_resume_returns_false(self):
+        """If a task was already resumed (no longer HOLDING), return False."""
+        em = EmployeeManager.__new__(EmployeeManager)
+        em._schedule = {}
+        em.executors = {"emp1": MagicMock()}
+        em._running_tasks = {}
+        em._hooks = {}
+        em._deferred_schedule = set()
+        em._event_loop = None
+        em._employees = {}
+        em._completion_queue = None
+        em._completion_consumer = None
+        em._pending_ceo_reports = {}
+
+        mock_node = MagicMock()
+        mock_node.status = "completed"  # already resumed
+        mock_node.node_type = "task"
+        mock_tree = MagicMock()
+        mock_tree.get_node.return_value = mock_node
+
+        entry = ScheduleEntry(node_id="task1", tree_path="/fake/tree.yaml")
+        em._schedule["emp1"] = [entry]
+
+        with patch("onemancompany.core.task_tree.get_tree", return_value=mock_tree):
+            result = await em.resume_held_task("emp1", "task1", "some result")
+
+        assert result is False, "Second resume should return False (not HOLDING)"


### PR DESCRIPTION
## Summary
- **P2.4 schedule_node dedup**: `schedule_node()` now checks for existing `node_id` before appending, preventing duplicate entries from repeated calls
- **P2.3 resume_held_task guard**: Verified existing guard (`status != HOLDING → return False`) is sufficient — asyncio single-threaded execution prevents true race conditions

## Test plan
- [x] 3 new tests: dedup prevents duplicates, different nodes both added, second resume returns False
- [x] Full test suite passes (2256 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)