### PR TITLE
fix: web search supports OAuth authentication

### DIFF
--- a/company/assets/tools/web_search/web_search.py
+++ b/company/assets/tools/web_search/web_search.py
@@ -15,23 +15,6 @@ from langchain_core.tools import tool
 from loguru import logger
 
 
-def _load_key_from_dotenv() -> str:
-    """Try to load ANTHROPIC_API_KEY from the company .env file."""
-    try:
-        from onemancompany.core.config import DATA_ROOT, DOT_ENV_FILENAME
-        env_path = DATA_ROOT / DOT_ENV_FILENAME
-        if not env_path.exists():
-            return ""
-        for line in env_path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if line.startswith("#") or "=" not in line:
-                continue
-            key, _, val = line.partition("=")
-            if key.strip() == _ENV_KEY_NAME:
-                return val.strip().strip("\"'")
-    except Exception as exc:
-        logger.debug("[web_search] failed to load API key from .env: {}", exc)
-    return ""
 
 
 _ENV_KEY_NAME = "ANTHROPIC_API_KEY"
@@ -53,6 +36,71 @@ _FIELD_TEXT = "text"
 _FIELD_TITLE = "title"
 _FIELD_URL = "url"
 _FIELD_PAGE_SNIPPET = "page_snippet"
+
+
+def _load_env_var(name: str) -> str:
+    """Load an env var, falling back to company .env file."""
+    val = os.environ.get(name, "").strip()
+    if val:
+        return val
+    try:
+        from onemancompany.core.config import DATA_ROOT, DOT_ENV_FILENAME
+        env_path = DATA_ROOT / DOT_ENV_FILENAME
+        if not env_path.exists():
+            return ""
+        for line in env_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line.startswith("#") or "=" not in line:
+                continue
+            key, _, v = line.partition("=")
+            if key.strip() == name:
+                return v.strip().strip("\"'")
+    except Exception:
+        pass
+    return ""
+
+
+def _resolve_anthropic_auth() -> tuple[str, dict]:
+    """Resolve Anthropic API authentication — supports both API key and OAuth.
+
+    Returns (key_or_token, auth_headers_dict). Empty dict if no auth available.
+    """
+    auth_method = _load_env_var("ANTHROPIC_AUTH_METHOD")
+
+    if auth_method == "oauth":
+        # OAuth: refresh token if needed, use Bearer header
+        access_token = _load_env_var(_ENV_KEY_NAME)
+        refresh_token = _load_env_var("ANTHROPIC_REFRESH_TOKEN")
+        if not access_token and not refresh_token:
+            return "", {}
+
+        # Try refreshing via the OAuth module
+        try:
+            from onemancompany.core.oauth import get_oauth_token, OAuthServiceConfig
+            config = OAuthServiceConfig(
+                service_name="anthropic",
+                authorize_url="https://console.anthropic.com/oauth/authorize",
+                token_url="https://console.anthropic.com/oauth/token",
+                scopes="",
+                client_id_env="ANTHROPIC_CLIENT_ID",
+                client_secret_env="ANTHROPIC_CLIENT_SECRET",
+            )
+            fresh_token = get_oauth_token(config)
+            if fresh_token:
+                return fresh_token, {"Authorization": f"Bearer {fresh_token}"}
+        except Exception as exc:
+            logger.debug("[web_search] OAuth refresh failed: {}", exc)
+
+        # Fallback: use the stored access token directly (may be expired)
+        if access_token:
+            return access_token, {"Authorization": f"Bearer {access_token}"}
+        return "", {}
+
+    # Default: API key auth
+    api_key = _load_env_var(_ENV_KEY_NAME)
+    if not api_key:
+        return "", {}
+    return api_key, {"x-api-key": api_key}
 
 
 def _post_json(url: str, headers: dict, payload: dict, timeout: int = 30) -> tuple[dict | None, str | None]:
@@ -115,17 +163,14 @@ def web_search(query: str, max_results: int = 5) -> dict:
     if not query:
         return {"status": "error", "message": "query is empty"}
 
-    api_key = os.environ.get(_ENV_KEY_NAME, "").strip()
-    if not api_key:
-        # Fallback: read from company .env file
-        api_key = _load_key_from_dotenv()
-    if not api_key:
+    api_key, auth_header = _resolve_anthropic_auth()
+    if not auth_header:
         return {"status": "error", "message": f"{_ENV_KEY_NAME} not configured in .env"}
 
     max_results = max(1, min(int(max_results), 20))
 
     headers = {
-        "x-api-key": api_key,
+        **auth_header,
         "anthropic-version": _API_VERSION,
         "content-type": "application/json",
         "User-Agent": _USER_AGENT,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.6"
+version = "0.4.7"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
When `ANTHROPIC_AUTH_METHOD=oauth`, the web_search tool now:
- Uses `Authorization: Bearer` header instead of `x-api-key`
- Attempts OAuth token refresh via the existing oauth module
- Falls back to stored access token if refresh fails

Previously the OAuth access token was passed as `x-api-key`, causing 401 errors.

## Test plan
- [x] Full suite: 2334 passed, 0 regressions
- [x] Compilation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)