### PR TITLE
fix: write/edit tools mark employees dirty for frontend sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.70",
+  "version": "0.3.71",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.69",
+  "version": "0.3.70",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.69"
+version = "0.3.70"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.70"
+version = "0.3.71"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -59,18 +59,18 @@ async def _chat(room_id: str, speaker: str, role: str, message: str) -> None:
 _files_read_by_employee: dict[str, set[str]] = {}
 
 
-def _mark_dirty_if_employee_path(resolved_path) -> None:
+def _mark_dirty_if_employee_path(resolved_path: Path) -> None:
     """If the written path is under EMPLOYEES_DIR, mark employees dirty for sync."""
     from onemancompany.core.config import EMPLOYEES_DIR
     from onemancompany.core.store import DirtyCategory, mark_dirty
 
     try:
-        resolved_str = str(resolved_path.resolve())
-        employees_str = str(EMPLOYEES_DIR.resolve())
-        if resolved_str.startswith(employees_str):
-            mark_dirty(DirtyCategory.EMPLOYEES)
+        resolved_path.resolve().relative_to(EMPLOYEES_DIR.resolve())
+        mark_dirty(DirtyCategory.EMPLOYEES)
+    except ValueError:
+        return  # not under EMPLOYEES_DIR — no dirty flag needed
     except Exception as exc:
-        logger.debug("_mark_dirty_if_employee_path failed: {}", exc)
+        logger.warning("_mark_dirty_if_employee_path failed: {}", exc)
 
 
 def _resolve_employee_path(file_path: str, employee_id: str = ""):

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -59,6 +59,20 @@ async def _chat(room_id: str, speaker: str, role: str, message: str) -> None:
 _files_read_by_employee: dict[str, set[str]] = {}
 
 
+def _mark_dirty_if_employee_path(resolved_path) -> None:
+    """If the written path is under EMPLOYEES_DIR, mark employees dirty for sync."""
+    from onemancompany.core.config import EMPLOYEES_DIR
+    from onemancompany.core.store import DirtyCategory, mark_dirty
+
+    try:
+        resolved_str = str(resolved_path.resolve())
+        employees_str = str(EMPLOYEES_DIR.resolve())
+        if resolved_str.startswith(employees_str):
+            mark_dirty(DirtyCategory.EMPLOYEES)
+    except Exception as exc:
+        logger.debug("_mark_dirty_if_employee_path failed: {}", exc)
+
+
 def _resolve_employee_path(file_path: str, employee_id: str = ""):
     """Resolve a file path using employee permissions. Returns Path or None."""
     from pathlib import Path
@@ -215,6 +229,7 @@ async def write(
 
     resolved.parent.mkdir(parents=True, exist_ok=True)
     write_text_utf(resolved, content)
+    _mark_dirty_if_employee_path(resolved)
     _files_read_by_employee.setdefault(employee_id, set()).add(str(resolved))
 
     result: dict = {
@@ -292,6 +307,7 @@ async def edit(
         replacements = 1
 
     write_text_utf(resolved, new_content)
+    _mark_dirty_if_employee_path(resolved)
     return {
         "status": "ok",
         "path": str(resolved),

--- a/tests/unit/agents/test_write_dirty_flag.py
+++ b/tests/unit/agents/test_write_dirty_flag.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import pytest
 
 from onemancompany.agents.common_tools import _mark_dirty_if_employee_path
+from onemancompany.core.store import DirtyCategory
 
 
 class TestMarkDirtyIfEmployeePath:
@@ -26,7 +27,7 @@ class TestMarkDirtyIfEmployeePath:
         with patch("onemancompany.core.config.EMPLOYEES_DIR", emp_dir), \
              patch("onemancompany.core.store.mark_dirty") as mock_dirty:
             _mark_dirty_if_employee_path(target)
-            mock_dirty.assert_called_once()
+            mock_dirty.assert_called_once_with(DirtyCategory.EMPLOYEES)
 
     def test_non_employee_path_does_not_mark_dirty(self, tmp_path):
         emp_dir = tmp_path / "company" / "human_resource" / "employees"

--- a/tests/unit/agents/test_write_dirty_flag.py
+++ b/tests/unit/agents/test_write_dirty_flag.py
@@ -1,0 +1,57 @@
+"""Regression test: write/edit to employee files must mark EMPLOYEES dirty.
+
+Root cause: agents using write()/edit() tools to modify employee files
+(e.g., work_principles.md) bypassed store.mark_dirty(), so the sync tick
+never broadcast changes to the frontend.
+"""
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from onemancompany.agents.common_tools import _mark_dirty_if_employee_path
+
+
+class TestMarkDirtyIfEmployeePath:
+    def test_employee_path_marks_dirty(self, tmp_path):
+        emp_dir = tmp_path / "company" / "human_resource" / "employees"
+        emp_dir.mkdir(parents=True)
+        target = emp_dir / "00004" / "work_principles.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("hello")
+
+        with patch("onemancompany.core.config.EMPLOYEES_DIR", emp_dir), \
+             patch("onemancompany.core.store.mark_dirty") as mock_dirty:
+            _mark_dirty_if_employee_path(target)
+            mock_dirty.assert_called_once()
+
+    def test_non_employee_path_does_not_mark_dirty(self, tmp_path):
+        emp_dir = tmp_path / "company" / "human_resource" / "employees"
+        emp_dir.mkdir(parents=True)
+        other = tmp_path / "company" / "business" / "projects" / "file.md"
+        other.parent.mkdir(parents=True)
+        other.write_text("hello")
+
+        with patch("onemancompany.core.config.EMPLOYEES_DIR", emp_dir), \
+             patch("onemancompany.core.store.mark_dirty") as mock_dirty:
+            _mark_dirty_if_employee_path(other)
+            mock_dirty.assert_not_called()
+
+
+class TestWriteEditCallMarkDirty:
+    """Structural test: verify write() and edit() call _mark_dirty_if_employee_path."""
+
+    def test_write_calls_mark_dirty(self):
+        from onemancompany.agents.common_tools import write
+        source = inspect.getsource(write.coroutine)
+        assert "_mark_dirty_if_employee_path" in source, \
+            "write() tool must call _mark_dirty_if_employee_path after writing"
+
+    def test_edit_calls_mark_dirty(self):
+        from onemancompany.agents.common_tools import edit
+        source = inspect.getsource(edit.coroutine)
+        assert "_mark_dirty_if_employee_path" in source, \
+            "edit() tool must call _mark_dirty_if_employee_path after editing"


### PR DESCRIPTION
## Summary
- **Root cause**: agents using `write()`/`edit()` tools to modify employee files (e.g., `work_principles.md`) bypassed `store.mark_dirty()`, so the sync tick never broadcast changes to the frontend
- Added `_mark_dirty_if_employee_path()` — checks if written path is under `EMPLOYEES_DIR` and marks dirty
- Called from both `write()` and `edit()` tools after file writes

## Test plan
- [x] 4 new regression tests (dirty flag behavior + structural verification)
- [x] Full suite: 2321 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)