### PR TITLE
feat: input validation + verification hints (tool reliability Batch 3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.94",
+  "version": "0.3.95",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.94"
+version = "0.3.95"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -60,6 +60,13 @@ async def _chat(room_id: str, speaker: str, role: str, message: str) -> None:
 _files_read_by_employee: dict[str, set[str]] = {}
 
 
+def _validate_employee_id(employee_id: str) -> dict | None:
+    """Validate employee_id is non-empty. Returns error dict or None if valid."""
+    if not employee_id or not employee_id.strip():
+        return {"status": "error", "message": "employee_id is required. Use list_colleagues() to find valid IDs."}
+    return None
+
+
 def _resolve_employee_path(file_path: str, employee_id: str = ""):
     """Resolve a file path using employee permissions. Returns Path or None."""
     from pathlib import Path
@@ -226,6 +233,7 @@ async def write(
         "status": "ok",
         "path": str(resolved),
         "type": "update" if is_update else "create",
+        "next_step": f"Verify with read('{file_path}').",
     }
     if is_update and original_content != content:
         # Compute a simple line-level diff summary
@@ -303,6 +311,7 @@ async def edit(
         "status": "ok",
         "path": str(resolved),
         "replacements": replacements,
+        "next_step": f"Verify with read('{file_path}').",
     }
 
 
@@ -1692,6 +1701,9 @@ async def update_work_principles(
         content: The complete new work principles content (Markdown).
         employee_id: Your own employee ID (auto-filled).
     """
+    id_err = _validate_employee_id(target_employee_id)
+    if id_err:
+        return id_err
     if not content or not content.strip():
         return {"status": "error", "message": "Content cannot be empty."}
 
@@ -1705,7 +1717,7 @@ async def update_work_principles(
     await _store.save_work_principles(target_employee_id, content)
     from onemancompany.core.config import EMPLOYEES_DIR
     path = EMPLOYEES_DIR / target_employee_id / "work_principles.md"
-    return {"status": "ok", "employee_id": target_employee_id, "path": str(path)}
+    return {"status": "ok", "employee_id": target_employee_id, "path": str(path), "next_step": "Verify by reading the employee's detail page."}
 
 
 @tool
@@ -1726,6 +1738,9 @@ async def update_guidance(
         note: The guidance note text (one clear, actionable instruction).
         employee_id: Your own employee ID (auto-filled).
     """
+    id_err = _validate_employee_id(target_employee_id)
+    if id_err:
+        return id_err
     if not note or not note.strip():
         return {"status": "error", "message": "Note cannot be empty."}
 

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -255,7 +255,11 @@ def dispatch_child(
             )
         return {"status": "error", "message": "No project directory in current task context."}
 
-    # Validate employee exists
+    # Validate employee_id format and existence
+    from onemancompany.agents.common_tools import _validate_employee_id
+    id_err = _validate_employee_id(employee_id)
+    if id_err:
+        return id_err
     from onemancompany.core.store import load_employee
     if not load_employee(employee_id):
         return {"status": "error", "message": f"Employee {employee_id} not found. Use list_colleagues() to find valid IDs."}

--- a/tests/unit/agents/test_tool_reliability.py
+++ b/tests/unit/agents/test_tool_reliability.py
@@ -110,3 +110,58 @@ class TestToolSelectionGuide:
         assert "IMPORTANT" in prompt
         assert "verify the change" in prompt.lower()
         assert "Internal vs External" in prompt
+
+
+class TestInputValidation:
+    def test_validate_employee_id_valid(self):
+        from onemancompany.agents.common_tools import _validate_employee_id
+        assert _validate_employee_id("00004") is None
+        assert _validate_employee_id("00010") is None
+
+    def test_validate_employee_id_non_empty_passes(self):
+        from onemancompany.agents.common_tools import _validate_employee_id
+        assert _validate_employee_id("abc") is None  # format not enforced, existence check handles it
+
+    def test_validate_employee_id_empty(self):
+        from onemancompany.agents.common_tools import _validate_employee_id
+        result = _validate_employee_id("")
+        assert result["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_update_work_principles_empty_id(self):
+        from onemancompany.agents.common_tools import update_work_principles
+        result = await update_work_principles.coroutine(
+            target_employee_id="",
+            content="anything",
+            employee_id="00004",
+        )
+        assert result["status"] == "error"
+        assert "required" in result["message"].lower()
+
+
+class TestNextStepHints:
+    @pytest.mark.asyncio
+    async def test_write_returns_next_step(self, tmp_path):
+        from onemancompany.agents.common_tools import write
+        target = tmp_path / "test.md"
+
+        with patch("onemancompany.agents.common_tools._resolve_employee_path", return_value=target):
+            result = await write.coroutine(file_path=str(target), content="hello", employee_id="00010")
+        assert result["status"] == "ok"
+        assert "next_step" in result
+        assert "read" in result["next_step"].lower()
+
+    @pytest.mark.asyncio
+    async def test_update_work_principles_returns_next_step(self):
+        with patch("onemancompany.agents.common_tools._store") as mock_store:
+            mock_store.save_work_principles = AsyncMock()
+            mock_store.load_employee = lambda eid: {"id": eid} if eid == "00004" else None
+
+            from onemancompany.agents.common_tools import update_work_principles
+            result = await update_work_principles.coroutine(
+                target_employee_id="00004",
+                content="# Principles",
+                employee_id="00004",
+            )
+        assert result["status"] == "ok"
+        assert "next_step" in result


### PR DESCRIPTION
## Summary
- **Input validation**: `_validate_employee_id()` shared helper, used in dispatch_child, update_work_principles, update_guidance
- **Verification hints**: write()/edit() success returns include `"next_step": "Verify with read('...')"`. update_work_principles includes similar hint.
- Completes the 3-batch tool reliability upgrade

## Test plan
- [x] 6 new tests for validation + next_step hints
- [x] Full suite: 2338 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)