### PR TITLE
fix: activity log right padding for scrollbar overlap

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -573,7 +573,7 @@ body.resize-dragging {
   border: 2px solid var(--border);
   border-top: none;
   border-radius: 0 0 2px 2px;
-  padding: 8px 10px;
+  padding: 8px 16px 8px 10px;
   flex: 1;
   overflow: hidden;  /* xterm.js handles its own scrolling */
   min-height: 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.61",
+  "version": "0.3.62",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.61"
+version = "0.3.62"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Added extra right padding (16px vs 10px) to `#activity-log` so the scrollbar doesn't overlap text

## Test Plan
- [ ] Visual check: activity log text no longer clipped by scrollbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)