### PR TITLE
fix: project delete cleans CEO session + task independence rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.3.98",
+  "version": "0.3.99",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.3.98"
+version = "0.3.99"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -539,7 +539,10 @@ def get_employee_tools_prompt(employee_id: str) -> str:
         "  - The task involves external commitments or brand representation\n"
         "  - You are blocked and no available tool or colleague can unblock you\n"
         "- **External communication**: Use Gmail ONLY for people OUTSIDE the company "
-        "(clients, vendors, partners, third parties)."
+        "(clients, vendors, partners, third parties).\n"
+        "- **Task independence**: Every task you receive is a NEW, independent assignment. "
+        "NEVER refuse a task because a similar one was done before. Past projects in your "
+        "work history are COMPLETED — they do not block new work on the same topic."
     )
     return "\n".join(parts)
 

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -2748,6 +2748,11 @@ async def archive_project_endpoint(project_id: str) -> dict:
         total_cancelled += employee_manager.abort_project(full_pid)
 
     archive_project(project_id)
+
+    # Remove CEO session so it disappears from the project list
+    from onemancompany.core.ceo_broker import get_ceo_broker
+    get_ceo_broker().remove_session(project_id)
+
     logger.info("[archive] Archived project {} — cancelled {} task(s)", project_id, total_cancelled)
     await event_bus.publish(CompanyEvent(type=EventType.STATE_SNAPSHOT, payload={}, agent=SYSTEM_AGENT))
     return {"status": "archived", "project_id": project_id, "tasks_cancelled": total_cancelled}
@@ -2779,6 +2784,10 @@ async def delete_project_endpoint(project_id: str) -> dict:
     # Delete entire project directory
     if project_dir.exists():
         shutil.rmtree(project_dir)
+
+    # Remove CEO session so it disappears from the project list
+    from onemancompany.core.ceo_broker import get_ceo_broker
+    get_ceo_broker().remove_session(project_id)
 
     logger.info("[delete] Deleted project {} — cancelled {} task(s)", project_id, total_cancelled)
     await event_bus.publish(CompanyEvent(type=EventType.STATE_SNAPSHOT, payload={}, agent=SYSTEM_AGENT))

--- a/src/onemancompany/core/ceo_broker.py
+++ b/src/onemancompany/core/ceo_broker.py
@@ -256,9 +256,21 @@ class CeoBroker:
         return self._sessions.get(self._base_project_id(project_id))
 
     def list_sessions(self) -> list[dict]:
-        summaries = [s.to_summary() for s in self._sessions.values()]
+        summaries = [
+            s.to_summary() for s in self._sessions.values()
+            if s.project_id != "default"  # filter out fallback session
+        ]
         summaries.sort(key=lambda s: (not s["has_pending"], s["project_id"]))
         return summaries
+
+    def remove_session(self, project_id: str) -> bool:
+        """Remove a session from memory. Returns True if session existed.
+
+        Disk history (ceo_session.yaml) is cleaned up by the caller
+        (e.g. project directory deletion via shutil.rmtree).
+        """
+        key = self._base_project_id(project_id)
+        return self._sessions.pop(key, None) is not None
 
     def recover(self, projects_dir: Path) -> None:
         """Rebuild sessions from disk on restart.


### PR DESCRIPTION
## Summary
Three fixes:

1. **CEO session cleanup on project delete/archive** — `broker.remove_session()` called from both endpoints. Previously the CEO console kept showing deleted projects and their chat history.

2. **Task independence rule** — New system prompt instruction: "Every task is a NEW, independent assignment. NEVER refuse because a similar one was done before." Agents were seeing past project history and refusing to work on similar topics.

3. **Filter "default" session** — Fallback session created when project_id is missing no longer appears in the CEO project list.

## Test plan
- [x] Full suite: 2341 passed, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)