### PR TITLE
feat: CEO console defaults to EA chat with sidebar Chat button

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2112,6 +2112,7 @@ class AppController {
 
   // ===== CEO Terminal (two-column: project list + xterm conversation) ===== //
 
+  _EA_CHAT = '_ea_chat';  // Reserved sentinel — not a real project ID
   _currentCeoProject = null;  // Currently selected project_id (session-level, e.g. "proj/iter_001")
 
   async _initCeoTerminal() {
@@ -2206,7 +2207,7 @@ class AppController {
         return;
       }
 
-      if (!this._currentCeoProject || this._currentCeoProject === '_ea_chat') {
+      if (!this._currentCeoProject || this._currentCeoProject === this._EA_CHAT) {
         // New task from EA chat (simple or standard mode)
         const mode = this._pendingSimpleMode ? 'simple' : 'standard';
         this._pendingSimpleMode = false;
@@ -2316,15 +2317,15 @@ class AppController {
   }
 
   _openEaChat() {
-    this._currentCeoProject = null;
-    this._currentConvId = null;
-    this._currentConvType = null;
-    // Update active states
+    // Clear pending modes that could interfere
+    this._pendingIterProject = null;
+    this._pendingSimpleMode = false;
+    // Update active states in sidebar
     document.querySelectorAll('.ceo-proj-item').forEach(el => el.classList.remove('active'));
     document.querySelectorAll('.ceo-oneonone-item').forEach(el => el.classList.remove('active'));
     document.getElementById('ceo-chat-btn')?.classList.add('active');
-    // Load EA session
-    this._selectCeoProject('_ea_chat');
+    // Delegate to _selectCeoProject which handles all state clearing
+    this._selectCeoProject(this._EA_CHAT);
   }
 
   // --- Slash command menu --- //
@@ -2465,11 +2466,11 @@ class AppController {
 
     // Update Chat button active state
     const chatBtn = document.getElementById('ceo-chat-btn');
-    chatBtn?.classList.toggle('active', this._currentCeoProject === '_ea_chat' || !this._currentCeoProject);
+    chatBtn?.classList.toggle('active', this._currentCeoProject === this._EA_CHAT || !this._currentCeoProject);
 
     for (const s of sessions) {
       // Skip EA chat session from project list (it has its own Chat button)
-      if (s.project_id === '_ea_chat') continue;
+      if (s.project_id === this._EA_CHAT) continue;
       const item = document.createElement('div');
       const hasPending = s.has_pending;
       item.className = 'ceo-proj-item' + (this._currentCeoProject === s.project_id ? ' active' : '') + (hasPending ? ' has-pending' : '');

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2120,13 +2120,17 @@ class AppController {
 
     this._ceoTerm = new CeoTerminal(messagesContainer);
 
+    // Wire Chat button — switches to EA default chat
+    document.getElementById('ceo-chat-btn')?.addEventListener('click', () => {
+      this._openEaChat();
+    });
+
     // Wire project list toggle
     const toggle = document.getElementById('ceo-list-toggle');
     const projectList = document.getElementById('ceo-project-list');
     toggle?.addEventListener('click', () => {
       const collapsed = projectList.classList.toggle('collapsed');
       toggle.textContent = collapsed ? '▶' : '◀';
-      // Refit terminal after animation
       setTimeout(() => this._ceoTerm?._fit(), 200);
     });
 
@@ -2202,8 +2206,8 @@ class AppController {
         return;
       }
 
-      if (!this._currentCeoProject) {
-        // New task (simple or standard mode)
+      if (!this._currentCeoProject || this._currentCeoProject === '_ea_chat') {
+        // New task from EA chat (simple or standard mode)
         const mode = this._pendingSimpleMode ? 'simple' : 'standard';
         this._pendingSimpleMode = false;
         const inp = document.getElementById('ceo-conv-input');
@@ -2306,6 +2310,21 @@ class AppController {
     });
 
     await this._refreshCeoProjectList();
+
+    // Default: open EA chat
+    this._openEaChat();
+  }
+
+  _openEaChat() {
+    this._currentCeoProject = null;
+    this._currentConvId = null;
+    this._currentConvType = null;
+    // Update active states
+    document.querySelectorAll('.ceo-proj-item').forEach(el => el.classList.remove('active'));
+    document.querySelectorAll('.ceo-oneonone-item').forEach(el => el.classList.remove('active'));
+    document.getElementById('ceo-chat-btn')?.classList.add('active');
+    // Load EA session
+    this._selectCeoProject('_ea_chat');
   }
 
   // --- Slash command menu --- //
@@ -2444,7 +2463,13 @@ class AppController {
 
     listEl.innerHTML = '';
 
+    // Update Chat button active state
+    const chatBtn = document.getElementById('ceo-chat-btn');
+    chatBtn?.classList.toggle('active', this._currentCeoProject === '_ea_chat' || !this._currentCeoProject);
+
     for (const s of sessions) {
+      // Skip EA chat session from project list (it has its own Chat button)
+      if (s.project_id === '_ea_chat') continue;
       const item = document.createElement('div');
       const hasPending = s.has_pending;
       item.className = 'ceo-proj-item' + (this._currentCeoProject === s.project_id ? ' active' : '') + (hasPending ? ' has-pending' : '');
@@ -2453,7 +2478,10 @@ class AppController {
       const display = name.length > 14 ? name.substring(0, 14) + '\u2026' : name;
       const badge = hasPending ? '<span class="ceo-proj-pending">●</span>' : '';
       item.innerHTML = badge + this._escHtml(display);
-      item.addEventListener('click', () => this._selectCeoProject(s.project_id));
+      item.addEventListener('click', () => {
+        chatBtn?.classList.remove('active');
+        this._selectCeoProject(s.project_id);
+      });
       listEl.appendChild(item);
     }
 

--- a/frontend/ceo-terminal.js
+++ b/frontend/ceo-terminal.js
@@ -81,7 +81,7 @@ class CeoTerminal {
     this._term.reset();
 
     const A = this._A();
-    const name = projectId ? projectId.split('/')[0] : 'New Task';
+    const name = projectId === '_ea_chat' ? 'Chat with EA' : (projectId ? projectId.split('/')[0] : 'New Task');
     const displayName = name.length > 25 ? name.substring(0, 25) + '\u2026' : name;
     this._term.writeln(`${A.cyan}${A.bold} ${displayName}${A.reset}`);
     this._divider();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -89,6 +89,8 @@
         </div>
         <div id="ceo-split">
           <div id="ceo-project-list">
+            <div id="ceo-chat-btn" class="ceo-nav-btn active" title="Chat with EA">&#128172; Chat</div>
+            <div class="ceo-section-header">Projects</div>
             <div id="ceo-projects-section"></div>
             <div id="ceo-oneonone-section">
               <div class="ceo-section-header" id="ceo-oneonone-toggle">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5323,6 +5323,20 @@ body.resize-dragging {
 }
 #ceo-list-toggle:hover { color: #aaa; background: #1a1a1a; }
 
+.ceo-nav-btn {
+  padding: 4px 6px;
+  cursor: pointer;
+  color: #4af;
+  font-size: 10px;
+  border-bottom: 1px solid #222;
+}
+.ceo-nav-btn:hover { background: #1a1a1a; }
+.ceo-nav-btn.active {
+  color: #fff;
+  background: #112;
+  border-left: 2px solid #4af;
+}
+
 .ceo-proj-item {
   padding: 4px 6px;
   cursor: pointer;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.36",
+  "version": "0.3.37",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.35"
+version = "0.3.36"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.36"
+version = "0.3.37"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- CEO Console opens to "Chat with EA" by default instead of empty state
- Left sidebar has 💬 Chat button above Projects — click to switch back to EA chat
- Messages in EA chat mode create new tasks (same as typing without a project selected)
- Chat button shows active/inactive state
- EA chat session (`_ea_chat`) filtered from project list

## Layout
```
┌─────────────────┐
│ 💬 Chat (active) │
│ Projects         │
│   proj_a         │
│   proj_b         │
│ ▼ 1-on-1         │
└─────────────────┘
```

## Test plan
- [x] 2255 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)