### PR TITLE
fix: watchdog default off + English prompts + no truncation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.97",
+  "version": "0.3.98",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.97"
+version = "0.3.98"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -4386,7 +4386,7 @@ async def dismiss_shortlist(body: dict) -> dict:
 
     # Resume HR's HOLDING task so it doesn't hang forever
     from onemancompany.core.vessel import employee_manager as _em
-    dismiss_reason = "CEO认为这次招聘是不需要的或者错误的，已取消本轮招聘"
+    dismiss_reason = "CEO decided this hiring round is unnecessary or incorrect — cancelled"
     held_node_id = _em.find_holding_task(HR_ID, f"batch_id={batch_id}")
     if held_node_id:
         await _em.resume_held_task(HR_ID, held_node_id, dismiss_reason)

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -42,6 +42,7 @@ class SystemCronDef:
     default_interval: str
     description: str
     handler: Callable[[], Coroutine[Any, Any, list | None]]
+    enabled_by_default: bool = True
     current_interval: str = ""
     current_interval_seconds: int = 0
     last_run: datetime | None = None
@@ -73,6 +74,7 @@ def system_cron(
     *,
     interval: str,
     description: str,
+    enabled_by_default: bool = True,
     registry: dict[str, SystemCronDef] | None = None,
 ):
     """Decorator to register a system cron handler."""
@@ -87,6 +89,7 @@ def system_cron(
             default_interval=interval,
             description=description,
             handler=fn,
+            enabled_by_default=enabled_by_default,
         )
         return fn
     return decorator
@@ -102,6 +105,7 @@ class SystemCronManager:
         self._registry = registry if registry is not None else _registry
         self._tasks: dict[str, asyncio.Task] = {}
         self._disabled: set[str] = set()  # crons explicitly disabled by user
+        self._enabled: set[str] = set()   # crons explicitly enabled (overrides enabled_by_default=False)
         # Only load persisted state for the global registry (not test registries)
         if registry is None:
             self._load_persisted_state()
@@ -119,6 +123,7 @@ class SystemCronManager:
         try:
             data = yaml.safe_load(read_text_utf(path)) or {}
             self._disabled = set(data.get("disabled", []))
+            self._enabled = set(data.get("enabled", []))
             # Restore custom intervals
             for name, interval in data.get("intervals", {}).items():
                 defn = self._registry.get(name)
@@ -143,6 +148,7 @@ class SystemCronManager:
         }
         data = {
             "disabled": sorted(self._disabled),
+            "enabled": sorted(self._enabled),
             "intervals": intervals,
         }
         try:
@@ -152,7 +158,14 @@ class SystemCronManager:
             logger.error("[system_cron] Failed to persist state: {}", e)
 
     def start_all(self) -> None:
-        """Start all registered system crons, skipping user-disabled ones."""
+        """Start all registered system crons, skipping disabled ones.
+
+        Crons with enabled_by_default=False are skipped unless the user
+        has explicitly enabled them (persisted in _enabled set on disk).
+        """
+        for name, defn in self._registry.items():
+            if not defn.enabled_by_default and name not in self._enabled:
+                self._disabled.add(name)
         for name in self._registry:
             if name in self._disabled:
                 logger.info("[system_cron] Skipping disabled cron: {}", name)
@@ -183,7 +196,8 @@ class SystemCronManager:
         self._tasks[name] = task
         if name in self._disabled:
             self._disabled.discard(name)
-            self._persist_state()
+        self._enabled.add(name)
+        self._persist_state()
         return {"status": "ok", "name": name}
 
     def stop(self, name: str) -> dict:
@@ -192,6 +206,7 @@ class SystemCronManager:
         if task and not task.done():
             task.cancel()
         self._disabled.add(name)
+        self._enabled.discard(name)
         self._persist_state()
         return {"status": "ok", "name": name}
 
@@ -337,7 +352,7 @@ async def talent_market_keepalive() -> list | None:
 _watchdog_nudged: set[str] = set()
 
 
