### PR TITLE
feat: EA chat gets full tools (COO+CSO+base+asset) except HR

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.42",
+  "version": "0.3.43",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.43",
+  "version": "0.3.44",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.42"
+version = "0.3.43"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.43"
+version = "0.3.44"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/conversation_adapters.py
+++ b/src/onemancompany/core/conversation_adapters.py
@@ -21,6 +21,9 @@ EXECUTOR_TYPE_LANGCHAIN = "langchain"
 EXECUTOR_TYPE_CLAUDE_SESSION = "claude_session"
 EXECUTOR_TYPE_SUBPROCESS = "subprocess"
 
+# Roles excluded from EA chat tool access (EA should not perform HR operations)
+_EA_EXCLUDED_ROLES: frozenset[str] = frozenset({"HR"})
+
 
 @runtime_checkable
 class ConversationAdapter(Protocol):
@@ -229,15 +232,20 @@ class _BaseConversationAdapter:
         """EA chat: build a one-shot agent with full tools (except HR role tools)."""
         from onemancompany.core.runtime_context import _interaction_type, _interaction_work_dir
         from onemancompany.core.tool_registry import tool_registry
-        from onemancompany.agents.base import make_llm, tracked_ainvoke, _extract_text
-        from langchain_core.messages import HumanMessage, SystemMessage
+        from onemancompany.agents.base import make_llm, extract_final_content
+        from langchain_core.messages import HumanMessage
+
+        logger.debug(
+            "[conversation] _send_ea_chat: employee={}, tool_count={}",
+            conversation.employee_id,
+            len(tool_registry.all_tool_names()),
+        )
 
         prompt = _build_conversation_prompt(conversation, messages, new_message)
         work_dir = _resolve_conversation_work_dir(conversation)
 
         # Get all tools except HR role tools
-        _HR_EXCLUDED = frozenset({"HR"})
-        tools = tool_registry.get_all_tools_except_roles(exclude_roles=_HR_EXCLUDED)
+        tools = tool_registry.get_all_tools_except_roles(exclude_roles=_EA_EXCLUDED_ROLES)
 
         # Build a LangGraph react agent with full tools
         from langgraph.prebuilt import create_react_agent
@@ -249,12 +257,7 @@ class _BaseConversationAdapter:
         tok_work = _interaction_work_dir.set(work_dir)
         try:
             result = await agent.ainvoke({"messages": [HumanMessage(content=prompt)]})
-            # Extract final text from agent output
-            msgs = result.get("messages", [])
-            for msg in reversed(msgs):
-                if hasattr(msg, "content") and msg.content and not hasattr(msg, "tool_calls"):
-                    return msg.content if isinstance(msg.content, str) else str(msg.content)
-            return ""
+            return extract_final_content(result)
         finally:
             _interaction_type.reset(tok_type)
             _interaction_work_dir.reset(tok_work)

--- a/src/onemancompany/core/conversation_adapters.py
+++ b/src/onemancompany/core/conversation_adapters.py
@@ -192,6 +192,11 @@ class _BaseConversationAdapter:
         self, conversation: Conversation, messages: list[Message], new_message: Message,
     ) -> str:
         from onemancompany.core.runtime_context import _interaction_type, _interaction_work_dir
+
+        # EA chat: use a one-shot agent with full tools (except HR role tools)
+        if conversation.type == ConversationType.EA_CHAT:
+            return await self._send_ea_chat(conversation, messages, new_message)
+
         executor = _get_employee_executor(conversation.employee_id)
         prompt = _build_conversation_prompt(conversation, messages, new_message)
         prompt = self._prepare_prompt(prompt, conversation)
@@ -214,6 +219,42 @@ class _BaseConversationAdapter:
         try:
             result = await executor.execute(prompt, ctx)
             return result.output
+        finally:
+            _interaction_type.reset(tok_type)
+            _interaction_work_dir.reset(tok_work)
+
+    async def _send_ea_chat(
+        self, conversation: Conversation, messages: list[Message], new_message: Message,
+    ) -> str:
+        """EA chat: build a one-shot agent with full tools (except HR role tools)."""
+        from onemancompany.core.runtime_context import _interaction_type, _interaction_work_dir
+        from onemancompany.core.tool_registry import tool_registry
+        from onemancompany.agents.base import make_llm, tracked_ainvoke, _extract_text
+        from langchain_core.messages import HumanMessage, SystemMessage
+
+        prompt = _build_conversation_prompt(conversation, messages, new_message)
+        work_dir = _resolve_conversation_work_dir(conversation)
+
+        # Get all tools except HR role tools
+        _HR_EXCLUDED = frozenset({"HR"})
+        tools = tool_registry.get_all_tools_except_roles(exclude_roles=_HR_EXCLUDED)
+
+        # Build a LangGraph react agent with full tools
+        from langgraph.prebuilt import create_react_agent
+
+        llm = make_llm(conversation.employee_id)
+        agent = create_react_agent(model=llm, tools=tools)
+
+        tok_type = _interaction_type.set(conversation.type)
+        tok_work = _interaction_work_dir.set(work_dir)
+        try:
+            result = await agent.ainvoke({"messages": [HumanMessage(content=prompt)]})
+            # Extract final text from agent output
+            msgs = result.get("messages", [])
+            for msg in reversed(msgs):
+                if hasattr(msg, "content") and msg.content and not hasattr(msg, "tool_calls"):
+                    return msg.content if isinstance(msg.content, str) else str(msg.content)
+            return ""
         finally:
             _interaction_type.reset(tok_type)
             _interaction_work_dir.reset(tok_work)

