### PR TITLE
fix: correct Anthropic OAuth URLs and client_id

### DIFF
--- a/company/assets/tools/web_search/web_search.py
+++ b/company/assets/tools/web_search/web_search.py
@@ -92,8 +92,8 @@ def _resolve_anthropic_auth() -> tuple[str, dict]:
     return api_key, {"x-api-key": api_key}
 
 
-_ANTHROPIC_TOKEN_URL = "https://api.anthropic.com/token"
-_ANTHROPIC_CLIENT_ID = "8ccecd22-59d4-4db0-a971-530cf734fd17"
+_ANTHROPIC_TOKEN_URL = "https://console.anthropic.com/api/oauth/token"
+_ANTHROPIC_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
 
 
 def _refresh_anthropic_token(refresh_token: str) -> str:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.10"
+version = "0.4.11"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -63,9 +63,9 @@ from onemancompany.core.background_tasks import background_task_manager
 # ---------------------------------------------------------------------------
 ONBOARDING_STEP_ORDER = ["assigning_id", "copying_skills", "registering_agent", "completed"]
 
-ANTHROPIC_OAUTH_CLIENT_ID = "8ccecd22-59d4-4db0-a971-530cf734fd17"
-ANTHROPIC_AUTH_URL = "https://api.anthropic.com/authorize"
-ANTHROPIC_TOKEN_URL = "https://api.anthropic.com/token"
+ANTHROPIC_OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+ANTHROPIC_AUTH_URL = "https://claude.ai/oauth/authorize"
+ANTHROPIC_TOKEN_URL = "https://console.anthropic.com/api/oauth/token"
 ANTHROPIC_REDIRECT_URI = "http://localhost:8000/api/oauth/callback"
 ANTHROPIC_CREATE_KEY_URL = "https://api.anthropic.com/api/oauth/claude_cli/create_api_key"
 


### PR DESCRIPTION
## Summary
OAuth was hitting wrong endpoints and using wrong client_id, returning Google tokens instead of Anthropic tokens.

| Field | Before (wrong) | After (correct) |
|-------|----------------|-----------------|
| authorize_url | `api.anthropic.com/authorize` | `claude.ai/oauth/authorize` |
| token_url | `api.anthropic.com/token` | `console.anthropic.com/api/oauth/token` |
| client_id | `8ccecd22-...` | `9d1c250a-...` (Claude Code CLI) |
| token format | `ya29.a0...` (Google) | `sk-ant-oat01-...` (Anthropic) |

This was the root cause of web_search 401 errors — the stored token was a Google OAuth token, not an Anthropic token.

## Test plan
- [x] Full suite: 2334 passed, 0 regressions
- [ ] Manual: re-login OAuth in settings, verify sk-ant-oat01 token, test web_search

🤖 Generated with [Claude Code](https://claude.com/claude-code)