### PR TITLE
fix: add edit hint to work_principles context block

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.82",
+  "version": "0.3.83",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.82"
+version = "0.3.83"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2119,10 +2119,11 @@ class EmployeeManager:
         # 4. Work principles
         principles = _store.load_employee_work_principles(employee_id)
         wp_path = EMPLOYEES_DIR / employee_id / "work_principles.md"
+        wp_hint = "To update: read() this file first, then edit() to modify."
         if principles and principles.strip():
-            parts.append(f"## Your Work Principles\nFile: {wp_path}\n{principles.strip()}")
+            parts.append(f"## Your Work Principles\nFile: {wp_path}\n{wp_hint}\n{principles.strip()}")
         else:
-            parts.append(f"## Your Work Principles\nFile: {wp_path}\n(not yet written)")
+            parts.append(f"## Your Work Principles\nFile: {wp_path}\n{wp_hint}\n(not yet written)")
 
         # 5. Talent-provided prompt (CLAUDE.md or talent_persona.md from onboarding)
         #    CLAUDE.md takes priority; fall back to talent_persona.md for LangChain talents.


### PR DESCRIPTION
## Summary
- Agents didn't know how to modify their own `work_principles.md` — path was shown but no usage instruction
- Added hint: "To update: read() this file first, then edit() to modify."
- Shown in every agent's task context alongside their work principles content

## Test plan
- [x] Context injection tests: 18 passed
- [x] Full suite: 2325 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)