### PR TITLE
ci: add version bump check to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need full history for version comparison
 
       - uses: actions/setup-python@v5
         with:
@@ -18,6 +20,20 @@ jobs:
         run: |
           pip install -e .
           pip install pytest pytest-asyncio pytest-timeout
+
+      - name: Version bump check
+        run: |
+          PR_VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "//;s/"//')
+          MAIN_VERSION=$(git show origin/main:pyproject.toml | grep '^version = ' | head -1 | sed 's/version = "//;s/"//')
+          echo "PR version: $PR_VERSION"
+          echo "Main version: $MAIN_VERSION"
+          python3 -c "
+          from packaging.version import Version
+          pr, main = Version('$PR_VERSION'), Version('$MAIN_VERSION')
+          if pr <= main:
+              raise SystemExit(f'ERROR: PR version {pr} must be greater than main version {main}. Run pre-commit hook or bump manually.')
+          print(f'OK: {pr} > {main}')
+          "
 
       - name: Compilation check
         run: python -c "from onemancompany.api.routes import router; print('OK')"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.9"
+version = "0.4.10"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- New CI step: compares `pyproject.toml` version in PR against `origin/main`
- Fails if PR version is not greater than main version
- Catches PRs that skipped the pre-commit hook (e.g. `--no-verify`)
- Uses `packaging.Version` for proper semver comparison

## Test plan
- [x] CI workflow change — will self-test on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)