### PR TITLE
fix: show work_principles.md path in agent context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.63",
+  "version": "0.3.64",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.63"
+version = "0.3.64"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2000,8 +2000,11 @@ class EmployeeManager:
 
         # 4. Work principles
         principles = _store.load_employee_work_principles(employee_id)
+        wp_path = EMPLOYEES_DIR / employee_id / "work_principles.md"
         if principles and principles.strip():
-            parts.append(f"## Your Work Principles\n{principles.strip()}")
+            parts.append(f"## Your Work Principles\nFile: {wp_path}\n{principles.strip()}")
+        else:
+            parts.append(f"## Your Work Principles\nFile: {wp_path}\n(not yet written)")
 
         # 5. Talent-provided prompt (CLAUDE.md or talent_persona.md from onboarding)
         #    CLAUDE.md takes priority; fall back to talent_persona.md for LangChain talents.

--- a/tests/unit/core/test_company_context_injection.py
+++ b/tests/unit/core/test_company_context_injection.py
@@ -78,12 +78,14 @@ class TestBuildCompanyContextBlock:
     @patch(f"{_STORE}.load_employee_guidance", return_value=[])
     @patch(f"{_CONFIG}.load_workflows", return_value={})
     @patch(f"{_STORE}.load_culture", return_value=[])
-    def test_empty_when_no_data_founding(self, _cult, _wf, _guid, _wp, _prof):
-        """Founding employees get no role identity from this block."""
+    def test_minimal_when_no_data_founding(self, _cult, _wf, _guid, _wp, _prof):
+        """Founding employees get only work_principles path (no role identity)."""
         mgr = _make_manager("00003")
         mgr.executors = {"00003": MagicMock()}
         result = mgr._build_company_context_block("00003")
-        assert result == ""
+        assert "Work Principles" in result
+        assert "work_principles.md" in result
+        assert "not yet written" in result
 
     @_patch_profile(_MOCK_PROFILE)
     @patch(f"{_STORE}.load_employee_work_principles", return_value="")
@@ -109,8 +111,9 @@ class TestBuildCompanyContextBlock:
         mgr = _make_manager()
         mgr.executors["00010"] = MagicMock(spec=LangChainExecutor)
         result = mgr._build_company_context_block("00010")
-        # No identity, no other data → empty
-        assert result == ""
+        # No identity, but work_principles path is always present
+        assert "Who You Are" not in result
+        assert "work_principles.md" in result
 
     @_patch_profile(_MOCK_PROFILE)
     @patch(f"{_STORE}.load_employee_work_principles", return_value="")
@@ -189,12 +192,13 @@ class TestBuildCompanyContextBlock:
     @patch(f"{_STORE}.load_employee_guidance", return_value=[])
     @patch(f"{_CONFIG}.load_workflows", return_value={})
     @patch(f"{_STORE}.load_culture", return_value=[])
-    def test_whitespace_only_principles_skipped(self, _cult, _wf, _guid, _wp, _prof):
-        """Founding employee with whitespace-only principles → empty."""
+    def test_whitespace_only_principles_shows_path(self, _cult, _wf, _guid, _wp, _prof):
+        """Whitespace-only principles still shows file path."""
         mgr = _make_manager("00003")
         mgr.executors = {"00003": MagicMock()}
         result = mgr._build_company_context_block("00003")
-        assert result == ""
+        assert "work_principles.md" in result
+        assert "not yet written" in result
 
 
 class TestTalentPersonaLoading:


### PR DESCRIPTION
## Summary
- Agents now see the **file path** to their `work_principles.md` in the task context block
- Previously agents only saw content (or nothing for empty), so when asked to write work principles they didn't know where to write and wrote to wrong locations (e.g. company workflows)
- Always shows the path, even when empty ("not yet written"), so agents know where to create it

## Test plan
- [x] Updated 3 context injection tests
- [x] Full suite: 2303 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)