### PR TITLE
chore: add CLAUDE.md with gstack skill configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# gstack
+
+Use the `/browse` skill from gstack for all web browsing. Never use `mcp__claude-in-chrome__*` tools.
+
+Available skills: /office-hours, /plan-ceo-review, /plan-eng-review, /plan-design-review, /design-consultation, /design-shotgun, /design-html, /review, /ship, /land-and-deploy, /canary, /benchmark, /browse, /connect-chrome, /qa, /qa-only, /design-review, /setup-browser-cookies, /setup-deploy, /retro, /investigate, /document-release, /codex, /cso, /autoplan, /careful, /freeze, /guard, /unfreeze, /gstack-upgrade, /learn

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,12 @@ uv venv && uv pip install -e ".[dev]"
 
 # Start the server (dev mode)
 .venv/bin/python -m onemancompany.main
+
+# Install gstack (Claude Code skills for browsing, QA, code review, etc.)
+git clone --single-branch --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack && cd ~/.claude/skills/gstack && ./setup
 ```
+
+> **Note:** gstack requires [bun](https://bun.sh). If not installed, run `curl -fsSL https://bun.sh/install | bash` first.
 
 ## Development Workflow
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.18"
+version = "0.4.19"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.17"
+version = "0.4.18"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.16"
+version = "0.4.17"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/unit/api/test_routes.py
+++ b/tests/unit/api/test_routes.py
@@ -3928,26 +3928,22 @@ class TestOAuthExchange:
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
-        call_count = 0
-
-        async def mock_post(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count <= 1:
-                return mock_resp
-            return mock_key_resp
-
-        mock_client.post = mock_post
+        # httpx.AsyncClient.post is only used for step 2 (create API key)
+        mock_client.post = AsyncMock(return_value=mock_key_resp)
 
         # Create profile.yaml so the persist path works
         emp_dir = tmp_path / "00010"
         emp_dir.mkdir()
         (emp_dir / "profile.yaml").write_text("api_key: old\n")
 
+        # _curl_token_exchange handles step 1 (token exchange via curl subprocess)
+        curl_return = {"access_token": "tok_abc", "refresh_token": "ref_xyz"}
+
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
              patch("onemancompany.core.config.employee_configs", {"00010": mock_cfg}), \
+             patch("onemancompany.api.routes._curl_token_exchange", return_value=curl_return), \
              patch("httpx.AsyncClient", return_value=mock_client), \
              patch("onemancompany.core.config.EMPLOYEES_DIR", tmp_path):
             app = _make_test_app()
@@ -4030,19 +4026,13 @@ class TestOAuthExchange:
             "redirect_uri": "http://localhost",
         }
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {}
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = AsyncMock(return_value=mock_resp)
+        # _curl_token_exchange returns response without access_token
+        curl_return = {}
 
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("httpx.AsyncClient", return_value=mock_client):
+             patch("onemancompany.api.routes._curl_token_exchange", return_value=curl_return):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.post("/api/employee/00010/oauth/exchange", json={
@@ -4053,7 +4043,7 @@ class TestOAuthExchange:
         assert "No access_token" in resp.json()["error"]
 
     async def test_oauth_exchange_token_failed_status(self):
-        """Token exchange returns non-200 status after both form and json attempts."""
+        """Token exchange returns error from curl."""
         from onemancompany.api.routes import _oauth_sessions
 
         state = _make_state()
@@ -4065,19 +4055,13 @@ class TestOAuthExchange:
             "redirect_uri": "http://localhost",
         }
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 400
-        mock_resp.text = "Bad request"
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = AsyncMock(return_value=mock_resp)
+        # _curl_token_exchange returns an error dict
+        curl_return = {"error": "Token exchange failed: Bad request"}
 
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("httpx.AsyncClient", return_value=mock_client):
+             patch("onemancompany.api.routes._curl_token_exchange", return_value=curl_return):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.post("/api/employee/00010/oauth/exchange", json={
@@ -4145,10 +4129,10 @@ class TestOAuthCallback:
             "redirect_uri": "http://localhost/api/oauth/callback",
         }
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"access_token": "tok", "refresh_token": "ref"}
+        # _curl_token_exchange handles step 1 (token exchange)
+        curl_return = {"access_token": "tok", "refresh_token": "ref"}
 
+        # httpx.AsyncClient handles step 2 (create API key)
         mock_key_resp = MagicMock()
         mock_key_resp.status_code = 200
         mock_key_resp.json.return_value = {"api_key": "sk-perm"}
@@ -4156,14 +4140,7 @@ class TestOAuthCallback:
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
-        call_count = 0
-        async def mock_post(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count <= 1:
-                return mock_resp
-            return mock_key_resp
-        mock_client.post = mock_post
+        mock_client.post = AsyncMock(return_value=mock_key_resp)
 
         mock_cfg = MagicMock()
         mock_cfg.api_key = ""
@@ -4176,6 +4153,7 @@ class TestOAuthCallback:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
+             patch("onemancompany.api.routes._curl_token_exchange", return_value=curl_return), \
              patch("httpx.AsyncClient", return_value=mock_client), \
              patch("onemancompany.core.config.employee_configs", {"00010": mock_cfg}), \
              patch("onemancompany.core.config.EMPLOYEES_DIR", tmp_path):
@@ -4202,15 +4180,10 @@ class TestOAuthCallback:
             "redirect_uri": "http://localhost",
         }
 
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = AsyncMock(side_effect=RuntimeError("net err"))
-
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("httpx.AsyncClient", return_value=mock_client):
+             patch("onemancompany.api.routes._curl_token_exchange", side_effect=RuntimeError("net err")):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/oauth/callback", params={
@@ -4221,7 +4194,7 @@ class TestOAuthCallback:
         assert "Token exchange error" in resp.text
 
     async def test_callback_token_failed_status(self):
-        """Token exchange returns non-200."""
+        """Token exchange returns error."""
         from onemancompany.api.routes import _oauth_sessions
 
         state = _make_state()
@@ -4233,19 +4206,12 @@ class TestOAuthCallback:
             "redirect_uri": "http://localhost",
         }
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 401
-        mock_resp.text = "Unauthorized"
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = AsyncMock(return_value=mock_resp)
+        curl_return = {"error": "Token exchange failed: Unauthorized"}
 
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
-             patch("httpx.AsyncClient", return_value=mock_client):
+             patch("onemancompany.api.routes._curl_token_exchange", return_value=curl_return):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.get("/api/oauth/callback", params={
@@ -4272,14 +4238,7 @@ class TestOAuthRefreshTokenExchange:
         mock_cfg.api_key = "old_key"
         mock_cfg.api_provider = "anthropic"
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = {"access_token": "new_tok", "refresh_token": "new_ref"}
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = AsyncMock(return_value=mock_resp)
+        curl_return = {"access_token": "new_tok", "refresh_token": "new_ref"}
 
         emp_dir = tmp_path / "00010"
         emp_dir.mkdir()
@@ -4289,7 +4248,7 @@ class TestOAuthRefreshTokenExchange:
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
              patch("onemancompany.core.config.employee_configs", {"00010": mock_cfg}), \
-             patch("httpx.AsyncClient", return_value=mock_client), \
+             patch("onemancompany.api.routes._curl_token_exchange", return_value=curl_return), \
              patch("onemancompany.core.config.EMPLOYEES_DIR", tmp_path):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
@@ -4298,7 +4257,7 @@ class TestOAuthRefreshTokenExchange:
         assert resp.json()["status"] == "refreshed"
 
     async def test_refresh_failed_status(self):
-        """Refresh returns non-200."""
+        """Refresh returns error from curl."""
         state = _make_state()
         bus = EventBus()
 
@@ -4306,19 +4265,13 @@ class TestOAuthRefreshTokenExchange:
         mock_cfg.oauth_refresh_token = "ref_tok"
         mock_cfg.api_provider = "anthropic"
 
-        mock_resp = MagicMock()
-        mock_resp.status_code = 401
-
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = AsyncMock(return_value=mock_resp)
+        curl_return = {"error": "Refresh failed: Unauthorized"}
 
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
              patch("onemancompany.core.config.employee_configs", {"00010": mock_cfg}), \
-             patch("httpx.AsyncClient", return_value=mock_client):
+             patch("onemancompany.api.routes._curl_token_exchange", return_value=curl_return):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.post("/api/employee/00010/oauth/refresh")
@@ -4334,16 +4287,11 @@ class TestOAuthRefreshTokenExchange:
         mock_cfg.oauth_refresh_token = "ref_tok"
         mock_cfg.api_provider = "anthropic"
 
-        mock_client = AsyncMock()
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = AsyncMock(side_effect=RuntimeError("timeout"))
-
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
              patch("onemancompany.core.config.employee_configs", {"00010": mock_cfg}), \
-             patch("httpx.AsyncClient", return_value=mock_client):
+             patch("onemancompany.api.routes._curl_token_exchange", side_effect=RuntimeError("timeout")):
             app = _make_test_app()
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.post("/api/employee/00010/oauth/refresh")
@@ -5465,25 +5413,14 @@ class TestOAuthExchangeCreateKeyException:
         mock_cfg.api_key = ""
         mock_cfg.oauth_refresh_token = ""
 
-        # Token exchange succeeds
-        mock_token_resp = MagicMock()
-        mock_token_resp.status_code = 200
-        mock_token_resp.json.return_value = {"access_token": "tok_abc", "refresh_token": "ref_xyz"}
+        # Step 1: _curl_token_exchange succeeds
+        curl_return = {"access_token": "tok_abc", "refresh_token": "ref_xyz"}
 
-        call_count = 0
-
-        async def mock_post(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count <= 1:
-                return mock_token_resp
-            # Second call (create_api_key) raises exception
-            raise ConnectionError("Network failure")
-
+        # Step 2: httpx create_api_key raises exception
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = mock_post
+        mock_client.post = AsyncMock(side_effect=ConnectionError("Network failure"))
 
         emp_dir = tmp_path / "00010"
         emp_dir.mkdir()
@@ -5493,6 +5430,7 @@ class TestOAuthExchangeCreateKeyException:
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
              patch("onemancompany.core.config.employee_configs", {"00010": mock_cfg}), \
+             patch("onemancompany.api.routes._curl_token_exchange", return_value=curl_return), \
              patch("httpx.AsyncClient", return_value=mock_client), \
              patch("onemancompany.core.config.EMPLOYEES_DIR", tmp_path):
             app = _make_test_app()
@@ -5534,25 +5472,14 @@ class TestOAuthCallbackCreateKeyException:
         mock_cfg.api_key = ""
         mock_cfg.oauth_refresh_token = ""
 
-        # Token exchange succeeds
-        mock_token_resp = MagicMock()
-        mock_token_resp.status_code = 200
-        mock_token_resp.json.return_value = {"access_token": "tok_cb", "refresh_token": "ref_cb"}
+        # Step 1: _curl_token_exchange succeeds
+        curl_return = {"access_token": "tok_cb", "refresh_token": "ref_cb"}
 
-        call_count = 0
-
-        async def mock_post(*args, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if call_count <= 1:
-                return mock_token_resp
-            # Second call (create_api_key) raises exception
-            raise ConnectionError("Network failure")
-
+        # Step 2: httpx create_api_key raises exception
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=False)
-        mock_client.post = mock_post
+        mock_client.post = AsyncMock(side_effect=ConnectionError("Network failure"))
 
         emp_dir = tmp_path / "00010"
         emp_dir.mkdir()
@@ -5561,6 +5488,7 @@ class TestOAuthCallbackCreateKeyException:
         with patch("onemancompany.api.routes.company_state", state), \
              _store_patches(state), \
              patch("onemancompany.api.routes.event_bus", bus), \
+             patch("onemancompany.api.routes._curl_token_exchange", return_value=curl_return), \
              patch("httpx.AsyncClient", return_value=mock_client), \
              patch("onemancompany.core.config.employee_configs", {"00010": mock_cfg}), \
              patch("onemancompany.core.config.EMPLOYEES_DIR", tmp_path):


### PR DESCRIPTION
## Summary
- Add CLAUDE.md with gstack skill section: use `/browse` for web browsing, never use `mcp__claude-in-chrome__*` tools, lists all available gstack skills
- Add gstack install instructions to CONTRIBUTING.md (Getting Started section)
- Fix all OAuth tests (10 tests across 5 test classes) that were broken since token exchange switched from httpx to curl subprocess

## Details

### gstack setup
- CLAUDE.md created with gstack configuration for the project
- CONTRIBUTING.md updated with one-liner install command and bun prerequisite note

### OAuth test fixes
All OAuth endpoints (`/oauth/exchange`, `/oauth/callback`, `/oauth/refresh`) now use `_curl_token_exchange()` (curl subprocess) instead of `httpx.AsyncClient` for token exchange. Tests still mocked `httpx.AsyncClient` for this step, causing them to hit the real Anthropic endpoint and get rate-limited.

Fixed test classes:
- `TestOAuthExchange` (3 tests)
- `TestOAuthCallback` (3 tests)
- `TestOAuthRefreshTokenExchange` (3 tests)
- `TestOAuthExchangeCreateKeyException` (1 test)
- `TestOAuthCallbackCreateKeyException` (1 test)

## Test plan
- [x] All 2334 unit tests pass locally
- [x] OAuth tests correctly mock `_curl_token_exchange` for step 1 and `httpx.AsyncClient` for step 2 (create API key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)