-@system_cron("project_progress_watchdog", interval="10m", description="Project progress watchdog — prevent stuck projects")
+@system_cron("project_progress_watchdog", interval="10m", description="Project progress watchdog — prevent stuck projects", enabled_by_default=False)
 async def project_progress_watchdog() -> list | None:
     """Scan active projects; nudge EA to continue any that are stuck.
 
@@ -440,15 +455,15 @@ async def project_progress_watchdog() -> list | None:
 
         project_abs_path = str(tree_path.parent.resolve())
         nudge_desc = (
-            f"[项目进度看门狗] 项目 {project_id} 存在未完成的任务节点且当前无人在执行。\n"
-            f"项目路径: {project_abs_path}\n\n"
-            f"请查看以下任务树状态，尝试继续推进项目完成：\n\n"
+            f"[Project Progress Watchdog] Project {project_id} has unfinished task nodes with no one executing.\n"
+            f"Project path: {project_abs_path}\n\n"
+            f"Review the task tree status and take action to continue:\n\n"
             f"{status_summary}\n\n"
-            f"请根据当前状态采取适当行动：\n"
-            f"- 如有 completed 状态的子任务，请 accept_child 或 reject_child\n"
-            f"- 如有 failed/blocked 的任务，请决定重试或跳过\n"
-            f"- 如需新增任务，请 dispatch_child\n"
-            f"- 如项目已无法继续，请说明原因"
+            f"Actions based on current state:\n"
+            f"- If tasks are completed: accept_child or reject_child\n"
+            f"- If tasks are failed/blocked: decide to retry or skip\n"
+            f"- If new tasks are needed: dispatch_child\n"
+            f"- If the project cannot continue: explain why"
         )
 
         lock = get_tree_lock(tree_path_str)
@@ -543,11 +558,11 @@ def _build_tree_status_summary(tree) -> str:
         nodes = by_status.get(status, [])
         if not nodes:
             continue
-        lines.append(f"【{status}】({len(nodes)}个):")
+        lines.append(f"[{status}] ({len(nodes)}):")
         for n in nodes[:5]:  # Cap at 5 per status to keep prompt manageable
             preview = n.description_preview or n.id
             lines.append(f"  - [{n.employee_id}] {preview[:100]}")
         if len(nodes) > 5:
-            lines.append(f"  ... 还有 {len(nodes) - 5} 个")
+            lines.append(f"  ... and {len(nodes) - 5} more")
 
     return "\n".join(lines)

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1316,7 +1316,7 @@ class EmployeeManager:
             clear_watchdog_nudge(node.project_id)
         self._log_node(employee_id, entry.node_id, "start", f"Starting task: {node.description_preview}")
         self._publish_node_update(employee_id, node)
-        self._push_to_ceo_session(node, f"▶ {node.title or node.description_preview[:80]}")
+        self._push_to_ceo_session(node, f"▶ {node.title or node.description_preview}")
 
         await _store.save_employee_runtime(employee_id, current_task_summary=node.description_preview[:100])
 
@@ -2418,13 +2418,13 @@ class EmployeeManager:
                         for c in failed_children
                     )
                     resume_desc = (
-                        f"[子任务失败通知] 以下子任务执行失败，请决定后续处理：\n\n"
+                        f"[Child Task Failure] The following child tasks have failed:\n\n"
                         f"{failure_summary}\n\n"
-                        f"可选操作：\n"
-                        f"- reject_child(node_id, reason, retry=True) 重新分配任务\n"
-                        f"- reject_child(node_id, reason, retry=False) 放弃该任务\n"
-                        f"- dispatch_child 分配给其他员工重试\n"
-                        f"- 如项目无法继续，请说明原因"
+                        f"Options:\n"
+                        f"- reject_child(node_id, reason, retry=True) to reassign the task\n"
+                        f"- reject_child(node_id, reason, retry=False) to abandon the task\n"
+                        f"- dispatch_child to assign to a different employee\n"
+                        f"- If the project cannot continue, explain why"
                     )
                     was_processing = parent_node.status == TaskPhase.PROCESSING.value
                     logger.info(
@@ -2467,12 +2467,12 @@ class EmployeeManager:
                         for c in cancelled_children
                     )
                     resume_desc = (
-                        f"[子任务取消通知] 以下子任务已被取消，请决定后续处理：\n\n"
+                        f"[Child Task Cancelled] The following child tasks have been cancelled:\n\n"
                         f"{cancel_summary}\n\n"
-                        f"可选操作：\n"
-                        f"- dispatch_child 重新分配任务给其他员工\n"
-                        f"- 继续处理剩余子任务\n"
-                        f"- 如项目无法继续，请说明原因"
+                        f"Options:\n"
+                        f"- dispatch_child to reassign to a different employee\n"
+                        f"- Continue with remaining child tasks\n"
+                        f"- If the project cannot continue, explain why"
                     )
                     was_processing = parent_node.status == TaskPhase.PROCESSING.value
                     logger.info(


### PR DESCRIPTION
## Summary
- **Watchdog default off**: `project_progress_watchdog` now `enabled_by_default=False`. Added `_enabled` set for explicit opt-in that survives restarts.
- **English prompts**: Translated all Chinese LLM prompts to English (failure notifications, cancellation notifications, watchdog nudge, tree summary, hiring dismissal reason). This was causing agents to respond in Chinese even when the user writes in English.
- **Removed truncation**: CEO session start message no longer truncated at 80 chars.

## Test plan
- [x] Full suite: 2341 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)