### PR TITLE
feat: Esc cancels in-progress agent response

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2301,7 +2301,15 @@ class AppController {
 
       // Escape: close slash menu
       if (e.key === 'Escape') {
-        slashMenu?.classList.add('hidden');
+        if (menuVisible) {
+          slashMenu.classList.add('hidden');
+        } else if (this._currentConvType === 'ea_chat' && this._eaChatConvId) {
+          // Cancel in-progress EA response
+          this._cancelConversationResponse(this._eaChatConvId);
+        } else if (this._currentConvType === 'oneonone' && this._currentConvId) {
+          // Cancel in-progress 1-on-1 response
+          this._cancelConversationResponse(this._currentConvId);
+        }
       }
     });
     input?.addEventListener('input', () => this._handleSlashInput(input));
@@ -2629,6 +2637,18 @@ class AppController {
     }));
 
     this._ceoTerm?.showChat(`1on1:${empNick}`, history);
+  }
+
+  async _cancelConversationResponse(convId) {
+    try {
+      const resp = await fetch(`/api/conversation/${convId}/cancel`, { method: 'POST' });
+      const data = await resp.json();
+      if (data.status === 'cancelled') {
+        this._ceoTerm?.appendMessage({ role: 'system', text: '⏹ Response cancelled', source: 'system' });
+      }
+    } catch (e) {
+      console.error('Failed to cancel:', e);
+    }
   }
 
   async _endOneononeFromTerminal() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.46",
+  "version": "0.3.47",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.46"
+version = "0.3.47"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -6019,6 +6019,7 @@ from onemancompany.core.models import ConversationType, ConversationPhase
 
 _conversation_service = ConversationService()
 _active_adapter_tasks: set[asyncio.Task] = set()
+_active_adapter_by_conv: dict[str, asyncio.Task] = {}  # conv_id → running adapter task
 
 _VALID_CONV_TYPES = {t.value for t in ConversationType}
 _VALID_CONV_PHASES = {p.value for p in ConversationPhase}
@@ -6259,8 +6260,23 @@ async def send_conversation_message(conv_id: str, body: dict) -> dict:
     # Dispatch to adapter in background (don't await — async reply via WebSocket)
     task = asyncio.create_task(_dispatch_conversation_to_adapter(conv_id, msg))
     _active_adapter_tasks.add(task)
-    task.add_done_callback(_active_adapter_tasks.discard)
+    _active_adapter_by_conv[conv_id] = task
+    def _cleanup(t, _cid=conv_id):
+        _active_adapter_tasks.discard(t)
+        _active_adapter_by_conv.pop(_cid, None)
+    task.add_done_callback(_cleanup)
     return {"status": "sent", "message": msg.to_dict()}
+
+
+@router.post("/api/conversation/{conv_id}/cancel")
+async def cancel_conversation_response(conv_id: str) -> dict:
+    """Cancel the in-progress agent response for a conversation."""
+    task = _active_adapter_by_conv.get(conv_id)
+    if not task or task.done():
+        return {"status": "no_active_task"}
+    task.cancel()
+    logger.info("[conversation] Cancelled adapter task for conv={}", conv_id)
+    return {"status": "cancelled"}
 
 
 @router.post("/api/conversation/{conv_id}/upload")


### PR DESCRIPTION
## Summary
- **Esc** in EA chat or 1-on-1 cancels the in-progress agent response
- Backend: `POST /api/conversation/{id}/cancel` — cancels the running asyncio adapter task
- Frontend: terminal shows "⏹ Response cancelled" on successful cancel
- Slash menu close takes priority (Esc first closes menu if open)
- Tracks adapter tasks by conv_id for targeted cancellation

## Test plan
- [x] 2267 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)