### PR TITLE
fix: stop aggressive OAuth token refresh in web_search

### DIFF
--- a/company/assets/tools/web_search/web_search.py
+++ b/company/assets/tools/web_search/web_search.py
@@ -64,25 +64,20 @@ def _resolve_anthropic_auth() -> tuple[str, dict]:
     """Resolve Anthropic API authentication — supports both API key and OAuth.
 
     Returns (key_or_token, auth_headers_dict). Empty dict if no auth available.
+    For OAuth, returns the stored token WITHOUT refreshing — refresh only on 401.
     """
     auth_method = _load_env_var("ANTHROPIC_AUTH_METHOD")
 
     if auth_method == "oauth":
-        # OAuth PKCE: refresh token if needed, use Bearer header
         access_token = _load_env_var(_ENV_KEY_NAME)
+        if access_token:
+            return access_token, {"Authorization": f"Bearer {access_token}"}
+        # No access token — try refresh as last resort
         refresh_token = _load_env_var("ANTHROPIC_REFRESH_TOKEN")
-        if not access_token and not refresh_token:
-            return "", {}
-
-        # Try refreshing via Anthropic PKCE (no client_secret needed)
         if refresh_token:
             fresh = _refresh_anthropic_token(refresh_token)
             if fresh:
                 return fresh, {"Authorization": f"Bearer {fresh}"}
-
-        # Fallback: use the stored access token directly (may be expired)
-        if access_token:
-            return access_token, {"Authorization": f"Bearer {access_token}"}
         return "", {}
 
     # Default: API key auth
