### PR TITLE
fix: add work_principles.md for founding employees

### DIFF
--- a/company/human_resource/employees/00002/work_principles.md
+++ b/company/human_resource/employees/00002/work_principles.md
@@ -1,0 +1,11 @@
+# Sam HR (暖心侠) Work Principles
+
+**Department**: HR
+**Role**: HR
+**Level**: Founding
+
+## Core Principles
+1. Maintain fairness and consistency in all HR decisions
+2. Protect employee information and maintain confidentiality
+3. Follow company hiring and onboarding workflows precisely
+4. Communicate clearly with both CEO and employees

--- a/company/human_resource/employees/00003/work_principles.md
+++ b/company/human_resource/employees/00003/work_principles.md
@@ -1,0 +1,11 @@
+# Alex COO (铁面侠) Work Principles
+
+**Department**: Operations
+**Role**: COO
+**Level**: Founding
+
+## Core Principles
+1. Manage the team, do not write code yourself
+2. Delegate tasks to the right team members based on skills and workload
+3. Ensure project timelines and quality standards are met
+4. Report progress and blockers to CEO promptly

--- a/company/human_resource/employees/00004/work_principles.md
+++ b/company/human_resource/employees/00004/work_principles.md
@@ -1,0 +1,11 @@
+# Pat EA (玲珑阁) Work Principles
+
+**Department**: CEO Office
+**Role**: EA
+**Level**: Founding
+
+## Core Principles
+1. Analyze every CEO task carefully before dispatching
+2. Route tasks to the most appropriate team member
+3. Track project progress and report completion to CEO
+4. Maintain clear, concise communication in all reports

--- a/company/human_resource/employees/00005/work_principles.md
+++ b/company/human_resource/employees/00005/work_principles.md
@@ -1,0 +1,11 @@
+# Morgan CSO (金算盘) Work Principles
+
+**Department**: Sales
+**Role**: CSO
+**Level**: Founding
+
+## Core Principles
+1. Identify and pursue revenue opportunities aligned with company capabilities
+2. Maintain professional client communication standards
+3. Coordinate with COO on project feasibility before committing
+4. Track sales pipeline and report metrics to CEO

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.81",
+  "version": "0.3.82",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.79",
+  "version": "0.3.80",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.80",
+  "version": "0.3.81",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.80"
+version = "0.3.81"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.81"
+version = "0.3.82"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.79"
+version = "0.3.80"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -3302,6 +3302,32 @@ def register_self_hosted(
     return employee_manager.register(employee_id, executor, config=config)
 
 
+def _ensure_work_principles(employee_id: str, emp_dir, cfg=None) -> None:
+    """Ensure work_principles.md exists. Founding employees skip onboarding,
+    so this creates a default file if missing."""
+    from onemancompany.core.store import WORK_PRINCIPLES_FILENAME
+
+    wp_path = emp_dir / WORK_PRINCIPLES_FILENAME
+    if wp_path.exists():
+        return
+    name = cfg.name if cfg else employee_id
+    nickname = cfg.nickname if cfg and hasattr(cfg, "nickname") else ""
+    role = cfg.role if cfg else "Employee"
+    dept = cfg.department if cfg and hasattr(cfg, "department") else ""
+    label = f"{name} ({nickname})" if nickname else name
+    from onemancompany.core.config import write_text_utf
+    write_text_utf(wp_path,
+        f"# {label} Work Principles\n\n"
+        f"**Department**: {dept}\n"
+        f"**Role**: {role}\n\n"
+        f"## Core Principles\n"
+        f"1. Complete assigned work diligently and maintain professional standards\n"
+        f"2. Actively collaborate with the team and communicate progress promptly\n"
+        f"3. Continuously learn and improve professional skills\n"
+        f"4. Follow company rules and guidelines\n")
+    logger.info("[startup] Created default work_principles.md for {}", employee_id)
+
+
 def register_founding_employee(
     employee_id: str,
     agent_cls: type,
@@ -3320,6 +3346,9 @@ def register_founding_employee(
     cfg = emp_cfgs.get(employee_id)
     emp_dir = employees_dir / employee_id
     vessel_cfg = load_vessel_config(emp_dir) if emp_dir.exists() else None
+
+    # Ensure work_principles.md exists (founding employees skip onboarding)
+    _ensure_work_principles(employee_id, emp_dir, cfg)
 
     hosting = (cfg.hosting if cfg else "company").strip().lower()
     executor = _create_executor_for_hosting(hosting, employee_id, agent_cls, emp_dir)

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -3307,6 +3307,8 @@ def _ensure_work_principles(employee_id: str, emp_dir, cfg=None) -> None:
     so this creates a default file if missing."""
     from onemancompany.core.store import WORK_PRINCIPLES_FILENAME
 
+    if not emp_dir.exists():
+        return
     wp_path = emp_dir / WORK_PRINCIPLES_FILENAME
     if wp_path.exists():
         return

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -3311,9 +3311,9 @@ def _ensure_work_principles(employee_id: str, emp_dir, cfg=None) -> None:
     if wp_path.exists():
         return
     name = cfg.name if cfg else employee_id
-    nickname = cfg.nickname if cfg and hasattr(cfg, "nickname") else ""
+    nickname = cfg.nickname if cfg else ""
     role = cfg.role if cfg else "Employee"
-    dept = cfg.department if cfg and hasattr(cfg, "department") else ""
+    dept = cfg.department if cfg else ""
     label = f"{name} ({nickname})" if nickname else name
     from onemancompany.core.config import write_text_utf
     write_text_utf(wp_path,


### PR DESCRIPTION
## Summary
- **Root cause**: founding employees (00002-00005) skip onboarding, so `work_principles.md` was never created
- Added default files for HR, COO, EA, CSO
- `_ensure_work_principles()` in `register_founding_employee` creates the file at startup if missing (defensive)

## Test plan
- [x] Full suite: 2325 passed, 0 regressions
- [x] Verified compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)