### PR TITLE
fix: banner alignment v2 — Align.center() instead of justify="center"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.2.744",
+  "version": "0.2.745",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.2.744"
+version = "0.2.745"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -10,6 +10,7 @@ import shutil
 from pathlib import Path
 
 import httpx
+from rich.align import Align
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -124,7 +125,12 @@ def _print_step(console: Console, num: int, codename: str, subtitle: str) -> Non
     ))
 
 def _pad_art(text: str) -> str:
-    """Pad all lines in ASCII art to equal width so centering is uniform."""
+    """Pad all lines in ASCII art to equal width with trailing spaces.
+
+    Rich's justify="center" strips trailing spaces before centering,
+    so we must NOT rely on ljust + center. Instead, the art is rendered
+    with justify="left" inside a centered Align wrapper.
+    """
     lines = text.splitlines()
     max_len = max((len(l) for l in lines), default=0)
     return "\n".join(l.ljust(max_len) for l in lines)
@@ -132,7 +138,7 @@ def _pad_art(text: str) -> str:
 
 def _step_welcome(console: Console) -> None:
     console.print(Panel(
-        Text(_pad_art(LOGO), style="bold bright_cyan", justify="center"),
+        Align.center(Text(_pad_art(LOGO), style="bold bright_cyan")),
         border_style="bright_magenta",
         padding=(1, 2),
         expand=True,
@@ -848,9 +854,8 @@ def _step_done(console: Console, host: str, port: int) -> None:
             "░▒▓  G E N E S I S   C O M P L E T E"
         ),
         style="bold bright_green",
-        justify="center",
     )
-    console.print(Panel(genesis_art, border_style="bright_green", expand=True, padding=(1, 2)))
+    console.print(Panel(Align.center(genesis_art), border_style="bright_green", expand=True, padding=(1, 2)))
     console.print(Panel(
         "  [bright_cyan]Your company is online. Neural cores activated.[/bright_cyan]\n\n"
         "  [bold]FOUNDING TEAM DEPLOYED:[/bold]\n"


### PR DESCRIPTION
## Summary
- Previous fix (PR #185) used `ljust()` + `justify="center"` but Rich strips trailing spaces before centering, so short lines still misaligned
- **Fix**: Use `Align.center()` wrapper which centers the entire text block as a unit, preserving internal line alignment. Removed `justify="center"` from Text.

## Test plan
- [x] Full test suite passes (2258 tests)
- [ ] Manual: `npx onemancompany` → LOGO and GENESIS banners should have all lines aligned

🤖 Generated with [Claude Code](https://claude.com/claude-code)