--- a/src/onemancompany/core/tool_registry.py
+++ b/src/onemancompany/core/tool_registry.py
@@ -97,6 +97,20 @@ class ToolRegistry:
                 result.append(tool)
         return result
 
+    def get_all_tools_except_roles(self, exclude_roles: frozenset[str] | None = None) -> list:
+        """Return all tools, bypassing role restrictions except for specific excluded roles.
+
+        Used for EA chat where EA needs near-full access.
+        """
+        result = []
+        for name, tool in self._tools.items():
+            meta = self._meta[name]
+            if meta.category == "role" and meta.allowed_roles and exclude_roles:
+                if any(r in exclude_roles for r in meta.allowed_roles):
+                    continue
+            result.append(tool)
+        return result
+
     @staticmethod
     def _is_allowed(meta: ToolMeta, emp_data: dict, employee_id: str) -> bool:
         """Check whether an employee is allowed to use a tool based on its category."""

--- a/tests/unit/core/test_tool_registry.py
+++ b/tests/unit/core/test_tool_registry.py
@@ -404,6 +404,67 @@ def tool_beta(x: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# ToolRegistry — get_all_tools_except_roles
+# ---------------------------------------------------------------------------
+
+class TestGetAllToolsExceptRoles:
+    def _build_registry_with_roles(self):
+        """Build a registry with tools across different roles."""
+        from onemancompany.core.tool_registry import ToolMeta, ToolRegistry
+
+        reg = ToolRegistry()
+
+        reg.register(
+            _make_mock_tool("list_colleagues"),
+            ToolMeta(name="list_colleagues", category="base"),
+        )
+        reg.register(
+            _make_mock_tool("bash"),
+            ToolMeta(name="bash", category="gated"),
+        )
+        reg.register(
+            _make_mock_tool("hire_employee"),
+            ToolMeta(name="hire_employee", category="role", allowed_roles=["HR"]),
+        )
+        reg.register(
+            _make_mock_tool("deploy"),
+            ToolMeta(name="deploy", category="role", allowed_roles=["Engineer"]),
+        )
+        reg.register(
+            _make_mock_tool("gmail"),
+            ToolMeta(name="gmail", category="asset", source="asset"),
+        )
+        return reg
+
+    def test_exclude_hr_returns_all_non_hr_tools(self):
+        reg = self._build_registry_with_roles()
+        tools = reg.get_all_tools_except_roles(exclude_roles=frozenset({"HR"}))
+        tool_names = [t.name for t in tools]
+
+        assert "list_colleagues" in tool_names
+        assert "bash" in tool_names
+        assert "deploy" in tool_names
+        assert "gmail" in tool_names
+        assert "hire_employee" not in tool_names
+
+    def test_no_exclusion_returns_everything(self):
+        reg = self._build_registry_with_roles()
+        tools = reg.get_all_tools_except_roles(exclude_roles=None)
+        tool_names = [t.name for t in tools]
+
+        assert len(tool_names) == 5
+        assert "hire_employee" in tool_names
+        assert "deploy" in tool_names
+
+    def test_empty_registry_returns_empty(self):
+        from onemancompany.core.tool_registry import ToolRegistry
+
+        reg = ToolRegistry()
+        tools = reg.get_all_tools_except_roles(exclude_roles=frozenset({"HR"}))
+        assert tools == []
+
+
+# ---------------------------------------------------------------------------
 # Module-level singleton
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
EA in ea_chat conversation now builds a one-shot LangGraph agent with nearly all company tools:
- Base tools (26): read, write, bash, dispatch_child, etc.
- Tree tools (7): create_project, accept_child, etc.
- COO role tools (13): request_hiring, deposit_company_knowledge, etc.
- CSO role tools (4): review_contract, complete_delivery, etc.
- Asset tools: web_search, gmail, image_generation, etc.
- **Excluded**: HR role tools (search_candidates, submit_shortlist, performance_review) — hiring goes through HR

Added `get_all_tools_except_roles(exclude_roles)` to ToolRegistry.

## Test plan
- [x] 2255 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)