### PR TITLE
feat: error transparency for employee task execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.62",
+  "version": "0.3.63",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.62"
+version = "0.3.63"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/subprocess_executor.py
+++ b/src/onemancompany/core/subprocess_executor.py
@@ -111,9 +111,10 @@ class SubprocessExecutor(Launcher):
 
         if self._process.returncode != 0:
             err_msg = stderr.decode(errors="replace")[:500] if stderr else "Unknown error"
+            error = f"Error (exit {self._process.returncode}): {err_msg}"
             if on_log:
-                on_log("error", f"Exit code {self._process.returncode}: {err_msg}")
-            return LaunchResult(output=f"Error (exit {self._process.returncode}): {err_msg}")
+                on_log("error", error)
+            return LaunchResult(error=error)
 
         raw = stdout.decode(errors="replace").strip()
         try:

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -420,11 +420,16 @@ def _parse_holding_metadata(result: str | None) -> dict | None:
 class LaunchResult:
     """Result from a single task execution."""
     output: str = ""
+    error: str | None = None  # structured error; None = no error
     model_used: str = ""
     input_tokens: int = 0
     output_tokens: int = 0
     total_tokens: int = 0
     cost_usd: float | None = None  # provider-reported cost; None = use catalog price
+
+
+class ExecutionError(Exception):
+    """Raised when a task execution fails in a way the caller should handle."""
 
 
 @dataclass
@@ -506,12 +511,17 @@ class ClaudeSessionExecutor(Launcher):
             task_id=context.task_id,
         )
         output = result.get("output", "")
+        error: str | None = None
+        if output and output.startswith("[claude-daemon error]"):
+            error = output
+            output = ""
         if on_log:
-            on_log("result", (output or "")[:500])
+            on_log("error" if error else "result", (error or output or "")[:500])
         input_tokens = result.get("input_tokens", 0)
         output_tokens = result.get("output_tokens", 0)
         return LaunchResult(
             output=output or "",
+            error=error,
             model_used=result.get("model", ""),
             input_tokens=input_tokens,
             output_tokens=output_tokens,
@@ -557,14 +567,17 @@ class ScriptExecutor(Launcher):
             output = stdout.decode(ENCODING_UTF8, errors="replace").strip()
             if proc.returncode != 0 and not output:
                 err = stderr.decode(ENCODING_UTF8, errors="replace").strip()
-                output = f"[script error] exit={proc.returncode}\n{err[:2000]}"
+                error_msg = f"[script error] exit={proc.returncode}\n{err[:2000]}"
+                if on_log:
+                    on_log("error", error_msg[:500])
+                return LaunchResult(error=error_msg)
             if on_log:
                 on_log("result", output[:500])
             return LaunchResult(output=output)
         except asyncio.TimeoutError:
-            return LaunchResult(output="[script timeout] Timed out after 600s")
+            return LaunchResult(error="[script timeout] Timed out after 600s")
         except Exception as e:
-            return LaunchResult(output=f"[script error] {e}")
+            return LaunchResult(error=f"[script error] {e}")
 
 
 
@@ -1334,6 +1347,10 @@ class EmployeeManager:
             if last_err is not None:
                 raise last_err
 
+            # Check for executor-reported errors
+            if launch_result and launch_result.error:
+                raise ExecutionError(launch_result.error)
+
             node.result = launch_result.output if launch_result else ""
             logger.debug("[TASK RESPONSE] employee={} node={}:\n{}",
                          employee_id, entry.node_id, _trunc(node.result))
@@ -1392,12 +1409,18 @@ class EmployeeManager:
             if not node.completed_at:
                 node.completed_at = datetime.now().isoformat()
             self._log_node(employee_id, entry.node_id, "timeout", f"Task timed out after {node.timeout_seconds or 3600}s")
+            self._push_to_ceo_session(node, f"\u2717 Timeout ({node.timeout_seconds or 3600}s)")
+            _append_progress(employee_id, f"Failed: {node.description_preview[:100]} \u2014 timeout")
         except Exception as e:
             agent_error = True
             node.set_status(TaskPhase.FAILED)
             logger.debug("[TASK LIFECYCLE] employee={} node={} → FAILED (error: {})", employee_id, entry.node_id, e)
             node.result = f"Error: {e!s}"
+            if not node.completed_at:
+                node.completed_at = datetime.now().isoformat()
             self._log_node(employee_id, entry.node_id, "error", f"Task failed: {e!s}")
+            self._push_to_ceo_session(node, f"\u2717 {e!s}"[:150])
+            _append_progress(employee_id, f"Failed: {node.description_preview[:100]} \u2014 {e!s}"[:300])
             logger.exception("Unhandled error")
         finally:
             _current_vessel.reset(loop_token)
@@ -3030,7 +3053,7 @@ class EmployeeManager:
             _project_dir = (node.project_dir if node else "") or str(Path(current_entry.tree_path).parent)
             _append_node_execution_log(_project_dir, node_id, log_type, content)
         else:
-            logger.debug("[_log_node] No _current_entries for {} — log not written to disk (node={})", employee_id, node_id)
+            logger.warning("[_log_node] No _current_entries for {} — log not written to disk (node={})", employee_id, node_id)
         # 2. WebSocket: real-time push to frontend
         self._publish_log_event(employee_id, node_id, entry)
 

--- a/tests/unit/core/test_agent_loop.py
+++ b/tests/unit/core/test_agent_loop.py
@@ -252,7 +252,8 @@ class TestScriptLauncher:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc):
             with patch("asyncio.wait_for", new_callable=AsyncMock, side_effect=asyncio.TimeoutError):
                 result = await launcher.execute("task desc", ctx)
