### PR TITLE
fix: strip [Company Context] from CEO session messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.37",
+  "version": "0.3.38",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.38",
+  "version": "0.3.39",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.37"
+version = "0.3.38"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.38"
+version = "0.3.39"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/ceo_broker.py
+++ b/src/onemancompany/core/ceo_broker.py
@@ -387,14 +387,19 @@ class CeoExecutor:
             session.project_dir = Path(context.work_dir)
 
         future = asyncio.get_running_loop().create_future()
-        # Strip injected context (e.g. [Company Context]...) from the message
+        # Strip injected [Company Context]...[/Company Context] block from the message
         # shown to CEO — only show the original task description
         clean_message = task_description
         ctx_start = clean_message.find("[Company Context]")
         if ctx_start >= 0:
-            clean_message = clean_message[:ctx_start].strip()
+            ctx_end = clean_message.find("[/Company Context]")
+            if ctx_end >= 0:
+                ctx_end += len("[/Company Context]")
+                clean_message = (clean_message[:ctx_start] + clean_message[ctx_end:]).strip()
+            else:
+                clean_message = clean_message[:ctx_start].strip()
         if not clean_message:
-            clean_message = task_description[:500]
+            clean_message = "(task description unavailable)"
 
         interaction = CeoInteraction(
             node_id=context.task_id,
@@ -413,7 +418,7 @@ class CeoExecutor:
             payload={
                 "project_id": project_id,
                 "node_id": context.task_id,
-                "message": task_description,
+                "message": clean_message,
                 "source_employee": context.employee_id,
                 "interaction_type": "ceo_request",
             },

--- a/src/onemancompany/core/ceo_broker.py
+++ b/src/onemancompany/core/ceo_broker.py
@@ -387,13 +387,22 @@ class CeoExecutor:
             session.project_dir = Path(context.work_dir)
 
         future = asyncio.get_running_loop().create_future()
+        # Strip injected context (e.g. [Company Context]...) from the message
+        # shown to CEO — only show the original task description
+        clean_message = task_description
+        ctx_start = clean_message.find("[Company Context]")
+        if ctx_start >= 0:
+            clean_message = clean_message[:ctx_start].strip()
+        if not clean_message:
+            clean_message = task_description[:500]
+
         interaction = CeoInteraction(
             node_id=context.task_id,
             tree_path="",
             project_id=project_id,
             source_employee=context.employee_id,
             interaction_type="ceo_request",
-            message=task_description,
+            message=clean_message,
             future=future,
         )
         session.enqueue(interaction)


### PR DESCRIPTION
## Summary
CeoExecutor was pushing the full task prompt (including injected `[Company Context]` system content) to the CEO conversation. CEO saw internal system prompts like `[00001] [Company Context]...` which is confusing.

Now strips everything after `[Company Context]` marker so CEO only sees the original task description.

## Test plan
- [x] 2255 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)