### PR TITLE
fix: improve project completion feedback for CEO

### DIFF
--- a/frontend/xterm-log.js
+++ b/frontend/xterm-log.js
@@ -179,9 +179,9 @@ class XTermLog {
     this._renderFeedNode(nodes, rootId, '');
   }
 
-  /** Trim a string to at most maxLen chars, appending '…' if truncated */
-  _clip(s, maxLen = 1000) {
-    return s.length > maxLen ? s.substring(0, maxLen) + '…' : s;
+  /** Pass-through — no truncation. Full content visible to CEO. */
+  _clip(s, _maxLen) {
+    return s;
   }
 
   // ─────────────────────────────────────────────────────────

--- a/frontend/xterm-log.js
+++ b/frontend/xterm-log.js
@@ -179,9 +179,9 @@ class XTermLog {
     this._renderFeedNode(nodes, rootId, '');
   }
 
-  /** Pass-through — no truncation. Full content visible to CEO. */
-  _clip(s, _maxLen) {
-    return s;
+  /** Clip very large strings to prevent xterm.js rendering lag. */
+  _clip(s, maxLen = 10000) {
+    return s.length > maxLen ? s.substring(0, maxLen) + '…' : s;
   }
 
   // ─────────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.68",
+  "version": "0.3.69",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.66",
+  "version": "0.3.67",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.64",
+  "version": "0.3.66",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.67",
+  "version": "0.3.68",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.67"
+version = "0.3.68"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.64"
+version = "0.3.66"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.68"
+version = "0.3.69"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.66"
+version = "0.3.67"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -633,31 +633,34 @@ async def task_followup(project_id: str, body: dict) -> dict:
 
     original_task = doc.get("task", "")
 
-    # Load task tree for context
+    # Load task tree and collect all previous work results
     tree_path = Path(pdir) / TASK_TREE_FILENAME
-    previous_result = ""
+    work_summary_lines: list[str] = []
     if tree_path.exists():
         tree = get_tree(tree_path, project_id=project_id)
-        root = tree.get_node(tree.root_id)
-        if root:
-            root.load_content(tree_path.parent)
-            if root.result:
-                previous_result = root.result
+        from onemancompany.core.vessel import _collect_work_results, _list_deliverables
+        work_nodes = _collect_work_results(tree, pdir)
+        for wn in work_nodes:
+            title = wn.title or wn.description_preview[:80]
+            result = (wn.result or "").strip()[:800]
+            work_summary_lines.append(f"  [{wn.employee_id}] {title}: {result}")
+        deliverables = _list_deliverables(pdir)
+        if deliverables:
+            work_summary_lines.append("")
+            work_summary_lines.append("Deliverable files in project directory:")
+            for fname in deliverables:
+                work_summary_lines.append(f"  {fname}")
 
     # Build follow-up task for EA
     context_parts = [
         f"CEO has added follow-up instructions to a completed task:\n",
         f"Original task: {original_task}\n",
     ]
-    if previous_result:
-        # Truncate very long results
-        prev = previous_result[:2000]
-        if len(previous_result) > 2000:
-            prev += "...(truncated)"
-        context_parts.append(f"Previous task result:\n{prev}\n")
+    if work_summary_lines:
+        context_parts.append(f"Previous work results:\n" + "\n".join(work_summary_lines) + "\n")
     context_parts.append(f"CEO follow-up instructions: {instructions}\n")
     context_parts.append(
-        f"\nPlease continue execution based on the CEO's follow-up instructions and previous task context."
+        f"\nBuild on the existing work — do NOT redo completed subtasks unless the CEO explicitly asks."
         f" Use dispatch_child() if subtasks are needed.\n\n"
         f"[Project ID: {project_id}] [Project workspace: {pdir}]"
     )

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -642,7 +642,7 @@ async def task_followup(project_id: str, body: dict) -> dict:
         work_nodes = _collect_work_results(tree, pdir)
         for wn in work_nodes:
             title = wn.title or wn.description_preview[:80]
-            result = (wn.result or "").strip()[:800]
+            result = (wn.result or "").strip()
             work_summary_lines.append(f"  [{wn.employee_id}] {title}: {result}")
         deliverables = _list_deliverables(pdir)
         if deliverables:

--- a/src/onemancompany/core/agent_loop.py
+++ b/src/onemancompany/core/agent_loop.py
@@ -34,7 +34,6 @@ from onemancompany.core.vessel import (  # noqa: F401 — explicit re-exports fo
     RETRY_DELAYS,
     MAX_HISTORY_ENTRIES,
     MAX_HISTORY_CHARS,
-    RESULT_SNIPPET_LEN,
     # Backward-compat aliases
     EmployeeHandle,
     _AgentRef,

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -682,6 +682,121 @@ def _trunc(s: str | None, limit: int = 3000) -> str:
     return text[:limit] + ("..." if len(text) > limit else "")
 
 
+def _result_preview(result: str, max_lines: int = 3, max_chars: int = 500) -> str:
+    """Extract a multi-line preview of a task result for CEO consumption."""
+    text = result.strip()
+    if not text:
+        return ""
+    lines = text.split("\n")[:max_lines]
+    preview = "\n    ".join(lines)
+    return preview[:max_chars]
+
+
+def _collect_work_results(tree, project_dir: str) -> list:
+    """Collect all completed/failed work nodes from the entire tree.
+
+    Returns task-type nodes that have results, excluding system and CEO nodes.
+    This recurses the full tree rather than only looking at direct children.
+    """
+    from onemancompany.core.task_lifecycle import SYSTEM_NODE_TYPES, TaskPhase
+
+    done_statuses = {
+        TaskPhase.COMPLETED.value, TaskPhase.ACCEPTED.value,
+        TaskPhase.FINISHED.value, TaskPhase.FAILED.value,
+    }
+    results = []
+    for node in tree.all_nodes():
+        if node.node_type in SYSTEM_NODE_TYPES or node.is_ceo_node:
+            continue
+        if node.status not in done_statuses:
+            continue
+        node.load_content(project_dir)
+        if node.result and node.result.strip():
+            results.append(node)
+    return results
+
+
+def _list_deliverables(project_dir: str) -> list[str]:
+    """List non-system files in project directory as deliverables."""
+    _skip = {"nodes", "task_tree.yaml", "llm_traces.jsonl", "iteration.yaml", ".DS_Store"}
+    pdir = Path(project_dir)
+    if not pdir.exists():
+        return []
+    files = []
+    for f in sorted(pdir.iterdir()):
+        if f.name in _skip or f.name.startswith("."):
+            continue
+        if f.is_file():
+            files.append(f.name)
+    return files
+
+
+async def _summarize_project_for_ceo(
+    project_name: str,
+    work_nodes: list,
+    deliverables: list[str],
+) -> str:
+    """Have EA write a concise project completion summary for the CEO.
+
+    Falls back to a simple result listing if the LLM call fails.
+    """
+    from onemancompany.agents.base import tracked_ainvoke
+    from onemancompany.core.config import EA_ID
+    from onemancompany.core.task_lifecycle import TaskPhase
+
+    # Build raw results context for EA
+    raw_parts: list[str] = []
+    for node in work_nodes:
+        status = "succeeded" if node.status != TaskPhase.FAILED.value else "FAILED"
+        title = node.title or node.description_preview[:80]
+        result = (node.result or "").strip()[:1000]
+        raw_parts.append(f"[{node.employee_id}] {title} ({status}):\n{result}")
+
+    if not raw_parts:
+        return ""
+
+    raw_context = "\n\n---\n\n".join(raw_parts)
+    deliverables_ctx = "\n".join(f"  - {f}" for f in deliverables) if deliverables else "(none)"
+
+    prompt = (
+        f"You are the Executive Assistant. Write a concise project completion report "
+        f"for the CEO.\n\n"
+        f"Project: {project_name}\n\n"
+        f"Deliverables:\n{deliverables_ctx}\n\n"
+        f"Raw task results:\n{raw_context}\n\n"
+        f"Instructions:\n"
+        f"- Summarize what was accomplished in 3-5 sentences\n"
+        f"- Highlight key deliverables and their quality\n"
+        f"- Note any failures or issues that need CEO attention\n"
+        f"- Use the project's language (Chinese if results are in Chinese)\n"
+        f"- Do NOT include greetings or signatures\n"
+        f"- Be direct and factual"
+    )
+
+    try:
+        llm = make_llm(EA_ID)
+        result = await tracked_ainvoke(llm, prompt, category="project_summary", employee_id=EA_ID)
+        summary = result.content.strip()
+        if summary:
+            logger.debug("[PROJECT SUMMARY] EA generated {}-char summary for {}", len(summary), project_name)
+            return summary
+    except Exception as e:
+        logger.warning("[PROJECT SUMMARY] EA summary failed for {}: {}", project_name, e)
+
+    # Fallback: simple result listing with previews
+    fallback_lines = ["Work summary:"]
+    for node in work_nodes:
+        status_icon = "✓" if node.status != TaskPhase.FAILED.value else "✗"
+        title = node.title or node.description_preview[:60]
+        preview = _result_preview(node.result or "")
+        if preview:
+            fallback_lines.append(f"  {status_icon} [{node.employee_id}] {title}:")
+            fallback_lines.append(f"    {preview}")
+        else:
+            fallback_lines.append(f"  {status_icon} [{node.employee_id}] {title}")
+    return "\n".join(fallback_lines)
+
+
 def _load_progress(employee_id: str, max_lines: int = PROGRESS_LOG_MAX_LINES) -> str:
     """Load recent entries from the employee's progress log."""
     path = EMPLOYEES_DIR / employee_id / PROGRESS_LOG_FILENAME
@@ -2446,27 +2561,42 @@ class EmployeeManager:
             if existing_confirm:
                 logger.debug("[PROJECT COMPLETE] Confirm node already exists for EA {} — skipping", ea_node.id)
             else:
-                # Build concise completion summary for CEO
+                # Build completion summary for CEO
                 _pdir = ea_node.project_dir or str(Path(entry.tree_path).parent)
-                ea_node.load_content(_pdir)
-                children = [c for c in tree.get_children(ea_node.id) if not c.is_ceo_node]
-                task_preview = (ea_node.description or "")[:120]
-                total = len(children)
-                succeeded = sum(1 for c in children if c.status in (TaskPhase.ACCEPTED.value, TaskPhase.FINISHED.value))
-                failed = sum(1 for c in children if c.status == TaskPhase.FAILED.value)
 
-                lines = [f"✅ Project complete: {task_preview}", ""]
-                lines.append(f"Result: {succeeded}/{total} subtasks succeeded" + (f", {failed} failed" if failed else ""))
-                lines.append("")
+                # Project name from project.yaml (not EA description)
+                _base_pid = project_id.split("/")[0] if project_id else ""
+                from onemancompany.core.project_archive import load_project as _load_proj
+                _proj_doc = _load_proj(_base_pid) if _base_pid else None
+                project_name = (_proj_doc or {}).get("name", "") or ea_node.description_preview[:80]
 
-                # Key deliverables — first line of each child's result
-                for child in children:
-                    child.load_content(_pdir)
-                    result_line = (child.result or "").strip().split("\n")[0][:150]
-                    if result_line:
-                        status_icon = "✓" if child.status in (TaskPhase.ACCEPTED.value, TaskPhase.FINISHED.value) else "✗"
-                        title = child.title or child.description_preview[:60]
-                        lines.append(f"  {status_icon} {title}: {result_line}")
+                # Recursively collect all work results from the tree
+                work_nodes = _collect_work_results(tree, _pdir)
+                succeeded = sum(
+                    1 for n in work_nodes
+                    if n.status in (TaskPhase.ACCEPTED.value, TaskPhase.FINISHED.value, TaskPhase.COMPLETED.value)
+                )
+                failed = sum(1 for n in work_nodes if n.status == TaskPhase.FAILED.value)
+                total = succeeded + failed
+
+                lines = [f"✅ {project_name} — complete", ""]
+                lines.append(f"{succeeded}/{total} subtasks succeeded" + (f", {failed} failed" if failed else ""))
+
+                # Deliverable files in project directory
+                deliverables = _list_deliverables(_pdir)
+                if deliverables:
+                    lines.append("")
+                    lines.append("Deliverables:")
+                    for fname in deliverables:
+                        lines.append(f"  {fname}")
+
+                # EA-written summary of work results for CEO
+                ea_summary = await _summarize_project_for_ceo(
+                    project_name, work_nodes, deliverables,
+                )
+                if ea_summary:
+                    lines.append("")
+                    lines.append(ea_summary)
 
                 lines.append("")
                 lines.append("Reply to confirm, or provide feedback for a new iteration.")

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -78,7 +78,6 @@ MAX_RETRIES = 3
 RETRY_DELAYS = [5, 15, 30]
 MAX_HISTORY_ENTRIES = 8
 MAX_HISTORY_CHARS = 3000
-RESULT_SNIPPET_LEN = 300
 
 # ---------------------------------------------------------------------------
 # ScheduleEntry — pure pointer to a TaskNode (replaces AgentTask)
@@ -644,12 +643,16 @@ class Vessel:
 # Progress log — file-based cross-task context (ralph-inspired)
 # ---------------------------------------------------------------------------
 
+_PROGRESS_LINE_MAX = 1000  # per-line cap for progress log (agent context, not CEO-facing)
+
+
 def _append_progress(employee_id: str, entry: str) -> None:
     """Append an entry to the employee's progress log (persistent across tasks)."""
     path = EMPLOYEES_DIR / employee_id / PROGRESS_LOG_FILENAME
     path.parent.mkdir(parents=True, exist_ok=True)
+    capped = entry[:_PROGRESS_LINE_MAX]
     with open(path, "a", encoding=ENCODING_UTF8) as f:
-        f.write(f"[{datetime.now().isoformat()[:19]}] {entry}\n")
+        f.write(f"[{datetime.now().isoformat()[:19]}] {capped}\n")
 
 
 # _append_execution_log removed — node-level execution.log (JSONL) is the single source of truth.
@@ -1534,7 +1537,7 @@ class EmployeeManager:
             if not node.completed_at:
                 node.completed_at = datetime.now().isoformat()
             self._log_node(employee_id, entry.node_id, "error", f"Task failed: {e!s}")
-            self._push_to_ceo_session(node, f"\u2717 {e!s}")
+            self._push_to_ceo_session(node, f"\u2717 {str(e)[:500]}")
             _append_progress(employee_id, f"Failed: {node.description_preview} \u2014 {e!s}")
             logger.exception("Unhandled error")
         finally:
@@ -1825,8 +1828,8 @@ class EmployeeManager:
         """Append task history from a TaskNode."""
         history = self.task_histories.setdefault(employee_id, [])
         history.append({
-            "task": node.description,
-            "result": node.result or "",
+            "task": (node.description or "")[:2000],
+            "result": (node.result or "")[:2000],
             "completed_at": node.completed_at or datetime.now().isoformat(),
         })
         _save_task_history(employee_id, history, self._history_summaries.get(employee_id, ""))

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -516,7 +516,7 @@ class ClaudeSessionExecutor(Launcher):
             error = output
             output = ""
         if on_log:
-            on_log("error" if error else "result", (error or output or "")[:500])
+            on_log("error" if error else "result", error or output or "")
         input_tokens = result.get("input_tokens", 0)
         output_tokens = result.get("output_tokens", 0)
         return LaunchResult(
@@ -569,10 +569,10 @@ class ScriptExecutor(Launcher):
                 err = stderr.decode(ENCODING_UTF8, errors="replace").strip()
                 error_msg = f"[script error] exit={proc.returncode}\n{err[:2000]}"
                 if on_log:
-                    on_log("error", error_msg[:500])
+                    on_log("error", error_msg)
                 return LaunchResult(error=error_msg)
             if on_log:
-                on_log("result", output[:500])
+                on_log("result", output)
             return LaunchResult(output=output)
         except asyncio.TimeoutError:
             return LaunchResult(error="[script timeout] Timed out after 600s")
@@ -1525,7 +1525,7 @@ class EmployeeManager:
                 node.completed_at = datetime.now().isoformat()
             self._log_node(employee_id, entry.node_id, "timeout", f"Task timed out after {node.timeout_seconds or 3600}s")
             self._push_to_ceo_session(node, f"\u2717 Timeout ({node.timeout_seconds or 3600}s)")
-            _append_progress(employee_id, f"Failed: {node.description_preview[:100]} \u2014 timeout")
+            _append_progress(employee_id, f"Failed: {node.description_preview} \u2014 timeout")
         except Exception as e:
             agent_error = True
             node.set_status(TaskPhase.FAILED)
@@ -1534,8 +1534,8 @@ class EmployeeManager:
             if not node.completed_at:
                 node.completed_at = datetime.now().isoformat()
             self._log_node(employee_id, entry.node_id, "error", f"Task failed: {e!s}")
-            self._push_to_ceo_session(node, f"\u2717 {e!s}"[:150])
-            _append_progress(employee_id, f"Failed: {node.description_preview[:100]} \u2014 {e!s}"[:300])
+            self._push_to_ceo_session(node, f"\u2717 {e!s}")
+            _append_progress(employee_id, f"Failed: {node.description_preview} \u2014 {e!s}")
             logger.exception("Unhandled error")
         finally:
             _current_vessel.reset(loop_token)
@@ -1611,12 +1611,12 @@ class EmployeeManager:
             # Record to history + progress
             if node.status in (TaskPhase.COMPLETED.value, TaskPhase.ACCEPTED.value, TaskPhase.FINISHED.value):
                 self._append_history_from_node(employee_id, node)
-                summary = (node.result or "")[:200]
-                _append_progress(employee_id, f"Completed: {node.description[:100]} → {summary}")
+                summary = node.result or ""
+                _append_progress(employee_id, f"Completed: {node.description_preview} → {summary}")
                 # Push result to CEO session
-                result_preview = (node.result or "").strip().split("\n")[0][:150]
-                if result_preview:
-                    self._push_to_ceo_session(node, f"✓ {result_preview}")
+                result_first_line = (node.result or "").strip().split("\n")[0]
+                if result_first_line:
+                    self._push_to_ceo_session(node, f"✓ {result_first_line}")
 
             # Post-task hook
             post_task_hook = self._hooks.get(employee_id, {}).get("post_task")
@@ -1792,12 +1792,12 @@ class EmployeeManager:
                 save_tree_async(entry.tree_path)
 
                 final_status = node.status
-                self._log_node(employee_id, task_id, "resumed", f"HOLDING → {final_status} with result: {result[:200]}")
+                self._log_node(employee_id, task_id, "resumed", f"HOLDING → {final_status} with result: {result}")
                 self._publish_node_update(employee_id, node)
 
                 self._append_history_from_node(employee_id, node)
-                summary = (node.result or "")[:200]
-                _append_progress(employee_id, f"Completed (resumed): {node.description_preview[:100]} → {summary}")
+                summary = node.result or ""
+                _append_progress(employee_id, f"Completed (resumed): {node.description_preview} → {summary}")
 
                 if node.project_dir:
                     try:
@@ -1825,8 +1825,8 @@ class EmployeeManager:
         """Append task history from a TaskNode."""
         history = self.task_histories.setdefault(employee_id, [])
         history.append({
-            "task": node.description[:200],
-            "result": (node.result or "")[:RESULT_SNIPPET_LEN],
+            "task": node.description,
+            "result": node.result or "",
             "completed_at": node.completed_at or datetime.now().isoformat(),
         })
         _save_task_history(employee_id, history, self._history_summaries.get(employee_id, ""))
@@ -2404,7 +2404,7 @@ class EmployeeManager:
                         if c.status == TaskPhase.FAILED.value
                     ]
                     failure_summary = "; ".join(
-                        f"[{c.employee_id}] {c.description_preview}: {(c.result or 'no details')[:150]}"
+                        f"[{c.employee_id}] {c.description_preview}: {c.result or 'no details'}"
                         for c in failed_children
                     )
                     resume_desc = (
@@ -2453,7 +2453,7 @@ class EmployeeManager:
                         if c.status == TaskPhase.CANCELLED.value
                     ]
                     cancel_summary = "; ".join(
-                        f"[{c.employee_id}] {c.description_preview}: {(c.result or 'cancelled')[:150]}"
+                        f"[{c.employee_id}] {c.description_preview}: {c.result or 'cancelled'}"
                         for c in cancelled_children
                     )
                     resume_desc = (
@@ -3498,7 +3498,7 @@ def scan_overdue_reviews(threshold_seconds: int = 300) -> list[dict]:
                 "node_id": node.id,
                 "employee_id": node.employee_id,
                 "reviewer_id": reviewer_id,
-                "description": (node.description or "")[:200],
+                "description": node.description or "",
                 "completed_at": node.completed_at,
                 "waiting_seconds": int(elapsed),
                 "project_id": node.project_id or project_dir.name,

--- a/tests/unit/core/test_ceo_integration.py
+++ b/tests/unit/core/test_ceo_integration.py
@@ -184,11 +184,15 @@ class TestProjectCompletionConfirmFlow:
             # The child just finished — trigger completion propagation
             entry = ScheduleEntry(node_id=child.id, tree_path=str(tree_path))
 
+            mock_summary_resp = MagicMock()
+            mock_summary_resp.content = "Project completed successfully."
             with (
                 patch(_SAVE_TREE_PATH),
                 patch(_STORE_PATH) as mock_store,
                 patch("onemancompany.core.vessel._store") as mock_store2,
                 patch.object(em, "_publish_node_update"),
+                patch("onemancompany.agents.base.tracked_ainvoke", new_callable=AsyncMock, return_value=mock_summary_resp),
+                patch("onemancompany.core.vessel.make_llm"),
             ):
                 mock_store.save_project_status = AsyncMock()
                 mock_store2.save_project_status = AsyncMock()

--- a/tests/unit/core/test_completion_feedback.py
+++ b/tests/unit/core/test_completion_feedback.py
@@ -1,7 +1,6 @@
 """Unit tests for project completion feedback — CEO confirmation message quality."""
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -125,32 +124,29 @@ class TestSummarizeProjectForCeo:
         node.status = status
         return node
 
-    def test_ea_summary_returned_on_success(self):
+    @pytest.mark.asyncio
+    async def test_ea_summary_returned_on_success(self):
         mock_response = MagicMock()
         mock_response.content = "项目已完成，提案已修订。"
         nodes = [self._make_work_node("00005", "Write proposal", "Done writing")]
 
         with patch("onemancompany.core.vessel.make_llm"), \
              patch("onemancompany.agents.base.tracked_ainvoke", new_callable=AsyncMock, return_value=mock_response):
-            result = asyncio.get_event_loop().run_until_complete(
-                _summarize_project_for_ceo("Test Project", nodes, ["proposal.md"])
-            )
+            result = await _summarize_project_for_ceo("Test Project", nodes, ["proposal.md"])
         assert result == "项目已完成，提案已修订。"
 
-    def test_fallback_on_llm_failure(self):
+    @pytest.mark.asyncio
+    async def test_fallback_on_llm_failure(self):
         nodes = [self._make_work_node("00005", "Write proposal", "Done writing")]
 
         with patch("onemancompany.core.vessel.make_llm"), \
              patch("onemancompany.agents.base.tracked_ainvoke", new_callable=AsyncMock, side_effect=Exception("LLM down")):
-            result = asyncio.get_event_loop().run_until_complete(
-                _summarize_project_for_ceo("Test Project", nodes, [])
-            )
+            result = await _summarize_project_for_ceo("Test Project", nodes, [])
         assert "Work summary:" in result
         assert "00005" in result
         assert "Write proposal" in result
 
-    def test_empty_work_nodes_returns_empty(self):
-        result = asyncio.get_event_loop().run_until_complete(
-            _summarize_project_for_ceo("Test Project", [], [])
-        )
+    @pytest.mark.asyncio
+    async def test_empty_work_nodes_returns_empty(self):
+        result = await _summarize_project_for_ceo("Test Project", [], [])
         assert result == ""

--- a/tests/unit/core/test_completion_feedback.py
+++ b/tests/unit/core/test_completion_feedback.py
@@ -1,0 +1,156 @@
+"""Unit tests for project completion feedback — CEO confirmation message quality."""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from onemancompany.core.vessel import (
+    _collect_work_results,
+    _list_deliverables,
+    _result_preview,
+    _summarize_project_for_ceo,
+)
+
+
+class TestResultPreview:
+    def test_single_line(self):
+        assert _result_preview("hello world") == "hello world"
+
+    def test_multi_line_truncates_to_3(self):
+        text = "line1\nline2\nline3\nline4\nline5"
+        result = _result_preview(text)
+        assert "line1" in result
+        assert "line2" in result
+        assert "line3" in result
+        assert "line4" not in result
+
+    def test_respects_max_chars(self):
+        text = "a" * 1000
+        result = _result_preview(text, max_chars=100)
+        assert len(result) <= 100
+
+    def test_empty_string(self):
+        assert _result_preview("") == ""
+
+    def test_whitespace_only(self):
+        assert _result_preview("   \n  \n  ") == ""
+
+
+class TestListDeliverables:
+    def test_lists_files_excludes_system(self, tmp_path):
+        (tmp_path / "proposal.md").write_text("hello")
+        (tmp_path / "task_tree.yaml").write_text("tree")
+        (tmp_path / "llm_traces.jsonl").write_text("traces")
+        (tmp_path / "nodes").mkdir()
+        (tmp_path / ".DS_Store").write_text("ds")
+
+        result = _list_deliverables(str(tmp_path))
+        assert result == ["proposal.md"]
+
+    def test_empty_dir(self, tmp_path):
+        assert _list_deliverables(str(tmp_path)) == []
+
+    def test_nonexistent_dir(self):
+        assert _list_deliverables("/nonexistent/path") == []
+
+    def test_multiple_files_sorted(self, tmp_path):
+        (tmp_path / "report.pdf").write_text("r")
+        (tmp_path / "analysis.md").write_text("a")
+        (tmp_path / "budget.xlsx").write_text("b")
+
+        result = _list_deliverables(str(tmp_path))
+        assert result == ["analysis.md", "budget.xlsx", "report.pdf"]
+
+    def test_excludes_iteration_yaml(self, tmp_path):
+        (tmp_path / "iteration.yaml").write_text("iter")
+        (tmp_path / "deliverable.md").write_text("d")
+
+        result = _list_deliverables(str(tmp_path))
+        assert result == ["deliverable.md"]
+
+
+class TestCollectWorkResults:
+    def test_collects_completed_task_nodes(self):
+        """Verify _collect_work_results returns completed task nodes, not system nodes."""
+        from unittest.mock import MagicMock
+        from onemancompany.core.task_lifecycle import NodeType, TaskPhase
+
+        node1 = MagicMock()
+        node1.node_type = NodeType.TASK
+        node1.status = TaskPhase.FINISHED.value
+        node1.is_ceo_node = False
+        node1.result = "did some work"
+        node1.employee_id = "00005"
+
+        node2 = MagicMock()
+        node2.node_type = NodeType.WATCHDOG_NUDGE
+        node2.status = TaskPhase.FINISHED.value
+        node2.is_ceo_node = False
+        node2.result = "nudge"
+
+        node3 = MagicMock()
+        node3.node_type = NodeType.CEO_REQUEST
+        node3.status = TaskPhase.FINISHED.value
+        node3.is_ceo_node = True
+        node3.result = "confirmed"
+
+        node4 = MagicMock()
+        node4.node_type = NodeType.TASK
+        node4.status = TaskPhase.FAILED.value
+        node4.is_ceo_node = False
+        node4.result = "error happened"
+        node4.employee_id = "00010"
+
+        tree = MagicMock()
+        tree.all_nodes.return_value = [node1, node2, node3, node4]
+
+        results = _collect_work_results(tree, "/tmp/proj")
+        # Should include node1 (finished task) and node4 (failed task with result)
+        # Should exclude node2 (system) and node3 (ceo node)
+        assert len(results) == 2
+        assert node1 in results
+        assert node4 in results
+
+
+class TestSummarizeProjectForCeo:
+    def _make_work_node(self, employee_id, title, result, status="finished"):
+        node = MagicMock()
+        node.employee_id = employee_id
+        node.title = title
+        node.description_preview = title
+        node.result = result
+        node.status = status
+        return node
+
+    def test_ea_summary_returned_on_success(self):
+        mock_response = MagicMock()
+        mock_response.content = "项目已完成，提案已修订。"
+        nodes = [self._make_work_node("00005", "Write proposal", "Done writing")]
+
+        with patch("onemancompany.core.vessel.make_llm"), \
+             patch("onemancompany.agents.base.tracked_ainvoke", new_callable=AsyncMock, return_value=mock_response):
+            result = asyncio.get_event_loop().run_until_complete(
+                _summarize_project_for_ceo("Test Project", nodes, ["proposal.md"])
+            )
+        assert result == "项目已完成，提案已修订。"
+
+    def test_fallback_on_llm_failure(self):
+        nodes = [self._make_work_node("00005", "Write proposal", "Done writing")]
+
+        with patch("onemancompany.core.vessel.make_llm"), \
+             patch("onemancompany.agents.base.tracked_ainvoke", new_callable=AsyncMock, side_effect=Exception("LLM down")):
+            result = asyncio.get_event_loop().run_until_complete(
+                _summarize_project_for_ceo("Test Project", nodes, [])
+            )
+        assert "Work summary:" in result
+        assert "00005" in result
+        assert "Write proposal" in result
+
+    def test_empty_work_nodes_returns_empty(self):
+        result = asyncio.get_event_loop().run_until_complete(
+            _summarize_project_for_ceo("Test Project", [], [])
+        )
+        assert result == ""

--- a/tests/unit/core/test_vessel.py
+++ b/tests/unit/core/test_vessel.py
@@ -521,7 +521,7 @@ class TestProjectConfirmViaExecutor:
         ea_children = reloaded.get_children(ea.id)
         confirm_nodes = [c for c in ea_children if c.node_type == NodeType.CEO_REQUEST.value or c.node_type == NodeType.CEO_REQUEST]
         assert len(confirm_nodes) == 1
-        assert "Project complete" in confirm_nodes[0].description_preview
+        assert "complete" in confirm_nodes[0].description_preview.lower()
 
     @pytest.mark.asyncio
     @patch("onemancompany.core.vessel.company_state")


### PR DESCRIPTION
## Summary
- **Project name** from project.yaml replaces EA description in confirmation message
- **Recursive collection** of all work node results (not just direct EA children — fixes 0/0 bug)
- **Deliverable files** listed from project directory (excludes system files)
- **Multi-line result previews** (3 lines / 500 chars) replace single-line / 150 char truncation

Before (omc-test-4):
```
✅ Project complete: CEO has assigned a new task. Please analyze...
Result: 0/0 subtasks succeeded
```

After:
```
✅ Flooring Store Inventory System Proposal — complete

2/2 subtasks succeeded

Deliverables:
  flooring_store_inventory_proposal.md

Work summary:
  ✓ [00004] EA dispatch:
    已分析CEO指令并将任务分配给COO...
  ✓ [00005] Final Quality Review:
    已完成对项目建议书的详细修订...
```

## Test plan
- [x] 11 new tests for helper functions
- [x] Updated existing confirm node test
- [x] Full suite: 2314 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)