### PR TITLE
fix: make repo BGM louder with proper chiptune melody

### DIFF
--- a/docs/index-full.html
+++ b/docs/index-full.html
@@ -671,34 +671,31 @@ document.querySelectorAll('.btn-secondary, .link-card, nav .links a').forEach(el
   el.addEventListener('click', SFX.click);
 });
 
-// ── Ambient Background Music Engine ──────────────────────────
-// Designed to harmonize with one-man-company.com's BGM (A minor, 120 BPM).
-// This runs at 60 BPM (half-time) in A minor — sine pads + gentle arpeggio.
-// Together: main site provides rhythm/energy, this provides warmth/harmony.
-// Standalone: chill ambient chiptune, peaceful and complete on its own.
+// ── Chiptune Background Music Engine ─────────────────────────
+// Key: A minor (harmonizes with one-man-company.com's A minor 120 BPM BGM).
+// Same tempo (120 BPM) so rhythms lock together.
+// Different texture: triangle bass + square melody (complementary voicing).
+// Standalone: catchy lo-fi chiptune. Together: fills harmonic space.
 const BGM = (() => {
   let ctx, playing = false, nodes = [];
 
-  // Half-time of main site (120 BPM) — creates dreamy interlock
-  const BPM = 60;
-  const beat = 60 / BPM; // 1 second per beat
+  const BPM = 120;
+  const beat = 60 / BPM; // 0.5s per beat
 
-  // A minor — same key as main site for perfect harmony
-  // Pad chords: Am(A-C-E) → C(C-E-G) → Dm(D-F-A) → Em(E-G-B)
-  const padChords = [
-    [110, 130.81, 164.81],  // Am: A2, C3, E3
-    [130.81, 164.81, 196],  // C:  C3, E3, G3
-    [146.83, 174.61, 220],  // Dm: D3, F3, A3
-    [164.81, 196, 246.94],  // Em: E3, G3, B3
+  // Bass line — triangle wave, A minor progression
+  // Am → F → C → G (classic minor pop progression)
+  const bassLine = [
+    110, 110, 110, 110, 87.31, 87.31, 87.31, 87.31,  // A2 A2 A2 A2 F2 F2 F2 F2
+    130.81, 130.81, 130.81, 130.81, 98, 98, 98, 98,   // C3 C3 C3 C3 G2 G2 G2 G2
   ];
 
-  // Gentle arpeggio — high register, sparse (lots of rests)
-  // A minor pentatonic: A, C, D, E, G in octave 4-5
-  const arpNotes = [
-    440, 0, 0, 0, 523.25, 0, 0, 0,   // A4 ... C5 ...
-    587.33, 0, 659.25, 0, 0, 0, 0, 0, // D5 . E5 . ...
-    783.99, 0, 0, 0, 659.25, 0, 0, 0, // G5 ... E5 ...
-    523.25, 0, 440, 0, 0, 0, 0, 0,    // C5 . A4 . ...
+  // Melody — square wave, A minor pentatonic (A C D E G)
+  // Catchy 8-bit phrase with movement and rests
+  const melody = [
+    440, 0, 523.25, 0, 440, 392, 0, 0,          // A4 . C5 . A4 G4 . .
+    659.25, 0, 587.33, 0, 523.25, 0, 440, 0,    // E5 . D5 . C5 . A4 .
+    523.25, 0, 659.25, 0, 783.99, 659.25, 0, 0,  // C5 . E5 . G5 E5 . .
+    587.33, 0, 523.25, 0, 440, 0, 392, 0,        // D5 . C5 . A4 . G4 .
   ];
 
   function start() {
@@ -706,92 +703,60 @@ const BGM = (() => {
     playing = true;
     ctx = new (window.AudioContext || window.webkitAudioContext)();
 
-    // Master volume — slightly quieter than main site so it sits underneath
+    // Master volume — audible standalone, blends well with main site
     const master = ctx.createGain();
-    master.gain.value = 0.06;
+    master.gain.value = 0.09;
     master.connect(ctx.destination);
 
-    // Pad layer — sine waves for warmth
-    const padGain = ctx.createGain();
-    padGain.gain.value = 0.5;
-    // Low-pass filter for dreamy quality
-    const padFilter = ctx.createBiquadFilter();
-    padFilter.type = 'lowpass';
-    padFilter.frequency.value = 1200;
-    padGain.connect(padFilter);
-    padFilter.connect(master);
+    // Bass layer — triangle wave (warm, distinct from main site's bass)
+    const bassGain = ctx.createGain();
+    bassGain.gain.value = 0.55;
+    bassGain.connect(master);
 
-    // Arpeggio layer — soft triangle wave
-    const arpGain = ctx.createGain();
-    arpGain.gain.value = 0.25;
-    const arpFilter = ctx.createBiquadFilter();
-    arpFilter.type = 'lowpass';
-    arpFilter.frequency.value = 3000;
-    arpGain.connect(arpFilter);
-    arpFilter.connect(master);
+    // Melody layer — square wave with detuning for chiptune character
+    const melGain = ctx.createGain();
+    melGain.gain.value = 0.35;
+    const melFilter = ctx.createBiquadFilter();
+    melFilter.type = 'lowpass';
+    melFilter.frequency.value = 2500;
+    melGain.connect(melFilter);
+    melFilter.connect(master);
 
-    // Sub bass layer — very low sine for body
-    const subGain = ctx.createGain();
-    subGain.gain.value = 0.4;
-    subGain.connect(master);
-
-    // Each chord lasts 4 beats, full loop = 16 beats
-    const chordDuration = beat * 4;
-    const loopDuration = padChords.length * chordDuration;
+    const loopDuration = bassLine.length * beat * 0.5;
 
     function scheduleLoop(startTime) {
-      // Pad chords — long sustained sine tones
-      padChords.forEach((chord, ci) => {
-        const t = startTime + ci * chordDuration;
-        chord.forEach(freq => {
-          const osc = ctx.createOscillator();
-          const env = ctx.createGain();
-          osc.type = 'sine';
-          osc.frequency.value = freq;
-          // Slow attack, long sustain, gentle release
-          env.gain.setValueAtTime(0, t);
-          env.gain.linearRampToValueAtTime(0.4, t + 0.3);
-          env.gain.setValueAtTime(0.4, t + chordDuration - 0.4);
-          env.gain.linearRampToValueAtTime(0, t + chordDuration);
-          osc.connect(env);
-          env.connect(padGain);
-          osc.start(t);
-          osc.stop(t + chordDuration + 0.05);
-          nodes.push(osc);
-        });
-
-        // Sub bass — root note one octave lower
-        const subOsc = ctx.createOscillator();
-        const subEnv = ctx.createGain();
-        subOsc.type = 'sine';
-        subOsc.frequency.value = chord[0] / 2; // one octave down
-        subEnv.gain.setValueAtTime(0, t);
-        subEnv.gain.linearRampToValueAtTime(0.3, t + 0.2);
-        subEnv.gain.setValueAtTime(0.3, t + chordDuration - 0.3);
-        subEnv.gain.linearRampToValueAtTime(0, t + chordDuration);
-        subOsc.connect(subEnv);
-        subEnv.connect(subGain);
-        subOsc.start(t);
-        subOsc.stop(t + chordDuration + 0.05);
-        nodes.push(subOsc);
-      });
-
-      // Arpeggio — gentle triangle notes on 8th-note grid
-      arpNotes.forEach((freq, i) => {
+      // Bass — triangle wave, 8th notes
+      bassLine.forEach((freq, i) => {
         if (freq === 0) return;
         const t = startTime + i * beat * 0.5;
         const osc = ctx.createOscillator();
         const env = ctx.createGain();
         osc.type = 'triangle';
         osc.frequency.value = freq;
-        osc.detune.value = Math.random() * 4 - 2; // subtle drift
-        // Short pluck envelope
-        env.gain.setValueAtTime(0.3, t);
-        env.gain.exponentialRampToValueAtTime(0.01, t + beat * 0.4);
+        env.gain.setValueAtTime(0.5, t);
+        env.gain.exponentialRampToValueAtTime(0.01, t + beat * 0.45);
         osc.connect(env);
-        env.connect(arpGain);
+        env.connect(bassGain);
         osc.start(t);
         osc.stop(t + beat * 0.5);
+        nodes.push(osc);
+      });
+
+      // Melody — square wave, 16th notes
+      melody.forEach((freq, i) => {
+        if (freq === 0) return;
+        const t = startTime + i * beat * 0.25;
+        const osc = ctx.createOscillator();
+        const env = ctx.createGain();
+        osc.type = 'square';
+        osc.frequency.value = freq;
+        osc.detune.value = Math.random() * 8 - 4; // chiptune drift
+        env.gain.setValueAtTime(0.3, t);
+        env.gain.exponentialRampToValueAtTime(0.01, t + beat * 0.2);
+        osc.connect(env);
+        env.connect(melGain);
+        osc.start(t);
+        osc.stop(t + beat * 0.25);
         nodes.push(osc);
       });
     }
@@ -800,7 +765,7 @@ const BGM = (() => {
     let nextLoop = ctx.currentTime + 0.1;
     scheduleLoop(nextLoop);
 
-    // Keep scheduling
+    // Keep scheduling ahead
     const interval = setInterval(() => {
       if (!playing) { clearInterval(interval); return; }
       nextLoop += loopDuration;

--- a/docs/index.html
+++ b/docs/index.html
@@ -1068,34 +1068,31 @@ document.querySelectorAll('.btn-secondary, .link-card, nav .links a').forEach(el
   el.addEventListener('click', SFX.click);
 });
 
-// ── Ambient Background Music Engine ──────────────────────────
-// Designed to harmonize with one-man-company.com's BGM (A minor, 120 BPM).
-// This runs at 60 BPM (half-time) in A minor — sine pads + gentle arpeggio.
-// Together: main site provides rhythm/energy, this provides warmth/harmony.
-// Standalone: chill ambient chiptune, peaceful and complete on its own.
+// ── Chiptune Background Music Engine ─────────────────────────
+// Key: A minor (harmonizes with one-man-company.com's A minor 120 BPM BGM).
+// Same tempo (120 BPM) so rhythms lock together.
+// Different texture: triangle bass + square melody (complementary voicing).
+// Standalone: catchy lo-fi chiptune. Together: fills harmonic space.
 const BGM = (() => {
   let ctx, playing = false, nodes = [];
 
-  // Half-time of main site (120 BPM) — creates dreamy interlock
-  const BPM = 60;
-  const beat = 60 / BPM; // 1 second per beat
+  const BPM = 120;
+  const beat = 60 / BPM; // 0.5s per beat
 
-  // A minor — same key as main site for perfect harmony
-  // Pad chords: Am(A-C-E) → C(C-E-G) → Dm(D-F-A) → Em(E-G-B)
-  const padChords = [
-    [110, 130.81, 164.81],  // Am: A2, C3, E3
-    [130.81, 164.81, 196],  // C:  C3, E3, G3
-    [146.83, 174.61, 220],  // Dm: D3, F3, A3
-    [164.81, 196, 246.94],  // Em: E3, G3, B3
+  // Bass line — triangle wave, A minor progression
+  // Am → F → C → G (classic minor pop progression)
+  const bassLine = [
+    110, 110, 110, 110, 87.31, 87.31, 87.31, 87.31,  // A2 A2 A2 A2 F2 F2 F2 F2
+    130.81, 130.81, 130.81, 130.81, 98, 98, 98, 98,   // C3 C3 C3 C3 G2 G2 G2 G2
   ];
 
-  // Gentle arpeggio — high register, sparse (lots of rests)
-  // A minor pentatonic: A, C, D, E, G in octave 4-5
-  const arpNotes = [
-    440, 0, 0, 0, 523.25, 0, 0, 0,   // A4 ... C5 ...
-    587.33, 0, 659.25, 0, 0, 0, 0, 0, // D5 . E5 . ...
-    783.99, 0, 0, 0, 659.25, 0, 0, 0, // G5 ... E5 ...
-    523.25, 0, 440, 0, 0, 0, 0, 0,    // C5 . A4 . ...
+  // Melody — square wave, A minor pentatonic (A C D E G)
+  // Catchy 8-bit phrase with movement and rests
+  const melody = [
+    440, 0, 523.25, 0, 440, 392, 0, 0,          // A4 . C5 . A4 G4 . .
+    659.25, 0, 587.33, 0, 523.25, 0, 440, 0,    // E5 . D5 . C5 . A4 .
+    523.25, 0, 659.25, 0, 783.99, 659.25, 0, 0,  // C5 . E5 . G5 E5 . .
+    587.33, 0, 523.25, 0, 440, 0, 392, 0,        // D5 . C5 . A4 . G4 .
   ];
 
   function start() {
@@ -1103,92 +1100,60 @@ const BGM = (() => {
     playing = true;
     ctx = new (window.AudioContext || window.webkitAudioContext)();
 
-    // Master volume — slightly quieter than main site so it sits underneath
+    // Master volume — audible standalone, blends well with main site
     const master = ctx.createGain();
-    master.gain.value = 0.06;
+    master.gain.value = 0.09;
     master.connect(ctx.destination);
 
-    // Pad layer — sine waves for warmth
-    const padGain = ctx.createGain();
-    padGain.gain.value = 0.5;
-    // Low-pass filter for dreamy quality
-    const padFilter = ctx.createBiquadFilter();
-    padFilter.type = 'lowpass';
-    padFilter.frequency.value = 1200;
-    padGain.connect(padFilter);
-    padFilter.connect(master);
+    // Bass layer — triangle wave (warm, distinct from main site's bass)
+    const bassGain = ctx.createGain();
+    bassGain.gain.value = 0.55;
+    bassGain.connect(master);
 
-    // Arpeggio layer — soft triangle wave
-    const arpGain = ctx.createGain();
-    arpGain.gain.value = 0.25;
-    const arpFilter = ctx.createBiquadFilter();
-    arpFilter.type = 'lowpass';
-    arpFilter.frequency.value = 3000;
-    arpGain.connect(arpFilter);
-    arpFilter.connect(master);
+    // Melody layer — square wave with detuning for chiptune character
+    const melGain = ctx.createGain();
+    melGain.gain.value = 0.35;
+    const melFilter = ctx.createBiquadFilter();
+    melFilter.type = 'lowpass';
+    melFilter.frequency.value = 2500;
+    melGain.connect(melFilter);
+    melFilter.connect(master);
 
-    // Sub bass layer — very low sine for body
-    const subGain = ctx.createGain();
-    subGain.gain.value = 0.4;
-    subGain.connect(master);
-
-    // Each chord lasts 4 beats, full loop = 16 beats
-    const chordDuration = beat * 4;
-    const loopDuration = padChords.length * chordDuration;
+    const loopDuration = bassLine.length * beat * 0.5;
 
     function scheduleLoop(startTime) {
-      // Pad chords — long sustained sine tones
-      padChords.forEach((chord, ci) => {
-        const t = startTime + ci * chordDuration;
-        chord.forEach(freq => {
-          const osc = ctx.createOscillator();
-          const env = ctx.createGain();
-          osc.type = 'sine';
-          osc.frequency.value = freq;
-          // Slow attack, long sustain, gentle release
-          env.gain.setValueAtTime(0, t);
-          env.gain.linearRampToValueAtTime(0.4, t + 0.3);
-          env.gain.setValueAtTime(0.4, t + chordDuration - 0.4);
-          env.gain.linearRampToValueAtTime(0, t + chordDuration);
-          osc.connect(env);
-          env.connect(padGain);
-          osc.start(t);
-          osc.stop(t + chordDuration + 0.05);
-          nodes.push(osc);
-        });
-
-        // Sub bass — root note one octave lower
-        const subOsc = ctx.createOscillator();
-        const subEnv = ctx.createGain();
-        subOsc.type = 'sine';
-        subOsc.frequency.value = chord[0] / 2; // one octave down
-        subEnv.gain.setValueAtTime(0, t);
-        subEnv.gain.linearRampToValueAtTime(0.3, t + 0.2);
-        subEnv.gain.setValueAtTime(0.3, t + chordDuration - 0.3);
-        subEnv.gain.linearRampToValueAtTime(0, t + chordDuration);
-        subOsc.connect(subEnv);
-        subEnv.connect(subGain);
-        subOsc.start(t);
-        subOsc.stop(t + chordDuration + 0.05);
-        nodes.push(subOsc);
-      });
-
-      // Arpeggio — gentle triangle notes on 8th-note grid
-      arpNotes.forEach((freq, i) => {
+      // Bass — triangle wave, 8th notes
+      bassLine.forEach((freq, i) => {
         if (freq === 0) return;
         const t = startTime + i * beat * 0.5;
         const osc = ctx.createOscillator();
         const env = ctx.createGain();
         osc.type = 'triangle';
         osc.frequency.value = freq;
-        osc.detune.value = Math.random() * 4 - 2; // subtle drift
-        // Short pluck envelope
-        env.gain.setValueAtTime(0.3, t);
-        env.gain.exponentialRampToValueAtTime(0.01, t + beat * 0.4);
+        env.gain.setValueAtTime(0.5, t);
+        env.gain.exponentialRampToValueAtTime(0.01, t + beat * 0.45);
         osc.connect(env);
-        env.connect(arpGain);
+        env.connect(bassGain);
         osc.start(t);
         osc.stop(t + beat * 0.5);
+        nodes.push(osc);
+      });
+
+      // Melody — square wave, 16th notes
+      melody.forEach((freq, i) => {
+        if (freq === 0) return;
+        const t = startTime + i * beat * 0.25;
+        const osc = ctx.createOscillator();
+        const env = ctx.createGain();
+        osc.type = 'square';
+        osc.frequency.value = freq;
+        osc.detune.value = Math.random() * 8 - 4; // chiptune drift
+        env.gain.setValueAtTime(0.3, t);
+        env.gain.exponentialRampToValueAtTime(0.01, t + beat * 0.2);
+        osc.connect(env);
+        env.connect(melGain);
+        osc.start(t);
+        osc.stop(t + beat * 0.25);
         nodes.push(osc);
       });
     }
@@ -1197,7 +1162,7 @@ const BGM = (() => {
     let nextLoop = ctx.currentTime + 0.1;
     scheduleLoop(nextLoop);
 
-    // Keep scheduling
+    // Keep scheduling ahead
     const interval = setInterval(() => {
       if (!playing) { clearInterval(interval); return; }
       nextLoop += loopDuration;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.30",
+  "version": "0.4.31",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.30"
+version = "0.4.31"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.29"
+version = "0.4.30"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/unit/core/test_agent_loop.py
+++ b/tests/unit/core/test_agent_loop.py
@@ -2158,9 +2158,10 @@ class TestProjectCompletionBottomUp:
     tree is resolved (bottom-up propagation via is_project_complete)."""
 
     @pytest.mark.asyncio
+    @patch("onemancompany.core.vessel._summarize_project_for_ceo", new_callable=AsyncMock, return_value="")
     @patch("onemancompany.core.vessel.company_state")
     @patch("onemancompany.core.vessel.event_bus")
-    async def test_flat_tree_all_children_accepted_triggers_retrospective(self, mock_bus, mock_state, tmp_path):
+    async def test_flat_tree_all_children_accepted_triggers_retrospective(self, mock_bus, mock_state, mock_summarize, tmp_path):
         """CEO → EA → [c1(accepted), c2(accepted)]
         Last review node completes → EA auto-completes → project complete → CEO confirm node created.
         """
@@ -2246,9 +2247,10 @@ class TestProjectCompletionBottomUp:
         mock_schedule.assert_not_called()
 
     @pytest.mark.asyncio
+    @patch("onemancompany.core.vessel._summarize_project_for_ceo", new_callable=AsyncMock, return_value="")
     @patch("onemancompany.core.vessel.company_state")
     @patch("onemancompany.core.vessel.event_bus")
-    async def test_mixed_terminal_states_still_triggers_retrospective(self, mock_bus, mock_state, tmp_path):
+    async def test_mixed_terminal_states_still_triggers_retrospective(self, mock_bus, mock_state, mock_summarize, tmp_path):
         """CEO → EA(completed) → [c1(accepted), c2(failed), c3(cancelled), review(finished)]
         EA already completed by prior review cycle. All children are RESOLVED
         (even though not all succeeded) → project complete → retrospective.
@@ -2295,9 +2297,10 @@ class TestProjectCompletionBottomUp:
 
 
     @pytest.mark.asyncio
+    @patch("onemancompany.core.vessel._summarize_project_for_ceo", new_callable=AsyncMock, return_value="")
     @patch("onemancompany.core.vessel.company_state")
     @patch("onemancompany.core.vessel.event_bus")
-    async def test_completed_parent_auto_promotes_when_children_all_accepted(self, mock_bus, mock_state, tmp_path):
+    async def test_completed_parent_auto_promotes_when_children_all_accepted(self, mock_bus, mock_state, mock_summarize, tmp_path):
         """CEO → EA(completed) → [c1(accepted), c2(just accepted)]
         EA is COMPLETED (early completion). When last child becomes ACCEPTED,
         EA should auto-promote COMPLETED → ACCEPTED → FINISHED, then project completes.


### PR DESCRIPTION
## Summary
- Replace quiet ambient pads with proper chiptune (bass + melody)
- 120 BPM A minor (same key/tempo as main site for harmony)
- Triangle bass: Am→F→C→G progression
- Square melody: A minor pentatonic, catchy 8-bit phrase
- Master volume 0.06→0.09

## Why
Previous version was too quiet and low-pitched, barely audible. Sounded lifeless standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)