### PR TITLE
fix: empty api_provider in profile falls back to field defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.22"
+version = "0.3.23"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.23"
+version = "0.3.24"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
+from typing import ClassVar
 
 import yaml
 from loguru import logger
@@ -492,19 +493,21 @@ class EmployeeConfig(BaseModel):
     api_provider: str = "openrouter"  # provider name from PROVIDER_REGISTRY
     api_key: str = ""  # Custom API key (used when api_provider != default)
     hosting: str = "company"  # "company" | "self" | "openclaw" — also serves as agent family selector
+    auth_method: str = "api_key"  # "api_key" | "oauth" (OAuth PKCE for Anthropic)
+    oauth_refresh_token: str = ""  # OAuth refresh token (long-lived)
+
+    # Fields where empty string should be treated as missing (use field default)
+    _NON_EMPTY_FIELDS: ClassVar[frozenset] = frozenset({"api_provider", "hosting", "auth_method"})
 
     @model_validator(mode="before")
     @classmethod
     def _normalize_empty_strings(cls, data):
         """Treat empty strings as missing so Pydantic uses field defaults."""
-        _FIELDS_WITH_DEFAULTS = {"api_provider": "openrouter", "hosting": "company"}
         if isinstance(data, dict):
-            for field, default in _FIELDS_WITH_DEFAULTS.items():
-                if not data.get(field):
-                    data[field] = default
+            for field_name in cls._NON_EMPTY_FIELDS:
+                if not data.get(field_name):
+                    data[field_name] = cls.model_fields[field_name].default
         return data
-    auth_method: str = "api_key"  # "api_key" | "oauth" (OAuth PKCE for Anthropic)
-    oauth_refresh_token: str = ""  # OAuth refresh token (long-lived)
 
 
 class Settings(BaseSettings):

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import yaml
 from loguru import logger
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Source root — for package-relative resources (frontend, talent_market, etc.)
@@ -490,8 +490,19 @@ class EmployeeConfig(BaseModel):
     pip: dict | None = None  # Performance Improvement Plan (if active)
     onboarding_completed: bool = False  # set True after onboarding routine
     api_provider: str = "openrouter"  # provider name from PROVIDER_REGISTRY
-    api_key: str = ""  # Custom API key (used when api_provider != "openrouter")
+    api_key: str = ""  # Custom API key (used when api_provider != default)
     hosting: str = "company"  # "company" | "self" | "openclaw" — also serves as agent family selector
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_empty_strings(cls, data):
+        """Treat empty strings as missing so Pydantic uses field defaults."""
+        _FIELDS_WITH_DEFAULTS = {"api_provider": "openrouter", "hosting": "company"}
+        if isinstance(data, dict):
+            for field, default in _FIELDS_WITH_DEFAULTS.items():
+                if not data.get(field):
+                    data[field] = default
+        return data
     auth_method: str = "api_key"  # "api_key" | "oauth" (OAuth PKCE for Anthropic)
     oauth_refresh_token: str = ""  # OAuth refresh token (long-lived)
 


### PR DESCRIPTION
## Summary
- Talent market employees get `api_provider: ''` in profile.yaml, which overwrote the Pydantic default `"openrouter"`
- Added `model_validator` to `EmployeeConfig` that normalizes empty strings to field defaults for `api_provider` and `hosting`
- Eliminates `Provider '' has no key, falling back to openrouter default` debug spam

## Root cause
YAML `api_provider: ''` is an explicit empty string, not a missing field. Pydantic treats it as a valid value and doesn't apply the field default.

## Test plan
- [x] 2250 unit tests pass
- [x] Verified: `EmployeeConfig(api_provider='')` → `api_provider='openrouter'`
- [x] Verified: `EmployeeConfig(api_provider='anthropic')` → preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)