### PR TITLE
fix: auto-accept missing dep resolution — dependents stuck PENDING forever

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.743",
+  "version": "0.2.744",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.742",
+  "version": "0.2.743",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.743"
+version = "0.2.744"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.742"
+version = "0.2.743"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2151,6 +2151,11 @@ class EmployeeManager:
                         c.set_status(TaskPhase.FINISHED)
                         logger.info("[ON_CHILD_COMPLETE] Auto-accepted orphaned COMPLETED node {} (review finished without tool call)", c.id)
                     save_tree_async(entry.tree_path)
+                    # Trigger dep resolution for each auto-accepted node so
+                    # downstream tasks waiting on them get unblocked.
+                    _pdir = parent_node.project_dir or str(Path(entry.tree_path).parent)
+                    for c in completed_siblings:
+                        _trigger_dep_resolution(_pdir, tree, c)
                     # Re-check gates below with updated statuses (children now FINISHED).
 
         # --- Auto-accept orphaned node whose parent is already RESOLVED ---
@@ -2167,6 +2172,8 @@ class EmployeeManager:
                     node.id, parent_node.id, parent_node.status,
                 )
                 save_tree_async(entry.tree_path)
+                _pdir = node.project_dir or str(Path(entry.tree_path).parent)
+                _trigger_dep_resolution(_pdir, tree, node)
 
         if parent_node and TaskPhase(parent_node.status) not in RESOLVED:
             children = tree.get_active_children(parent_node.id)

--- a/tests/unit/core/test_auto_accept_dep_resolution.py
+++ b/tests/unit/core/test_auto_accept_dep_resolution.py
@@ -1,0 +1,90 @@
+"""Regression: auto-accept must trigger _trigger_dep_resolution for dependents."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+from onemancompany.core.task_lifecycle import TaskPhase, NodeType
+
+
+@pytest.mark.asyncio
+async def test_auto_accept_triggers_dep_resolution():
+    """When a review finishes and siblings are auto-accepted,
+    _trigger_dep_resolution must be called for each so downstream
+    tasks with depends_on get unblocked."""
+    from onemancompany.core.vessel import EmployeeManager, ScheduleEntry
+
+    em = EmployeeManager.__new__(EmployeeManager)
+    em._schedule = {}
+    em.executors = {"emp1": MagicMock()}
+    em._running_tasks = {}
+    em._hooks = {}
+    em._deferred_schedule = set()
+    em._event_loop = None
+    em._employees = {}
+    em._completion_queue = None
+    em._completion_consumer = None
+    em._pending_ceo_reports = {}
+
+    # Build a minimal tree: parent → [child_task (COMPLETED), review (FINISHED)]
+    child_task = MagicMock()
+    child_task.id = "child1"
+    child_task.node_type = NodeType.TASK
+    child_task.status = TaskPhase.COMPLETED.value
+    child_task.is_ceo_node = False
+    child_task.branch_active = True
+    child_task.project_dir = "/fake/project"
+    child_task.set_status = MagicMock()
+    child_task.acceptance_result = None
+
+    review_node = MagicMock()
+    review_node.id = "review1"
+    review_node.node_type = NodeType.REVIEW
+    review_node.status = TaskPhase.FINISHED.value
+    review_node.parent_id = "parent1"
+    review_node.is_ceo_node = False
+    review_node.branch_active = True
+    review_node.project_dir = "/fake/project"
+    review_node.project_id = "proj1"
+
+    parent_node = MagicMock()
+    parent_node.id = "parent1"
+    parent_node.status = TaskPhase.HOLDING.value
+    parent_node.is_ceo_node = False
+    parent_node.node_type = NodeType.TASK
+    parent_node.project_dir = "/fake/project"
+
+    mock_tree = MagicMock()
+    mock_tree.get_node = lambda nid: {
+        "review1": review_node,
+        "parent1": parent_node,
+        "child1": child_task,
+    }.get(nid)
+    mock_tree.get_active_children = MagicMock(return_value=[child_task, review_node])
+    mock_tree.get_children = MagicMock(return_value=[child_task, review_node])
+    mock_tree.is_project_complete = MagicMock(return_value=False)
+    mock_tree.mode = "standard"
+
+    entry = ScheduleEntry(node_id="review1", tree_path="/fake/tree.yaml")
+    em._schedule["emp1"] = [entry]
+
+    with patch("onemancompany.core.task_tree.get_tree", return_value=mock_tree), \
+         patch("onemancompany.core.task_tree.save_tree_async"), \
+         patch("onemancompany.core.vessel._trigger_dep_resolution") as mock_dep_res, \
+         patch("onemancompany.core.vessel._store") as mock_store, \
+         patch("onemancompany.core.vessel.Path") as mock_path:
+        mock_path.return_value.exists.return_value = True
+        mock_path.return_value.parent = "/fake"
+        mock_store.save_project_status = AsyncMock()
+        mock_store.save_employee_runtime = AsyncMock()
+
+        await em._on_child_complete_inner("emp1", entry, project_id="proj1")
+
+        # _trigger_dep_resolution must have been called for auto-accepted child
+        assert mock_dep_res.called, "_trigger_dep_resolution was not called after auto-accept"
+        # Should be called with the child_task node (the one that was auto-accepted)
+        call_args = mock_dep_res.call_args_list
+        resolved_nodes = [c.args[2] for c in call_args]
+        assert child_task in resolved_nodes, f"Expected child_task in resolved nodes, got {resolved_nodes}"


### PR DESCRIPTION
## Summary
- **Root cause**: When `_on_child_complete_inner` auto-accepted COMPLETED nodes (after review finished without explicit accept/reject), it set them to FINISHED but **never called `_trigger_dep_resolution()`**
- Downstream tasks with `depends_on` pointing to these nodes stayed PENDING forever — the dependency system was never notified
- This is why employee 00007's task was stuck: its 2 dependencies were auto-accepted to FINISHED, but no one told the scheduler to unblock 00007

## Fix
Added `_trigger_dep_resolution()` calls to both auto-accept paths:
1. Review-triggered auto-accept (completed siblings after review finishes)
2. Orphaned node auto-accept (parent already resolved)

## Test plan
- [x] Full test suite passes (2257 tests)
- [ ] Manual: task with depends_on → deps auto-accepted → dependent task should start

🤖 Generated with [Claude Code](https://claude.com/claude-code)