@@ -102,7 +97,9 @@ def _refresh_anthropic_token(refresh_token: str) -> str:
     On success, updates .env with the new access token and returns it.
     Returns empty string on failure.
     """
-    payload = json.dumps({
+    import urllib.parse
+
+    payload = urllib.parse.urlencode({
         "grant_type": "refresh_token",
         "refresh_token": refresh_token,
         "client_id": _ANTHROPIC_CLIENT_ID,
@@ -111,7 +108,7 @@ def _refresh_anthropic_token(refresh_token: str) -> str:
     req = urllib.request.Request(
         _ANTHROPIC_TOKEN_URL,
         data=payload,
-        headers={"Content-Type": "application/json"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
         method="POST",
     )
     try:
@@ -226,6 +223,22 @@ def web_search(query: str, max_results: int = 5) -> dict:
     }
 
     resp_json, err = _post_json(_API_URL, headers, payload, timeout=60)
+
+    # On 401 (expired OAuth token), refresh once and retry
+    if err and "HTTP 401" in err and _load_env_var("ANTHROPIC_AUTH_METHOD") == "oauth":
+        refresh_token = _load_env_var("ANTHROPIC_REFRESH_TOKEN")
+        if refresh_token:
+            logger.debug("[web_search] Got 401, refreshing OAuth token")
+            fresh = _refresh_anthropic_token(refresh_token)
+            if fresh:
+                headers = {
+                    "Authorization": f"Bearer {fresh}",
+                    "anthropic-version": _API_VERSION,
+                    "content-type": "application/json",
+                    "User-Agent": _USER_AGENT,
+                }
+                resp_json, err = _post_json(_API_URL, headers, payload, timeout=60)
+
     if err or resp_json is None:
         return {"status": "error", "message": err or "empty response from API"}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.32",
+  "version": "0.4.33",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.33",
+  "version": "0.4.34",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.33"
+version = "0.4.34"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.32"
+version = "0.4.33"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/unit/tools/test_web_search.py
+++ b/tests/unit/tools/test_web_search.py
@@ -1,0 +1,203 @@
+"""Unit tests for web_search tool — OAuth auth resolution and 401 retry."""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+# All patches target the web_search module where names are looked up
+_MOD = "company.assets.tools.web_search.web_search"
+
+
+class TestResolveAnthropicAuth:
+    """_resolve_anthropic_auth should use stored token first, only refresh when needed."""
+
+    def test_api_key_auth(self):
+        """Non-OAuth: returns x-api-key header."""
+        from company.assets.tools.web_search.web_search import _resolve_anthropic_auth
+
+        with patch(f"{_MOD}._load_env_var") as mock_env:
+            mock_env.side_effect = lambda name: {
+                "ANTHROPIC_AUTH_METHOD": "api_key",
+                "ANTHROPIC_API_KEY": "sk-test-key",
+            }.get(name, "")
+            token, headers = _resolve_anthropic_auth()
+
+        assert token == "sk-test-key"
+        assert headers == {"x-api-key": "sk-test-key"}
+
+    def test_oauth_uses_stored_token_without_refresh(self):
+        """OAuth with valid access token should NOT call _refresh_anthropic_token."""
+        from company.assets.tools.web_search.web_search import _resolve_anthropic_auth
+
+        with patch(f"{_MOD}._load_env_var") as mock_env, \
+             patch(f"{_MOD}._refresh_anthropic_token") as mock_refresh:
+            mock_env.side_effect = lambda name: {
+                "ANTHROPIC_AUTH_METHOD": "oauth",
+                "ANTHROPIC_API_KEY": "stored-access-token",
+                "ANTHROPIC_REFRESH_TOKEN": "some-refresh-token",
+            }.get(name, "")
+            token, headers = _resolve_anthropic_auth()
+
+        assert token == "stored-access-token"
+        assert headers == {"Authorization": "Bearer stored-access-token"}
+        mock_refresh.assert_not_called()
+
+    def test_oauth_no_access_token_tries_refresh(self):
+        """OAuth with no access token but refresh token should try to refresh."""
+        from company.assets.tools.web_search.web_search import _resolve_anthropic_auth
+
+        with patch(f"{_MOD}._load_env_var") as mock_env, \
+             patch(f"{_MOD}._refresh_anthropic_token", return_value="fresh-token") as mock_refresh:
+            mock_env.side_effect = lambda name: {
+                "ANTHROPIC_AUTH_METHOD": "oauth",
+                "ANTHROPIC_API_KEY": "",
+                "ANTHROPIC_REFRESH_TOKEN": "my-refresh-token",
+            }.get(name, "")
+            token, headers = _resolve_anthropic_auth()
+
+        assert token == "fresh-token"
+        assert headers == {"Authorization": "Bearer fresh-token"}
+        mock_refresh.assert_called_once_with("my-refresh-token")
+
+    def test_oauth_no_tokens_returns_empty(self):
+        """OAuth with no tokens at all returns empty."""
+        from company.assets.tools.web_search.web_search import _resolve_anthropic_auth
+
+        with patch(f"{_MOD}._load_env_var", return_value="") as mock_env:
+            # First call for auth_method returns "oauth", rest return ""
+            mock_env.side_effect = lambda name: "oauth" if name == "ANTHROPIC_AUTH_METHOD" else ""
+            token, headers = _resolve_anthropic_auth()
+
+        assert token == ""
+        assert headers == {}
+
+
+class TestWebSearch401Retry:
+    """web_search should retry once on 401 with refreshed token."""
+
+    def test_401_triggers_refresh_and_retry(self):
+        """On 401, web_search should refresh token and retry the API call."""
+        from company.assets.tools.web_search.web_search import web_search
+
+        success_response = {
+            "content": [
+                {"type": "text", "text": "Search results here"},
+            ]
+        }
+
+        call_count = 0
+
+        def mock_post_json(url, headers, payload, timeout=30):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call: 401 expired token
+                return None, "HTTP 401: Unauthorized"
+            # Second call: success with fresh token
+            return success_response, None
+
+        with patch(f"{_MOD}._resolve_anthropic_auth", return_value=("old-token", {"Authorization": "Bearer old-token"})), \
+             patch(f"{_MOD}._post_json", side_effect=mock_post_json), \
+             patch(f"{_MOD}._load_env_var") as mock_env, \
+             patch(f"{_MOD}._refresh_anthropic_token", return_value="fresh-token") as mock_refresh:
+            mock_env.side_effect = lambda name: {
+                "ANTHROPIC_AUTH_METHOD": "oauth",
+                "ANTHROPIC_REFRESH_TOKEN": "my-refresh",
+            }.get(name, "")
+
+            result = web_search.invoke({"query": "test query"})
+
+        assert result["status"] == "ok"
+        assert result["answer"] == "Search results here"
+        mock_refresh.assert_called_once_with("my-refresh")
+        assert call_count == 2
+
+    def test_401_no_refresh_token_returns_error(self):
+        """On 401 without refresh token, returns the original error."""
+        from company.assets.tools.web_search.web_search import web_search
+
+        with patch(f"{_MOD}._resolve_anthropic_auth", return_value=("old-token", {"Authorization": "Bearer old-token"})), \
+             patch(f"{_MOD}._post_json", return_value=(None, "HTTP 401: Unauthorized")), \
+             patch(f"{_MOD}._load_env_var") as mock_env:
+            mock_env.side_effect = lambda name: {
+                "ANTHROPIC_AUTH_METHOD": "oauth",
+                "ANTHROPIC_REFRESH_TOKEN": "",
+            }.get(name, "")
+
+            result = web_search.invoke({"query": "test query"})
+
+        assert result["status"] == "error"
+        assert "401" in result["message"]
+
+    def test_non_401_error_no_retry(self):
+        """Non-401 errors should not trigger refresh/retry."""
+        from company.assets.tools.web_search.web_search import web_search
+
+        with patch(f"{_MOD}._resolve_anthropic_auth", return_value=("token", {"Authorization": "Bearer token"})), \
+             patch(f"{_MOD}._post_json", return_value=(None, "HTTP 500: Internal Server Error")), \
+             patch(f"{_MOD}._refresh_anthropic_token") as mock_refresh:
+
+            result = web_search.invoke({"query": "test query"})
+
+        assert result["status"] == "error"
+        assert "500" in result["message"]
+        mock_refresh.assert_not_called()
+
+    def test_api_key_401_no_retry(self):
+        """API key auth with 401 should not attempt OAuth refresh."""
+        from company.assets.tools.web_search.web_search import web_search
+
+        with patch(f"{_MOD}._resolve_anthropic_auth", return_value=("bad-key", {"x-api-key": "bad-key"})), \
+             patch(f"{_MOD}._post_json", return_value=(None, "HTTP 401: Invalid API key")), \
+             patch(f"{_MOD}._load_env_var") as mock_env, \
+             patch(f"{_MOD}._refresh_anthropic_token") as mock_refresh:
+            mock_env.side_effect = lambda name: {
+                "ANTHROPIC_AUTH_METHOD": "api_key",
+            }.get(name, "")
+
+            result = web_search.invoke({"query": "test query"})
+
+        assert result["status"] == "error"
+        mock_refresh.assert_not_called()
+
+
+class TestRefreshTokenFormat:
+    """_refresh_anthropic_token should use form-urlencoded, not JSON."""
+
+    def test_refresh_sends_form_urlencoded(self):
+        """Token refresh request must use application/x-www-form-urlencoded."""
+        from company.assets.tools.web_search.web_search import _refresh_anthropic_token
+
+        captured_req = {}
+
+        def mock_urlopen(req, timeout=None):
+            captured_req["content_type"] = req.get_header("Content-type")
+            captured_req["data"] = req.data.decode("utf-8")
+            captured_req["url"] = req.full_url
+
+            resp = MagicMock()
+            resp.read.return_value = b'{"access_token": "new-tok", "refresh_token": "new-ref"}'
+            resp.__enter__ = lambda s: resp
+            resp.__exit__ = MagicMock(return_value=False)
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=mock_urlopen), \
+             patch("onemancompany.core.config.update_env_var"):
+            result = _refresh_anthropic_token("my-refresh-token")
+
+        assert result == "new-tok"
+        assert captured_req["content_type"] == "application/x-www-form-urlencoded"
+        assert "grant_type=refresh_token" in captured_req["data"]
+        assert "refresh_token=my-refresh-token" in captured_req["data"]
+
+    def test_refresh_failure_returns_empty(self):
+        """On network error, returns empty string."""
+        from company.assets.tools.web_search.web_search import _refresh_anthropic_token
+
+        with patch("urllib.request.urlopen", side_effect=Exception("network error")):
+            result = _refresh_anthropic_token("some-token")
+
+        assert result == ""


### PR DESCRIPTION
## Summary
- web_search tool was refreshing OAuth token on **every call**, hammering Anthropic's token endpoint
- This exhausted rate limits, also blocking OAuth re-login (same endpoint)
- Now: use stored token first, only refresh on 401
- Also fixed: token refresh uses form-urlencoded (not JSON) per Anthropic spec

## Root cause
`_resolve_anthropic_auth()` unconditionally called `_refresh_anthropic_token()` whenever a refresh_token existed, instead of trying the stored access_token first.

## Test plan
- [x] Full test suite: 2343 passed
- [ ] Manual: OAuth login → web_search works → no rate limit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)