### PR TITLE
chore: move meetings to /slash commands, remove toolbar button

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -797,9 +797,7 @@ class AppController {
 
     // 1-on-1 meeting modal bindings
     const oneononeModal = document.getElementById('oneonone-modal');
-    document.getElementById('guidance-toolbar-btn')?.addEventListener('click', () => {
-      oneononeModal.classList.remove('hidden');
-    });
+    // Meeting button removed from toolbar — meetings now via /1on1, /allhands, /discuss
     document.getElementById('oneonone-close-btn').addEventListener('click', () => this.closeOneononeModal());
     document.getElementById('oneonone-close-btn2').addEventListener('click', () => this.closeOneononeModal());
     oneononeModal.addEventListener('click', (e) => {
@@ -2374,10 +2372,12 @@ class AppController {
       }},
       { cmd: '/allhands', desc: 'Start All-Hands meeting (CEO address)', action: () => {
         this._ceoTerm?.appendMessage({ role: 'system', text: 'Starting All-Hands meeting...', source: 'system' });
+        document.getElementById('oneonone-modal')?.classList.remove('hidden');
         this._startGroupMeeting('all_hands');
       }},
       { cmd: '/discuss', desc: 'Start discussion meeting (open floor)', action: () => {
         this._ceoTerm?.appendMessage({ role: 'system', text: 'Starting discussion meeting...', source: 'system' });
+        document.getElementById('oneonone-modal')?.classList.remove('hidden');
         this._startGroupMeeting('discussion');
       }},
       { cmd: '/attach', desc: 'Attach file or image', action: () => document.getElementById('ceo-file-input')?.click() },

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -797,7 +797,7 @@ class AppController {
 
     // 1-on-1 meeting modal bindings
     const oneononeModal = document.getElementById('oneonone-modal');
-    document.getElementById('guidance-toolbar-btn').addEventListener('click', () => {
+    document.getElementById('guidance-toolbar-btn')?.addEventListener('click', () => {
       oneononeModal.classList.remove('hidden');
     });
     document.getElementById('oneonone-close-btn').addEventListener('click', () => this.closeOneononeModal());
@@ -2363,6 +2363,22 @@ class AppController {
           .catch(e => {
             this._ceoTerm?.appendMessage({ role: 'system', text: `Review error: ${e.message}`, source: 'system' });
           });
+      }},
+      { cmd: '/1on1', desc: 'Start 1-on-1 meeting with an employee', action: () => {
+        const modal = document.getElementById('oneonone-modal');
+        if (modal) {
+          document.getElementById('meeting-type-select').value = 'oneonone';
+          document.getElementById('meeting-type-select').dispatchEvent(new Event('change'));
+          modal.classList.remove('hidden');
+        }
+      }},
+      { cmd: '/allhands', desc: 'Start All-Hands meeting (CEO address)', action: () => {
+        this._ceoTerm?.appendMessage({ role: 'system', text: 'Starting All-Hands meeting...', source: 'system' });
+        this._startGroupMeeting('all_hands');
+      }},
+      { cmd: '/discuss', desc: 'Start discussion meeting (open floor)', action: () => {
+        this._ceoTerm?.appendMessage({ role: 'system', text: 'Starting discussion meeting...', source: 'system' });
+        this._startGroupMeeting('discussion');
       }},
       { cmd: '/attach', desc: 'Attach file or image', action: () => document.getElementById('ceo-file-input')?.click() },
     ];

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -43,7 +43,7 @@
           <span class="status-item" id="employee-count">&#128101; 2</span>
           <span class="status-item status-clickable" id="tool-count" onclick="window.app.openToolList()">&#128295; 0</span>
           <span class="status-item" id="room-count">&#127970; 0/0</span>
-          <button id="guidance-toolbar-btn" class="toolbar-icon-btn" title="Meeting">&#127891;</button>
+          <!-- Meeting moved to /meeting slash command in CEO console -->
           <button id="ex-employee-toolbar-btn" class="toolbar-icon-btn" title="Ex-Employee Wall">&#128220;</button>
           <button id="company-culture-toolbar-btn" class="toolbar-icon-btn" title="Company Culture">&#127988;</button>
           <button id="company-direction-toolbar-btn" class="toolbar-icon-btn" title="Company Direction">&#127919;</button>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.34"
+version = "0.3.35"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.33"
+version = "0.3.34"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- `/1on1` — opens 1-on-1 meeting modal with employee selector
- `/allhands` — starts All-Hands meeting directly
- `/discuss` — starts Discussion meeting directly
- Removed 🎓 Meeting toolbar button (guidance-toolbar-btn)

## Test plan
- [x] 2255 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)