-                assert "[script timeout]" in result.output
+                assert result.error is not None
+                assert "[script timeout]" in result.error
 
     @pytest.mark.asyncio
     async def test_execute_exception(self):
@@ -261,8 +262,9 @@ class TestScriptLauncher:
 
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, side_effect=OSError("No such file")):
             result = await launcher.execute("task desc", ctx)
-            assert "[script error]" in result.output
-            assert "No such file" in result.output
+            assert result.error is not None
+            assert "[script error]" in result.error
+            assert "No such file" in result.error
 
     def test_is_ready(self):
         launcher = ScriptLauncher("emp01")
@@ -931,8 +933,9 @@ class TestScriptLauncherErrorCode:
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc):
             with patch("asyncio.wait_for", new_callable=AsyncMock, return_value=(b"", b"some error")):
                 result = await launcher.execute("task desc", ctx)
-                assert "[script error]" in result.output
-                assert "some error" in result.output
+                assert result.error is not None
+                assert "[script error]" in result.error
+                assert "some error" in result.error
 
     @pytest.mark.asyncio
     async def test_execute_nonzero_exit_with_stdout(self):

--- a/tests/unit/core/test_error_transparency.py
+++ b/tests/unit/core/test_error_transparency.py
@@ -1,0 +1,193 @@
+"""Unit tests for error transparency — LaunchResult.error + ExecutionError."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from onemancompany.core.vessel import (
+    ClaudeSessionExecutor,
+    ExecutionError,
+    LaunchResult,
+    ScriptExecutor,
+    TaskContext,
+)
+from onemancompany.core.subprocess_executor import SubprocessExecutor
+
+
+_CTX = TaskContext(project_id="proj1", work_dir="/tmp", employee_id="00010", task_id="t1")
+
+
+class TestLaunchResultError:
+    def test_default_error_is_none(self):
+        result = LaunchResult(output="hello")
+        assert result.error is None
+
+    def test_error_field_set(self):
+        result = LaunchResult(error="something broke")
+        assert result.error == "something broke"
+        assert result.output == ""
+
+    def test_backward_compat_no_error(self):
+        result = LaunchResult(
+            output="ok",
+            model_used="claude-3",
+            input_tokens=100,
+            output_tokens=50,
+            total_tokens=150,
+        )
+        assert result.error is None
+
+
+class TestExecutionError:
+    def test_is_exception(self):
+        err = ExecutionError("task failed")
+        assert isinstance(err, Exception)
+        assert str(err) == "task failed"
+
+
+class TestClaudeSessionExecutorError:
+    def test_daemon_error_sets_error_field(self):
+        executor = ClaudeSessionExecutor("00010")
+        mock_result = {
+            "output": "[claude-daemon error] connection refused",
+            "model": "",
+            "input_tokens": 0,
+            "output_tokens": 0,
+        }
+        with patch(
+            "onemancompany.core.claude_session.run_claude_session",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                executor.execute("do stuff", _CTX)
+            )
+        assert result.error == "[claude-daemon error] connection refused"
+        assert result.output == ""
+
+
+class TestScriptExecutorError:
+    def test_nonzero_exit_no_stdout_sets_error_field(self):
+        executor = ScriptExecutor("00010", script_path="/bin/true")
+
+        async def _run():
+            with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.communicate = AsyncMock(return_value=(b"", b"segfault"))
+                mock_proc.returncode = 1
+                mock_exec.return_value = mock_proc
+                return await executor.execute("do stuff", _CTX)
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        assert result.error is not None
+        assert "exit" in result.error.lower() or "script" in result.error.lower()
+
+    def test_timeout_sets_error_field(self):
+        executor = ScriptExecutor("00010", script_path="/bin/true")
+
+        async def _run():
+            with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+                mock_exec.return_value = mock_proc
+                with patch("asyncio.wait_for", new_callable=AsyncMock, side_effect=asyncio.TimeoutError):
+                    return await executor.execute("do stuff", _CTX)
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        assert result.error is not None
+        assert "timed out" in result.error.lower() or "timeout" in result.error.lower()
+
+    def test_exception_sets_error_field(self):
+        executor = ScriptExecutor("00010", script_path="/bin/true")
+
+        async def _run():
+            with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
+                mock_exec.side_effect = FileNotFoundError("/bin/missing")
+                return await executor.execute("do stuff", _CTX)
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        assert result.error is not None
+        assert "script error" in result.error.lower()
+
+
+class TestSubprocessExecutorError:
+    def test_nonzero_exit_sets_error_field(self):
+        executor = SubprocessExecutor("00010", script_path="/bin/false", timeout_seconds=10)
+
+        async def _run():
+            mock_proc = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b"segfault"))
+            mock_proc.returncode = 1
+            mock_proc.pid = 12345
+            with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=mock_proc):
+                return await executor.execute("do stuff", _CTX)
+
+        result = asyncio.get_event_loop().run_until_complete(_run())
+        assert result.error is not None
+        assert "exit" in result.error.lower() or "1" in result.error
+
+
+class TestExecuteTaskErrorCheck:
+    """Test that _execute_task raises ExecutionError when LaunchResult.error is set."""
+
+    def test_launch_result_error_raises_execution_error(self):
+        launch_result = LaunchResult(error="connection refused")
+        with pytest.raises(ExecutionError, match="connection refused"):
+            if launch_result.error:
+                raise ExecutionError(launch_result.error)
+
+    def test_launch_result_no_error_does_not_raise(self):
+        launch_result = LaunchResult(output="all good")
+        if launch_result.error:
+            raise ExecutionError(launch_result.error)
+
+
+class TestFailedPathCompleteness:
+    """Test that the FAILED path calls _push_to_ceo_session and _append_progress."""
+
+    def test_except_block_has_ceo_push_and_progress(self):
+        import inspect
+        from onemancompany.core.vessel import EmployeeManager
+
+        source = inspect.getsource(EmployeeManager._execute_task)
+        lines = source.split("\n")
+        in_except_block = False
+        found_ceo_push = False
+        found_progress = False
+        for line in lines:
+            if "except Exception as e:" in line:
+                in_except_block = True
+            elif in_except_block:
+                if line.strip().startswith("except ") or line.strip().startswith("finally:"):
+                    break
+                if "_push_to_ceo_session" in line:
+                    found_ceo_push = True
+                if "_append_progress" in line:
+                    found_progress = True
+        assert found_ceo_push, "except Exception block must call _push_to_ceo_session"
+        assert found_progress, "except Exception block must call _append_progress"
+
+
+class TestLogNodeWarning:
+    """Test that _log_node warns (not debug) when _current_entries is missing."""
+
+    def test_missing_current_entries_logs_warning(self):
+        import inspect
+        from onemancompany.core.vessel import EmployeeManager
+
+        source = inspect.getsource(EmployeeManager._log_node)
+        lines = source.split("\n")
+        in_else = False
+        for line in lines:
+            if "else:" in line:
+                in_else = True
+            elif in_else:
+                if "logger.warning" in line and "_current_entries" in line:
+                    return  # Found it
+                if "logger.debug" in line and "_current_entries" in line:
+                    pytest.fail("_log_node uses logger.debug for missing _current_entries — should be logger.warning")
+                if line.strip() and not line.strip().startswith("#"):
+                    break
+        pytest.fail("Could not find warning log for missing _current_entries in _log_node")

--- a/tests/unit/core/test_subprocess_executor.py
+++ b/tests/unit/core/test_subprocess_executor.py
@@ -72,8 +72,9 @@ class TestSubprocessExecutor:
         with patch("onemancompany.core.subprocess_executor.asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await exe.execute("do work", ctx)
 
-        assert "Error" in result.output
-        assert "exit 1" in result.output
+        assert result.error is not None
+        assert "Error" in result.error
+        assert "exit 1" in result.error
 
     @pytest.mark.asyncio
     async def test_execute_timeout_raises(self):


### PR DESCRIPTION
## Summary
- **LaunchResult** gains `error: str | None` field — executors populate it on failure instead of burying errors in `output`
- **ExecutionError** exception bridges executor errors into existing `except Exception` FAILED path
- **FAILED path** now calls `_push_to_ceo_session` and `_append_progress` — errors visible in CEO console + progress log
- **`_log_node`** warns (not debug) when `_current_entries` missing — easier diagnostics

Zero new systems — all changes feed into existing FAILED infrastructure (status machine, `_log_node`, WebSocket, frontend rendering).

## Test plan
- [x] 13 new unit tests in `test_error_transparency.py`
- [x] Full suite: 2279 passed, 0 regressions
- [x] Compilation verified
- [x] Code review passed (Important issue fixed: `on_log` type/content on error path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)