### PR TITLE
feat: add AI Search Talent toggle to Talent Market

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,3 +15,4 @@ tools:
 talent_market:
   url: "https://api.one-man-company.com/mcp/sse" # Centralized Talent Market endpoint
   api_key: "" # Set your API key in Settings or here
+  use_ai_search: false # Use AI-powered search for better candidate matching

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5305,6 +5305,13 @@ class AppController {
             </div>
             <label class="api-field-label">API Key (configure to use cloud service)</label>
             <input type="password" id="api-tm-key" class="api-key-input" placeholder="${tm.api_key_set ? tm.api_key_preview : '(none)'}" />
+            ${tm.api_key_set ? `
+            <div style="margin:6px 0;display:flex;align-items:center;gap:6px;">
+              <input type="checkbox" id="api-tm-use-ai" ${tm.use_ai_search ? 'checked' : ''} style="accent-color:var(--pixel-green);" />
+              <label for="api-tm-use-ai" style="font-size:6.5px;color:var(--pixel-yellow);cursor:pointer;">
+                AI-Powered Search (improves candidate quality)
+              </label>
+            </div>` : ''}
             <div class="api-card-actions">
               <button class="pixel-btn small" onclick="app._saveApiSettings('talent_market')">Save</button>
               <span id="api-tm-result" class="api-test-result"></span>
@@ -5334,6 +5341,8 @@ class AppController {
       const body = { provider, mode: 'remote' };
       const key = document.getElementById('api-tm-key').value.trim();
       if (key) body.api_key = key;
+      const aiCheckbox = document.getElementById('api-tm-use-ai');
+      if (aiCheckbox) body.use_ai_search = aiCheckbox.checked;
       try {
         const resp = await fetch('/api/settings/api', {
           method: 'PUT',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.20",
+  "version": "0.4.22",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.23",
+  "version": "0.4.25",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.20"
+version = "0.4.22"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.25"
+version = "0.4.26"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.22"
+version = "0.4.23"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.23"
+version = "0.4.25"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.19"
+version = "0.4.20"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.26"
+version = "0.4.27"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/recruitment.py
+++ b/src/onemancompany/agents/recruitment.py
@@ -21,6 +21,7 @@ from typing import Literal
 from loguru import logger
 
 from onemancompany.core import store as _store
+from onemancompany.core.config import load_app_config
 from onemancompany.core.models import EventType, HostingMode
 
 # --- Pydantic models (migrated from talent_market/boss_online.py) ---
@@ -393,7 +394,8 @@ class TalentMarketClient:
 
     async def search(self, job_description: str) -> dict:
         """Search for candidates matching a job description."""
-        return await self._call("search_candidates", job_description=job_description)
+        use_ai = load_app_config().get("talent_market", {}).get("use_ai_search", False)
+        return await self._call("search_candidates", job_description=job_description, use_ai=use_ai)
 
     async def list_available(self, role: str = "", skills: str = "", page: int = 1, page_size: int = 20) -> dict:
         """List available talents with optional filters."""
@@ -428,8 +430,6 @@ talent_market = TalentMarketClient()
 
 async def start_talent_market() -> None:
     """Connect to the Talent Market MCP server using config.yaml settings."""
-    from onemancompany.core.config import load_app_config
-
     tm_config = load_app_config().get("talent_market", {})
     logger.debug("[recruitment] talent_market config: {}", {k: v[:8] + "..." if k == "api_key" and v else v for k, v in tm_config.items()})
     url = tm_config.get("url", "https://api.one-man-company.com/mcp/sse")

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -2036,6 +2036,7 @@ async def get_api_settings() -> dict:
             "mode": "cloud" if bool(tm_key) else "local",
             "connected": _get_talent_market_connected(),
             "local_talent_count": _get_local_talent_count(),
+            "use_ai_search": tm.get("use_ai_search", False),
         },
     }
 
@@ -2052,27 +2053,32 @@ async def update_api_settings(body: dict) -> dict:
         import yaml
         from onemancompany.core.config import APP_CONFIG_PATH, load_app_config, reload_app_config
         api_key = body.get("api_key", "")
-        if not api_key:
-            return {"error": "API key is required"}
+        if not api_key and "use_ai_search" not in body:
+            return {"error": "API key or use_ai_search is required"}
         config = load_app_config()
         tm = config.setdefault("talent_market", {})
-        tm["api_key"] = api_key
+        if api_key:
+            tm["api_key"] = api_key
+        if "use_ai_search" in body:
+            tm["use_ai_search"] = bool(body["use_ai_search"])
         write_text_utf(APP_CONFIG_PATH, yaml.dump(config, default_flow_style=False, allow_unicode=True))
         reload_app_config()
 
-        # Reconnect Talent Market with new API key
-        try:
-            from onemancompany.agents.recruitment import stop_talent_market, start_talent_market
-            await stop_talent_market()
-            await start_talent_market()
-        except Exception as e:
-            logger.error("Failed to reconnect Talent Market: {}", e)
+        # Reconnect Talent Market only if API key was actually changed
+        if api_key:
+            try:
+                from onemancompany.agents.recruitment import stop_talent_market, start_talent_market
+                await stop_talent_market()
+                await start_talent_market()
+            except Exception as e:
+                logger.error("Failed to reconnect Talent Market: {}", e)
 
         return {
             "status": "updated",
             "talent_market": {
-                "api_key_set": True,
-                "api_key_preview": "..." + api_key[-4:] if len(api_key) >= 4 else "",
+                "api_key_set": bool(tm.get("api_key", "")),
+                "api_key_preview": ("..." + api_key[-4:]) if api_key and len(api_key) >= 4 else "",
+                "use_ai_search": tm.get("use_ai_search", False),
             },
         }
 

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -581,6 +581,19 @@ def _step_optional(console: Console) -> dict[str, str]:
     if key.strip():
         extras[ENV_KEY_TALENT_MARKET] = key.strip()
         console.print("  [bright_green]▸[/bright_green] Saved")
+        # AI Search Talent toggle (only when TM API key is provided)
+        console.print()
+        console.print(
+            "  [bold]AI-Powered Talent Search[/bold]\n"
+            "  [dim]Uses AI to match candidates to job descriptions.\n"
+            "  Improves candidate quality. Can be changed later in Settings.[/dim]"
+        )
+        use_ai = _inq.confirm(
+            message="Enable AI Search Talent?",
+            default=True,
+            style=INQ_STYLE,
+        ).execute()
+        extras["USE_AI_SEARCH"] = "true" if use_ai else "false"
 
     return extras
 
@@ -673,6 +686,10 @@ def _step_execute(
         tm_key = extras.get(ENV_KEY_TALENT_MARKET, "")
         if tm_key:
             cfg.setdefault("talent_market", {})["api_key"] = tm_key
+        # AI Search toggle
+        use_ai_val = extras.get("USE_AI_SEARCH", "")
+        if use_ai_val:
+            cfg.setdefault("talent_market", {})["use_ai_search"] = use_ai_val == "true"
         write_text_utf(dst_config, yaml.dump(cfg, default_flow_style=False, allow_unicode=True))
         if sandbox_enabled:
             console.print("  [green]\u2714[/green] Sandbox tools enabled")

--- a/tests/unit/agents/test_recruitment.py
+++ b/tests/unit/agents/test_recruitment.py
@@ -208,7 +208,7 @@ class TestTalentMarketClient:
         client._call = AsyncMock(return_value={"roles": []})
 
         result = await client.search("python dev")
-        client._call.assert_awaited_once_with("search_candidates", job_description="python dev")
+        client._call.assert_awaited_once_with("search_candidates", job_description="python dev", use_ai=False)
         assert result == {"roles": []}
 
     @pytest.mark.asyncio
@@ -495,3 +495,49 @@ class TestPendingCandidates:
 
         # Cleanup
         pending_candidates.clear()
+
+
+class TestSearchPassesUseAi:
+    """TalentMarketClient.search() reads use_ai_search from config and passes it."""
+
+    @pytest.mark.asyncio
+    async def test_search_passes_use_ai_true(self, monkeypatch):
+        from onemancompany.agents import recruitment
+
+        captured_kwargs = {}
+
+        async def fake_call(self, tool_name, _retry=True, **kwargs):
+            captured_kwargs.update(kwargs)
+            return {"roles": [], "session_id": ""}
+
+        monkeypatch.setattr(recruitment.TalentMarketClient, "_call", fake_call)
+        monkeypatch.setattr(
+            "onemancompany.agents.recruitment.load_app_config",
+            lambda: {"talent_market": {"use_ai_search": True}},
+        )
+
+        client = recruitment.TalentMarketClient()
+        await client.search("need a python dev")
+
+        assert captured_kwargs.get("use_ai") is True
+
+    @pytest.mark.asyncio
+    async def test_search_passes_use_ai_false_by_default(self, monkeypatch):
+        from onemancompany.agents import recruitment
+
+        captured_kwargs = {}
+
+        async def fake_call(self, tool_name, _retry=True, **kwargs):
+            captured_kwargs.update(kwargs)
+            return {"roles": [], "session_id": ""}
+
+        monkeypatch.setattr(recruitment.TalentMarketClient, "_call", fake_call)
+        monkeypatch.setattr(
+            "onemancompany.agents.recruitment.load_app_config",
+            lambda: {"talent_market": {}},
+        )
+
+        client = recruitment.TalentMarketClient()
+        await client.search("need a python dev")
+
+        assert captured_kwargs.get("use_ai") is False

--- a/tests/unit/agents/test_recruitment.py
+++ b/tests/unit/agents/test_recruitment.py
@@ -201,9 +201,11 @@ class TestTalentMarketClient:
         assert result == {}
 
     @pytest.mark.asyncio
-    async def test_search(self):
+    async def test_search(self, monkeypatch):
+        from onemancompany.agents import recruitment
         from onemancompany.agents.recruitment import TalentMarketClient
 
+        monkeypatch.setattr(recruitment, "load_app_config", lambda: {"talent_market": {}})
         client = TalentMarketClient()
         client._call = AsyncMock(return_value={"roles": []})
 

--- a/tests/unit/api/test_routes.py
+++ b/tests/unit/api/test_routes.py
@@ -6578,3 +6578,104 @@ class TestCeoTaskMode:
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
                 resp = await c.post("/api/ceo/qa", json={"question": "hello"})
         assert resp.status_code in (404, 405)
+
+
+class TestAiSearchSettings:
+    """GET/PUT /api/settings/api includes use_ai_search."""
+
+    @pytest.mark.asyncio
+    async def test_get_returns_use_ai_search(self, monkeypatch):
+        from onemancompany.api.routes import get_api_settings
+        from onemancompany.core import config as config_mod
+
+        mock_settings = MagicMock()
+        mock_settings.openrouter_api_key = ""
+        mock_settings.anthropic_api_key = ""
+        mock_settings.openrouter_base_url = ""
+        mock_settings.default_llm_model = ""
+        mock_settings.anthropic_auth_method = "api_key"
+        monkeypatch.setattr(config_mod, "settings", mock_settings)
+        monkeypatch.setattr(
+            config_mod, "load_app_config",
+            lambda: {"talent_market": {"api_key": "k", "use_ai_search": True}},
+        )
+        monkeypatch.setattr(
+            "onemancompany.api.routes._get_talent_market_connected", lambda: False,
+        )
+        monkeypatch.setattr(
+            "onemancompany.api.routes._get_local_talent_count", lambda: 0,
+        )
+
+        result = await get_api_settings()
+        assert result["talent_market"]["use_ai_search"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_returns_use_ai_search_default_false(self, monkeypatch):
+        from onemancompany.api.routes import get_api_settings
+        from onemancompany.core import config as config_mod
+
+        mock_settings = MagicMock()
+        mock_settings.openrouter_api_key = ""
+        mock_settings.anthropic_api_key = ""
+        mock_settings.openrouter_base_url = ""
+        mock_settings.default_llm_model = ""
+        mock_settings.anthropic_auth_method = "api_key"
+        monkeypatch.setattr(config_mod, "settings", mock_settings)
+        monkeypatch.setattr(
+            config_mod, "load_app_config",
+            lambda: {"talent_market": {"api_key": ""}},
+        )
+        monkeypatch.setattr(
+            "onemancompany.api.routes._get_talent_market_connected", lambda: False,
+        )
+        monkeypatch.setattr(
+            "onemancompany.api.routes._get_local_talent_count", lambda: 0,
+        )
+
+        result = await get_api_settings()
+        assert result["talent_market"]["use_ai_search"] is False
+
+    @pytest.mark.asyncio
+    async def test_put_updates_use_ai_search(self, monkeypatch, tmp_path):
+        import yaml
+        from onemancompany.api.routes import update_api_settings
+        from onemancompany.core import config as config_mod
+        from onemancompany.core.config import write_text_utf
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump({"talent_market": {"api_key": "k", "use_ai_search": False}}))
+
+        monkeypatch.setattr(config_mod, "APP_CONFIG_PATH", config_file)
+        monkeypatch.setattr(config_mod, "load_app_config", lambda: yaml.safe_load(config_file.read_text()))
+        monkeypatch.setattr(config_mod, "reload_app_config", lambda: None)
+        monkeypatch.setattr("onemancompany.api.routes.write_text_utf", lambda p, c: p.write_text(c))
+
+        result = await update_api_settings({"provider": "talent_market", "use_ai_search": True})
+        assert result["status"] == "updated"
+        assert result["talent_market"]["use_ai_search"] is True
+
+        saved = yaml.safe_load(config_file.read_text())
+        assert saved["talent_market"]["use_ai_search"] is True
+
+    @pytest.mark.asyncio
+    async def test_put_use_ai_search_only_without_api_key(self, monkeypatch, tmp_path):
+        """PUT with only use_ai_search (no api_key) should work."""
+        import yaml
+        from onemancompany.api.routes import update_api_settings
+        from onemancompany.core import config as config_mod
+
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(yaml.dump({"talent_market": {"api_key": "existing-key", "use_ai_search": False}}))
+
+        monkeypatch.setattr(config_mod, "APP_CONFIG_PATH", config_file)
+        monkeypatch.setattr(config_mod, "load_app_config", lambda: yaml.safe_load(config_file.read_text()))
+        monkeypatch.setattr(config_mod, "reload_app_config", lambda: None)
+        monkeypatch.setattr("onemancompany.api.routes.write_text_utf", lambda p, c: p.write_text(c))
+
+        result = await update_api_settings({"provider": "talent_market", "use_ai_search": True})
+        assert result["status"] == "updated"
+        assert result["talent_market"]["use_ai_search"] is True
+
+        # Verify existing api_key was not wiped
+        saved = yaml.safe_load(config_file.read_text())
+        assert saved["talent_market"]["api_key"] == "existing-key"

--- a/tests/unit/test_onboard.py
+++ b/tests/unit/test_onboard.py
@@ -213,3 +213,63 @@ class TestCreateExecutorForHosting:
         from onemancompany.core.subprocess_executor import SubprocessExecutor
         executor = _create_executor_for_hosting("openclaw", "00002", MagicMock, Path("/tmp"))
         assert isinstance(executor, SubprocessExecutor)
+
+
+class TestAiSearchPrompt:
+    """AI Search Talent prompt appears only when TM API key is provided."""
+
+    def test_ai_search_prompt_shown_when_api_key_provided(self):
+        """When user enters a TM API key, the AI search confirm is shown."""
+        from onemancompany.onboard import _step_optional, ENV_KEY_TALENT_MARKET
+
+        mock_console = MagicMock()
+
+        # Mock inquirer: Anthropic=skip, SkillMarket=skip, TM=key, AI search=True
+        mock_secret = MagicMock()
+        mock_secret.execute = MagicMock(side_effect=["", "", "tm-key-123"])
+        mock_confirm = MagicMock()
+        mock_confirm.execute = MagicMock(return_value=True)
+
+        with patch("InquirerPy.inquirer.secret", return_value=mock_secret), \
+             patch("InquirerPy.inquirer.confirm", return_value=mock_confirm) as mock_confirm_fn:
+            extras = _step_optional(mock_console)
+
+        assert extras[ENV_KEY_TALENT_MARKET] == "tm-key-123"
+        assert extras.get("USE_AI_SEARCH") == "true"
+        mock_confirm_fn.assert_called_once()
+
+    def test_ai_search_prompt_not_shown_when_no_api_key(self):
+        """When user skips TM API key, no AI search prompt is shown."""
+        from onemancompany.onboard import _step_optional, ENV_KEY_TALENT_MARKET
+
+        mock_console = MagicMock()
+
+        # Mock inquirer: all keys skipped
+        mock_secret = MagicMock()
+        mock_secret.execute = MagicMock(return_value="")
+
+        with patch("InquirerPy.inquirer.secret", return_value=mock_secret), \
+             patch("InquirerPy.inquirer.confirm") as mock_confirm_fn:
+            extras = _step_optional(mock_console)
+
+        assert ENV_KEY_TALENT_MARKET not in extras
+        assert "USE_AI_SEARCH" not in extras
+        mock_confirm_fn.assert_not_called()
+
+    def test_ai_search_false_when_user_declines(self):
+        """When user declines AI search, extras has USE_AI_SEARCH=false."""
+        from onemancompany.onboard import _step_optional, ENV_KEY_TALENT_MARKET
+
+        mock_console = MagicMock()
+
+        mock_secret = MagicMock()
+        mock_secret.execute = MagicMock(side_effect=["", "", "tm-key-456"])
+        mock_confirm = MagicMock()
+        mock_confirm.execute = MagicMock(return_value=False)
+
+        with patch("InquirerPy.inquirer.secret", return_value=mock_secret), \
+             patch("InquirerPy.inquirer.confirm", return_value=mock_confirm):
+            extras = _step_optional(mock_console)
+
+        assert extras[ENV_KEY_TALENT_MARKET] == "tm-key-456"
+        assert extras.get("USE_AI_SEARCH") == "false"


### PR DESCRIPTION
## Summary
- Add `use_ai_search` boolean to `config.yaml` under `talent_market` (default: false)
- Onboarding wizard: after entering Talent Market API key, prompt user to enable AI-powered search
- Recruitment: `TalentMarketClient.search()` reads the setting and passes `use_ai=True/False` to MCP `search_candidates` call
- Settings API: GET/PUT `/api/settings/api` exposes `use_ai_search` for runtime changes
- Frontend: checkbox toggle in Talent Market settings card (only visible when API key is set)

## Test plan
- [x] 3 tests for onboarding prompt logic (shown/hidden/declined)
- [x] 2 tests for recruitment `use_ai` parameter passing
- [x] 4 tests for settings API GET/PUT with `use_ai_search`
- [x] Full suite: 2342 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)