### PR TITLE
feat: EA Chat is a real conversation — no auto-project creation

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2357,7 +2357,7 @@ class AppController {
           text: m.text || '',
           source: m.sender === 'ceo' ? undefined : '玲珑阁 (EA)',
         }));
-      } catch (e) {}
+      } catch (e) { console.error('EA chat history load error:', e); }
     }
     this._ceoTerm?.showChat(this._EA_CHAT, messages);
   }
@@ -2373,7 +2373,7 @@ class AppController {
           this._currentConvId = this._eaChatConvId;
           return;
         }
-      } catch (e) {}
+      } catch (e) { console.error('EA chat error:', e); }
       // Stale — clear and recreate
       this._eaChatConvId = null;
       localStorage.removeItem('ea-chat-conv-id');

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -268,15 +268,16 @@ class AppController {
     // Unified conversation events
     if (msg.type === 'conversation_message') {
       const p = msg.payload || msg;
-      // xterm terminal path takes priority when viewing a 1-on-1
-      if (this._currentConvId === p.conv_id && this._ceoTerm && this._currentConvType === 'oneonone') {
-        // Skip CEO's own messages (already shown via optimistic append)
+      // xterm terminal path: 1-on-1 or EA chat
+      if (this._currentConvId === p.conv_id && this._ceoTerm && (this._currentConvType === 'oneonone' || this._currentConvType === 'ea_chat')) {
         if (p.sender !== 'ceo' && p.text != null) {
-          const empNick = this._resolveEmployeeNickname(p.employee_id || this._currentConvEmployeeId || '');
+          const source = this._currentConvType === 'ea_chat'
+            ? '玲珑阁 (EA)'
+            : this._resolveEmployeeNickname(p.employee_id || this._currentConvEmployeeId || '');
           this._ceoTerm.appendMessage({
             role: 'system',
             text: p.text,
-            source: empNick,
+            source,
           });
         }
       } else if (this._chatPanel && p.conv_id === this._chatPanel.getConvId() && p.text != null) {
@@ -2207,12 +2208,20 @@ class AppController {
         return;
       }
 
-      if (!this._currentCeoProject || this._currentCeoProject === this._EA_CHAT) {
-        // New task from EA chat (simple or standard mode)
+      if (this._currentCeoProject === this._EA_CHAT && this._eaChatConvId) {
+        // EA Chat: send as conversation message — EA decides whether to create project
+        try {
+          await fetch(`/api/conversation/${this._eaChatConvId}/message`, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({ text }),
+          });
+          // EA response arrives via WebSocket conversation_message event
+        } catch (e) { console.error('Failed to send EA chat message:', e); }
+      } else if (!this._currentCeoProject) {
+        // No project selected and no EA chat — fallback to task creation
         const mode = this._pendingSimpleMode ? 'simple' : 'standard';
         this._pendingSimpleMode = false;
-        const inp = document.getElementById('ceo-conv-input');
-        if (inp) inp.placeholder = '$ Type message, / for commands (Enter to send)';
         try {
           const formData = new FormData();
           formData.append('task', text);
@@ -2316,16 +2325,74 @@ class AppController {
     this._openEaChat();
   }
 
-  _openEaChat() {
+  _eaChatConvId = null;  // Persistent conversation ID for EA chat
+
+  async _openEaChat() {
     // Clear pending modes that could interfere
     this._pendingIterProject = null;
     this._pendingSimpleMode = false;
+    this._currentCeoProject = this._EA_CHAT;
+    this._currentConvType = 'ea_chat';
+    this._currentConvId = this._eaChatConvId;
+    this._currentConvEmployeeId = '00004';  // EA
+
     // Update active states in sidebar
     document.querySelectorAll('.ceo-proj-item').forEach(el => el.classList.remove('active'));
     document.querySelectorAll('.ceo-oneonone-item').forEach(el => el.classList.remove('active'));
     document.getElementById('ceo-chat-btn')?.classList.add('active');
-    // Delegate to _selectCeoProject which handles all state clearing
-    this._selectCeoProject(this._EA_CHAT);
+
+    // Ensure EA chat conversation exists
+    if (!this._eaChatConvId) {
+      await this._ensureEaChatConversation();
+    }
+
+    // Load conversation history
+    let messages = [];
+    if (this._eaChatConvId) {
+      try {
+        const resp = await fetch(`/api/conversation/${this._eaChatConvId}/messages`);
+        const data = await resp.json();
+        messages = (data.messages || []).map(m => ({
+          role: m.sender === 'ceo' ? 'ceo' : 'system',
+          text: m.text || '',
+          source: m.sender === 'ceo' ? undefined : '玲珑阁 (EA)',
+        }));
+      } catch (e) {}
+    }
+    this._ceoTerm?.showChat(this._EA_CHAT, messages);
+  }
+
+  async _ensureEaChatConversation() {
+    // Check localStorage for existing EA chat conv_id
+    this._eaChatConvId = localStorage.getItem('ea-chat-conv-id') || null;
+    if (this._eaChatConvId) {
+      // Verify it still exists
+      try {
+        const resp = await fetch(`/api/conversation/${this._eaChatConvId}/messages`);
+        if (resp.ok) {
+          this._currentConvId = this._eaChatConvId;
+          return;
+        }
+      } catch (e) {}
+      // Stale — clear and recreate
+      this._eaChatConvId = null;
+      localStorage.removeItem('ea-chat-conv-id');
+    }
+
+    // Create a new persistent EA chat conversation
+    try {
+      const resp = await fetch('/api/conversation/create', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ type: 'ea_chat', employee_id: '00004', tools_enabled: true }),
+      });
+      const conv = await resp.json();
+      this._eaChatConvId = conv.id;
+      this._currentConvId = conv.id;
+      localStorage.setItem('ea-chat-conv-id', conv.id);
+    } catch (e) {
+      console.error('Failed to create EA chat conversation:', e);
+    }
   }
 
   // --- Slash command menu --- //

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.39",
+  "version": "0.3.40",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.41",
+  "version": "0.3.42",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.39"
+version = "0.3.40"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.40"
+version = "0.3.41"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.41"
+version = "0.3.42"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -713,7 +713,7 @@ def create_project(task: str, mode: str = "standard") -> dict:
     from pathlib import Path
     from onemancompany.core.config import CEO_ID, EA_ID, TASK_TREE_FILENAME
     from onemancompany.core.task_lifecycle import NodeType, TaskPhase
-    from onemancompany.core.task_tree import TaskTree, evict_tree
+    from onemancompany.core.task_tree import TaskTree
     from onemancompany.core.vessel import employee_manager
 
     if not task:

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -694,6 +694,106 @@ def set_project_name(name: str) -> dict:
     return {"status": "ok", "name": name.strip()}
 
 
+@tool
+def create_project(task: str, mode: str = "standard") -> dict:
+    """Create a new project from a CEO task description.
+
+    Use this when the CEO gives a task that requires team execution
+    (development, research, hiring, marketing, etc.). Do NOT use this
+    for simple questions or conversations — just answer those directly.
+
+    This creates a project with a task tree and schedules EA to analyze
+    and dispatch the work to appropriate team members.
+
+    Args:
+        task: The full task description from the CEO.
+        mode: "standard" (with retrospective) or "simple" (no retrospective).
+    """
+    import asyncio
+    from pathlib import Path
+    from onemancompany.core.config import CEO_ID, EA_ID, TASK_TREE_FILENAME
+    from onemancompany.core.task_lifecycle import NodeType, TaskPhase
+    from onemancompany.core.task_tree import TaskTree, evict_tree
+    from onemancompany.core.vessel import employee_manager
+
+    if not task:
+        return {"status": "error", "message": "Task description is required"}
+    if mode not in ("simple", "standard"):
+        mode = "standard"
+
+    try:
+        from onemancompany.core.project_archive import (
+            async_create_project_from_task,
+            get_project_dir,
+        )
+
+        # Create project (sync wrapper for async function)
+        loop = None
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None  # No event loop — will use asyncio.run() below
+
+        if loop and loop.is_running():
+            # We're in an async context — use a thread to run the async function
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor() as pool:
+                pid, iter_id = pool.submit(
+                    lambda: asyncio.run(async_create_project_from_task(task, "pending"))
+                ).result(timeout=30)
+        else:
+            pid, iter_id = asyncio.run(async_create_project_from_task(task, "pending"))
+
+        pdir = get_project_dir(pid)
+        ctx_id = f"{pid}/{iter_id}" if iter_id else pid
+
+        # Build task tree
+        tree_path = Path(pdir) / TASK_TREE_FILENAME
+        tree = TaskTree(project_id=ctx_id, mode=mode)
+        ceo_root = tree.create_root(employee_id=CEO_ID, description=task)
+        ceo_root.node_type = NodeType.CEO_PROMPT
+        ceo_root.set_status(TaskPhase.PROCESSING)
+
+        ea_task = (
+            f"CEO has assigned a new task. Please analyze and dispatch to the appropriate owner:\n\n"
+            f"Task: {task}\n\n"
+            f"[Project ID: {ctx_id}] [Project workspace: {pdir}]"
+        )
+        ea_node = tree.add_child(
+            parent_id=ceo_root.id,
+            employee_id=EA_ID,
+            description=ea_task,
+            acceptance_criteria=[],
+        )
+
+        from onemancompany.core.vessel import _save_project_tree
+        _save_project_tree(pdir, tree)
+        _add_to_project_team(pdir, CEO_ID)
+        _add_to_project_team(pdir, EA_ID)
+
+        # Create CEO session for the project
+        from onemancompany.core.ceo_broker import get_ceo_broker
+        broker = get_ceo_broker()
+        session = broker.get_or_create_session(ctx_id)
+        session.project_dir = Path(pdir)
+        session.push_system_message(f"Project created: {task[:100]}", source="system")
+        session.save_history(Path(pdir))
+
+        # Schedule EA
+        employee_manager.schedule_node(EA_ID, ea_node.id, str(tree_path))
+        employee_manager._schedule_next(EA_ID)
+
+        logger.info("[create_project] Created project {} from EA chat", ctx_id)
+        return {
+            "status": "ok",
+            "project_id": ctx_id,
+            "message": f"Project created and assigned to EA for analysis. Project ID: {ctx_id}",
+        }
+    except Exception as e:
+        logger.error("[create_project] Failed: {}", e)
+        return {"status": "error", "message": str(e)}
+
+
 # ---------------------------------------------------------------------------
 # Registration
 # ---------------------------------------------------------------------------
@@ -706,3 +806,4 @@ tool_registry.register(reject_child, ToolMeta(name="reject_child", category="bas
 tool_registry.register(unblock_child, ToolMeta(name="unblock_child", category="base"))
 tool_registry.register(cancel_child, ToolMeta(name="cancel_child", category="base"))
 tool_registry.register(set_project_name, ToolMeta(name="set_project_name", category="base"))
+tool_registry.register(create_project, ToolMeta(name="create_project", category="base"))

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -6059,7 +6059,7 @@ def _pick_reusable_oneonone_conversation(employee_id: str) -> tuple[Conversation
         except Exception:
             logger.warning("[conversation] failed to load meta from {}", conv_dir)
             continue
-        if conv.type != "oneonone" or conv.employee_id != employee_id or conv.phase == ConversationPhase.CLOSING.value:
+        if conv.type not in ("oneonone", "ea_chat") or conv.employee_id != employee_id or conv.phase == ConversationPhase.CLOSING.value:
             continue
 
         try:

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -6193,8 +6193,8 @@ async def create_conversation(body: dict) -> dict:
     if conv_type == ConversationType.CEO_INBOX.value and not body.get("project_dir"):
         raise HTTPException(status_code=400, detail="project_dir is required for ceo_inbox conversations")
 
-    # Reuse prior one-on-one thread per employee so restarting meeting preserves history.
-    if conv_type == ConversationType.ONE_ON_ONE.value and body.get("reuse_existing", True):
+    # Reuse prior conversation thread per employee (one-on-one and ea_chat)
+    if conv_type in (ConversationType.ONE_ON_ONE.value, ConversationType.EA_CHAT.value) and body.get("reuse_existing", True):
         reusable = _pick_reusable_oneonone_conversation(employee_id)
         if reusable:
             conv, conv_dir = reusable

--- a/src/onemancompany/core/conversation_adapters.py
+++ b/src/onemancompany/core/conversation_adapters.py
@@ -122,7 +122,7 @@ def _build_conversation_prompt(
         lines.append(
             "This is a direct chat with the CEO. You are their EA (Executive Assistant).\n"
             "- Answer questions directly and concisely.\n"
-            "- If the CEO gives a task that requires team execution, use dispatch_child() to create a project.\n"
+            "- If the CEO gives a task that requires team execution, use create_project() to start a project.\n"
             "- For simple questions (weather, info, advice), just answer — do NOT create a project.\n"
             "- Only create projects for tasks that need employee work (development, research, hiring, etc.)."
         )

--- a/src/onemancompany/core/conversation_adapters.py
+++ b/src/onemancompany/core/conversation_adapters.py
@@ -118,6 +118,14 @@ def _build_conversation_prompt(
             lines.append(shared_prompt)
     elif conversation.type == ConversationType.CEO_INBOX:
         lines.append("The CEO is responding to your request. Answer their questions.")
+    elif conversation.type == ConversationType.EA_CHAT:
+        lines.append(
+            "This is a direct chat with the CEO. You are their EA (Executive Assistant).\n"
+            "- Answer questions directly and concisely.\n"
+            "- If the CEO gives a task that requires team execution, use dispatch_child() to create a project.\n"
+            "- For simple questions (weather, info, advice), just answer — do NOT create a project.\n"
+            "- Only create projects for tasks that need employee work (development, research, hiring, etc.)."
+        )
 
     if messages:
         lines.append("\n--- Conversation History ---")

--- a/src/onemancompany/core/models.py
+++ b/src/onemancompany/core/models.py
@@ -45,6 +45,7 @@ class ConversationType(str, Enum):
     """Types of conversation channels."""
     CEO_INBOX = "ceo_inbox"
     ONE_ON_ONE = "oneonone"
+    EA_CHAT = "ea_chat"
 
 
 class ConversationPhase(str, Enum):


### PR DESCRIPTION
## Summary
EA Chat was auto-creating a project for every CEO message (even "hello").
Now it's a real conversation:

- Creates a persistent `ea_chat` conversation with EA (00004)
- CEO messages go through conversation API → EA LLM responds with full toolset
- EA answers simple questions directly (no project created)
- EA uses `dispatch_child()` only when the task needs team execution
- Conversation reused across sessions (localStorage + backend reuse)

## What changed
- **Frontend**: `doSend` in EA Chat mode calls conversation API instead of `/api/ceo/task`
- **Backend**: Added `EA_CHAT` ConversationType, ea_chat prompt in conversation_adapters
- **Backend**: `ea_chat` conversations reuse existing threads (like 1-on-1)
- **Frontend**: WebSocket handler shows EA responses in xterm terminal

## Test plan
- [x] 2255 unit tests pass
- [ ] Manual: type "hello" in EA Chat — EA responds without creating project
- [ ] Manual: type "build a website" — EA creates project via dispatch_child

🤖 Generated with [Claude Code](https://claude.com/claude-code)