### PR TITLE
fix: clean CEO confirm prompt + dismiss error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.96",
+  "version": "0.3.97",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.97",
-  "description": "The Agent Operating System for One-Person Companies",
+  "version": "0.3.96",
+  "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.96"
+version = "0.3.97"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.97"
+version = "0.3.96"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -1350,6 +1350,11 @@ async def fire_employee(employee_id: str, body: dict) -> dict:
         result = await execute_fire(employee_id, reason)
     except Exception as e:
         logger.error("fire_employee failed for {}: {}", employee_id, e)
+        # Check if employee was actually removed despite the error
+        from onemancompany.core.store import load_employee as _load_emp
+        if _load_emp(employee_id) is None:
+            logger.info("Employee {} was removed despite error — returning success", employee_id)
+            return {"status": "fired", "id": employee_id, "name": "", "nickname": "", "reason": reason}
         return {"error": str(e)}
     return result
 

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1344,43 +1344,50 @@ class EmployeeManager:
                              entry.node_id, _effective_dir)
                 save_tree_async(entry.tree_path)
 
-            # Tree context includes current node description + ancestors + children
-            tree_ctx = _build_tree_context(tree, node, _effective_dir)
-            task_with_ctx = tree_ctx if tree_ctx else node.description
+            # CEO_REQUEST nodes (confirm/inbox) get clean description only —
+            # no tree context, no SOPs, no progress log. The confirm message
+            # built by _on_child_complete already contains the full summary.
+            is_ceo_request = node.node_type in (NodeType.CEO_REQUEST, NodeType.CEO_REQUEST.value)
+            if is_ceo_request:
+                task_with_ctx = node.description
+            else:
+                # Tree context includes current node description + ancestors + children
+                tree_ctx = _build_tree_context(tree, node, _effective_dir)
+                task_with_ctx = tree_ctx if tree_ctx else node.description
 
-            # Inject dependency context if this node has depends_on
-            dep_ctx = _build_dependency_context(tree, node, _effective_dir)
-            if dep_ctx:
-                task_with_ctx = dep_ctx + task_with_ctx
+                # Inject dependency context if this node has depends_on
+                dep_ctx = _build_dependency_context(tree, node, _effective_dir)
+                if dep_ctx:
+                    task_with_ctx = dep_ctx + task_with_ctx
 
-            if project_id:
-                identity = self._build_project_identity(project_id)
-                if identity:
-                    task_with_ctx = f"{identity}\n\n{task_with_ctx}"
+                if project_id:
+                    identity = self._build_project_identity(project_id)
+                    if identity:
+                        task_with_ctx = f"{identity}\n\n{task_with_ctx}"
 
-            if _effective_dir:
-                task_with_ctx += f"\n\n[Project workspace: {_effective_dir} — save all outputs here]"
+                if _effective_dir:
+                    task_with_ctx += f"\n\n[Project workspace: {_effective_dir} — save all outputs here]"
 
-            if project_id:
-                proj_ctx = self._get_project_history_context(project_id)
-                if proj_ctx:
-                    task_with_ctx = f"{task_with_ctx}\n\n{proj_ctx}"
+                if project_id:
+                    proj_ctx = self._get_project_history_context(project_id)
+                    if proj_ctx:
+                        task_with_ctx = f"{task_with_ctx}\n\n{proj_ctx}"
 
-            if project_id:
-                workflow_ctx = self._get_project_workflow_context(employee_id, project_id)
-                if workflow_ctx:
-                    task_with_ctx = f"{task_with_ctx}\n\n{workflow_ctx}"
+                if project_id:
+                    workflow_ctx = self._get_project_workflow_context(employee_id, project_id)
+                    if workflow_ctx:
+                        task_with_ctx = f"{task_with_ctx}\n\n{workflow_ctx}"
 
-            inject_progress = cfg.context.inject_progress_log if cfg else True
-            if inject_progress:
-                progress = _load_progress(employee_id)
-                if progress:
-                    task_with_ctx += f"\n\n[Previous Work Learnings]\n{progress}"
+                inject_progress = cfg.context.inject_progress_log if cfg else True
+                if inject_progress:
+                    progress = _load_progress(employee_id)
+                    if progress:
+                        task_with_ctx += f"\n\n[Previous Work Learnings]\n{progress}"
 
-            # Company context: culture, SOPs, guidance, work principles
-            company_ctx = self._build_company_context_block(employee_id)
-            if company_ctx:
-                task_with_ctx = f"{company_ctx}\n\n{task_with_ctx}"
+                # Company context: culture, SOPs, guidance, work principles
+                company_ctx = self._build_company_context_block(employee_id)
+                if company_ctx:
+                    task_with_ctx = f"{company_ctx}\n\n{task_with_ctx}"
 
             # Debug: print full task prompt (without history)
             logger.debug("[TASK PROMPT] employee={} node={} project={}:\n{}",


### PR DESCRIPTION
## Summary
Two fixes:

1. **Clean CEO confirm prompt** — CEO_REQUEST nodes (project completion confirm, inbox) no longer get the full context injection (tree ancestors, SOPs, progress log, company context). The confirm message built by _on_child_complete already contains the summary. CEO now sees clean, readable messages.

2. **Dismiss employee error** — When `execute_fire` raises after the employee folder is already moved, the route handler now checks if the employee is actually gone and returns success instead of showing an error alert.

## Test plan
- [x] Full suite: 2338 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)