### PR TITLE
feat: talent market local/remote mode + AI search error fallback

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,3 +16,4 @@ talent_market:
   url: "https://api.one-man-company.com/mcp/sse" # Centralized Talent Market endpoint
   api_key: "" # Set your API key in Settings or here
   use_ai_search: false # Use AI-powered search for better candidate matching
+  mode: "local" # "local" = use talents/ folder, "remote" = use cloud Talent Market

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5309,21 +5309,23 @@ class AppController {
               <label style="font-size:6.5px;color:var(--text-dim);margin-right:2px;">Mode:</label>
               <input type="hidden" id="api-tm-mode-val" value="${tm.mode || 'local'}" />
               <button class="pixel-btn small" id="api-tm-mode-local"
-                onclick="document.getElementById('api-tm-mode-val').value='local';this.style.borderColor='var(--pixel-green)';this.style.color='var(--pixel-green)';document.getElementById('api-tm-mode-remote').style.borderColor='';document.getElementById('api-tm-mode-remote').style.color=''"
+                onclick="document.getElementById('api-tm-mode-val').value='local';this.style.borderColor='var(--pixel-green)';this.style.color='var(--pixel-green)';document.getElementById('api-tm-mode-remote').style.borderColor='';document.getElementById('api-tm-mode-remote').style.color='';document.getElementById('api-tm-remote-opts').style.display='none'"
                 style="font-size:5.5px;padding:2px 6px;${tm.mode === 'local' ? 'border-color:var(--pixel-green);color:var(--pixel-green);' : ''}">💾 Local</button>
               <button class="pixel-btn small" id="api-tm-mode-remote"
-                onclick="document.getElementById('api-tm-mode-val').value='remote';this.style.borderColor='var(--pixel-cyan)';this.style.color='var(--pixel-cyan)';document.getElementById('api-tm-mode-local').style.borderColor='';document.getElementById('api-tm-mode-local').style.color=''"
+                onclick="document.getElementById('api-tm-mode-val').value='remote';this.style.borderColor='var(--pixel-cyan)';this.style.color='var(--pixel-cyan)';document.getElementById('api-tm-mode-local').style.borderColor='';document.getElementById('api-tm-mode-local').style.color='';document.getElementById('api-tm-remote-opts').style.display='block'"
                 style="font-size:5.5px;padding:2px 6px;${tm.mode === 'remote' ? 'border-color:var(--pixel-cyan);color:var(--pixel-cyan);' : ''}">☁️ Remote</button>
             </div>
-            <label class="api-field-label">API Key (required for remote mode)</label>
-            <input type="password" id="api-tm-key" class="api-key-input" placeholder="${tm.api_key_set ? tm.api_key_preview : '(none)'}" />
-            ${tm.api_key_set ? `
-            <div style="margin:6px 0;display:flex;align-items:center;gap:6px;">
-              <input type="checkbox" id="api-tm-use-ai" ${tm.use_ai_search ? 'checked' : ''} style="accent-color:var(--pixel-green);" />
-              <label for="api-tm-use-ai" style="font-size:6.5px;color:var(--pixel-yellow);cursor:pointer;">
-                AI-Powered Search (improves candidate quality)
-              </label>
-            </div>` : ''}
+            <div id="api-tm-remote-opts" style="${tm.mode === 'remote' ? '' : 'display:none;'}">
+              <label class="api-field-label">API Key</label>
+              <input type="password" id="api-tm-key" class="api-key-input" placeholder="${tm.api_key_set ? tm.api_key_preview : '(none)'}" />
+              ${tm.api_key_set ? `
+              <div style="margin:6px 0;display:flex;align-items:center;gap:6px;">
+                <input type="checkbox" id="api-tm-use-ai" ${tm.use_ai_search ? 'checked' : ''} style="accent-color:var(--pixel-green);" />
+                <label for="api-tm-use-ai" style="font-size:6.5px;color:var(--pixel-yellow);cursor:pointer;">
+                  AI-Powered Search (improves candidate quality)
+                </label>
+              </div>` : ''}
+            </div>
             <div class="api-card-actions">
               <button class="pixel-btn small" onclick="app._saveApiSettings('talent_market')">Save</button>
               <span id="api-tm-result" class="api-test-result"></span>

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5297,13 +5297,25 @@ class AppController {
           </div>
           <div id="api-tm-body" class="api-card-body collapsed">
             <div class="tm-status-info" style="font-size:6.5px;margin-bottom:4px;color:var(--text-dim);">
-              ${tm.connected
-                ? '✅ Connected to Cloud Talent Market'
-                : tm.api_key_set
-                  ? '❌ Cloud connection failed, using Local Talent Market'
-                  : 'API Key not configured, using Local Talent Market (' + (tm.local_talent_count || 0) + ' talents)'}
+              ${tm.mode === 'remote'
+                ? (tm.connected
+                  ? '✅ Connected to Cloud Talent Market'
+                  : tm.api_key_set
+                    ? '❌ Cloud connection failed'
+                    : '⚠️ API Key not configured')
+                : '💾 Using Local Talent Market (' + (tm.local_talent_count || 0) + ' talents)'}
             </div>
-            <label class="api-field-label">API Key (configure to use cloud service)</label>
+            <div style="margin:6px 0;display:flex;align-items:center;gap:6px;">
+              <label style="font-size:6.5px;color:var(--text-dim);margin-right:2px;">Mode:</label>
+              <input type="hidden" id="api-tm-mode-val" value="${tm.mode || 'local'}" />
+              <button class="pixel-btn small" id="api-tm-mode-local"
+                onclick="document.getElementById('api-tm-mode-val').value='local';this.style.borderColor='var(--pixel-green)';this.style.color='var(--pixel-green)';document.getElementById('api-tm-mode-remote').style.borderColor='';document.getElementById('api-tm-mode-remote').style.color=''"
+                style="font-size:5.5px;padding:2px 6px;${tm.mode === 'local' ? 'border-color:var(--pixel-green);color:var(--pixel-green);' : ''}">💾 Local</button>
+              <button class="pixel-btn small" id="api-tm-mode-remote"
+                onclick="document.getElementById('api-tm-mode-val').value='remote';this.style.borderColor='var(--pixel-cyan)';this.style.color='var(--pixel-cyan)';document.getElementById('api-tm-mode-local').style.borderColor='';document.getElementById('api-tm-mode-local').style.color=''"
+                style="font-size:5.5px;padding:2px 6px;${tm.mode === 'remote' ? 'border-color:var(--pixel-cyan);color:var(--pixel-cyan);' : ''}">☁️ Remote</button>
+            </div>
+            <label class="api-field-label">API Key (required for remote mode)</label>
             <input type="password" id="api-tm-key" class="api-key-input" placeholder="${tm.api_key_set ? tm.api_key_preview : '(none)'}" />
             ${tm.api_key_set ? `
             <div style="margin:6px 0;display:flex;align-items:center;gap:6px;">
@@ -5338,11 +5350,13 @@ class AppController {
 
   async _saveApiSettings(provider) {
     if (provider === 'talent_market') {
-      const body = { provider, mode: 'remote' };
+      const body = { provider };
       const key = document.getElementById('api-tm-key').value.trim();
       if (key) body.api_key = key;
       const aiCheckbox = document.getElementById('api-tm-use-ai');
       if (aiCheckbox) body.use_ai_search = aiCheckbox.checked;
+      const modeVal = document.getElementById('api-tm-mode-val');
+      if (modeVal) body.mode = modeVal.value;
       try {
         const resp = await fetch('/api/settings/api', {
           method: 'PUT',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.35",
+  "version": "0.4.36",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.34",
+  "version": "0.4.35",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.34"
+version = "0.4.35"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.35"
+version = "0.4.36"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/recruitment.py
+++ b/src/onemancompany/agents/recruitment.py
@@ -463,10 +463,20 @@ def _local_fallback_search(job_description: str) -> dict:
     }
 
 
+def _is_error_response(grouped: dict) -> str:
+    """Check if a Talent Market response is an error. Returns error message or empty string."""
+    if "error" in grouped:
+        err = grouped["error"]
+        return err.get("message", str(err)) if isinstance(err, dict) else str(err)
+    if grouped.get("status") == "error":
+        return grouped.get("message", "Unknown error")
+    return ""
+
+
 @tool
 async def search_candidates(job_description: str) -> dict:
     """Search for candidates matching a job description.
-    Uses Talent Market API when connected, falls back to local talent packages.
+    Uses Talent Market API when connected (and mode=remote), falls back to local talent packages.
 
     Args:
         job_description: The job requirements / description text.
@@ -476,31 +486,62 @@ async def search_candidates(job_description: str) -> dict:
     """
     global _last_session_id
 
-    logger.debug("[recruitment] search_candidates called, talent_market.connected={}", talent_market.connected)
+    tm_config = load_app_config().get("talent_market", {})
+    tm_mode = tm_config.get("mode", "local")
+
+    logger.debug("[recruitment] search_candidates called, mode={}, talent_market.connected={}", tm_mode, talent_market.connected)
     from_market = False
-    if talent_market.connected:
+    market_warning = ""
+
+    if tm_mode == "remote" and talent_market.connected:
         try:
             logger.debug("[recruitment] Calling Talent Market API for JD: {}", job_description[:80])
             grouped = await talent_market.search(job_description)
-            total = sum(len(r.get("candidates", [])) for r in grouped.get("roles", []))
-            logger.info("Talent Market returned {} candidates in {} roles for JD: {}",
-                        total, len(grouped.get("roles", [])), job_description[:80])
-            # Enumerate all returned talents for debugging
-            for role_group in grouped.get("roles", []):
-                for idx, candidate in enumerate(role_group.get("candidates", [])):
-                    talent_data = candidate.get("talent", {}) if isinstance(candidate.get("talent"), dict) else {}
-                    profile = talent_data.get("profile", {}) if isinstance(talent_data, dict) else {}
-                    talent_id = profile.get("id", "") or candidate.get("id", "") or candidate.get("talent_id", "")
-                    talent_name = profile.get("name", "") or candidate.get("name", "")
-                    talent_role = role_group.get("role", "")
-                    logger.debug("[recruitment] Talent Market candidate #{}: id={}, name={}, role={}",
-                                 idx + 1, talent_id, talent_name, talent_role)
-            from_market = True
+
+            # Check for error response (e.g. insufficient credits)
+            err_msg = _is_error_response(grouped)
+            if err_msg:
+                logger.warning("[recruitment] Talent Market returned error: {}", err_msg)
+                # Fallback: retry without AI search if it was enabled
+                use_ai = tm_config.get("use_ai_search", False)
+                if use_ai:
+                    logger.info("[recruitment] Retrying without AI search...")
+                    grouped = await talent_market._call("search_candidates", job_description=job_description, use_ai=False)
+                    err_msg2 = _is_error_response(grouped)
+                    if err_msg2:
+                        logger.warning("[recruitment] Non-AI search also failed: {}, falling back to local", err_msg2)
+                        market_warning = f"Cloud search failed ({err_msg}). Using local talent pool instead."
+                        grouped = _local_fallback_search(job_description)
+                    else:
+                        market_warning = f"AI search unavailable ({err_msg}). Showing standard search results."
+                        from_market = True
+                else:
+                    market_warning = f"Cloud search failed ({err_msg}). Using local talent pool instead."
+                    grouped = _local_fallback_search(job_description)
+            else:
+                total = sum(len(r.get("candidates", [])) for r in grouped.get("roles", []))
+                logger.info("Talent Market returned {} candidates in {} roles for JD: {}",
+                            total, len(grouped.get("roles", [])), job_description[:80])
+                for role_group in grouped.get("roles", []):
+                    for idx, candidate in enumerate(role_group.get("candidates", [])):
+                        talent_data = candidate.get("talent", {}) if isinstance(candidate.get("talent"), dict) else {}
+                        profile = talent_data.get("profile", {}) if isinstance(talent_data, dict) else {}
+                        talent_id = profile.get("id", "") or candidate.get("id", "") or candidate.get("talent_id", "")
+                        talent_name = profile.get("name", "") or candidate.get("name", "")
+                        talent_role = role_group.get("role", "")
+                        logger.debug("[recruitment] Talent Market candidate #{}: id={}, name={}, role={}",
+                                     idx + 1, talent_id, talent_name, talent_role)
+                from_market = True
         except Exception as e:
             logger.opt(exception=e).error("Talent Market search failed, falling back to local: {!r}", e)
+            market_warning = f"Cloud connection error. Using local talent pool instead."
             grouped = _local_fallback_search(job_description)
     else:
-        logger.info("[recruitment] Talent Market not connected, using local talent pool")
+        if tm_mode == "remote" and not talent_market.connected:
+            logger.info("[recruitment] Talent Market not connected, falling back to local")
+            market_warning = "Cloud Talent Market not connected. Using local talent pool."
+        else:
+            logger.info("[recruitment] Using local talent pool (mode=local)")
         grouped = _local_fallback_search(job_description)
 
     _last_session_id = grouped.get("session_id", "")
@@ -527,13 +568,18 @@ async def search_candidates(job_description: str) -> dict:
         all_ids = list(_last_search_results.keys())
         logger.info("[recruitment] Auto-submitting {} Talent Market candidates as shortlist", len(all_ids))
         result = await _auto_submit_shortlist(job_description, all_ids, grouped.get("roles", []))
-        return {
+        resp = {
             "type": grouped.get("type", "market"),
             "summary": result,
             "roles": grouped.get("roles", []),
             "auto_shortlisted": True,
         }
+        if market_warning:
+            resp["warning"] = market_warning
+        return resp
 
+    if market_warning:
+        grouped["warning"] = market_warning
     return grouped
 
 

--- a/src/onemancompany/agents/recruitment.py
+++ b/src/onemancompany/agents/recruitment.py
@@ -392,9 +392,15 @@ class TalentMarketClient:
             await self.connect(url, api_key)
             logger.info("[TalentMarket] auto-reconnected")
 
-    async def search(self, job_description: str) -> dict:
-        """Search for candidates matching a job description."""
-        use_ai = load_app_config().get("talent_market", {}).get("use_ai_search", False)
+    async def search(self, job_description: str, *, use_ai: bool | None = None) -> dict:
+        """Search for candidates matching a job description.
+
+        Args:
+            job_description: The job requirements text.
+            use_ai: Override AI search setting. None = read from config.
+        """
+        if use_ai is None:
+            use_ai = load_app_config().get("talent_market", {}).get("use_ai_search", False)
         return await self._call("search_candidates", job_description=job_description, use_ai=use_ai)
 
     async def list_available(self, role: str = "", skills: str = "", page: int = 1, page_size: int = 20) -> dict:
@@ -506,7 +512,7 @@ async def search_candidates(job_description: str) -> dict:
                 use_ai = tm_config.get("use_ai_search", False)
                 if use_ai:
                     logger.info("[recruitment] Retrying without AI search...")
-                    grouped = await talent_market._call("search_candidates", job_description=job_description, use_ai=False)
+                    grouped = await talent_market.search(job_description, use_ai=False)
                     err_msg2 = _is_error_response(grouped)
                     if err_msg2:
                         logger.warning("[recruitment] Non-AI search also failed: {}, falling back to local", err_msg2)

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -2033,7 +2033,7 @@ async def get_api_settings() -> dict:
         "talent_market": {
             "api_key_set": bool(tm_key),
             "api_key_preview": ("..." + tm_key[-4:]) if len(tm_key) >= 4 else "",
-            "mode": "cloud" if bool(tm_key) else "local",
+            "mode": tm.get("mode", "local"),
             "connected": _get_talent_market_connected(),
             "local_talent_count": _get_local_talent_count(),
             "use_ai_search": tm.get("use_ai_search", False),
@@ -2053,14 +2053,17 @@ async def update_api_settings(body: dict) -> dict:
         import yaml
         from onemancompany.core.config import APP_CONFIG_PATH, load_app_config, reload_app_config
         api_key = body.get("api_key", "")
-        if not api_key and "use_ai_search" not in body:
-            return {"error": "API key or use_ai_search is required"}
+        has_toggle = "use_ai_search" in body or "mode" in body
+        if not api_key and not has_toggle:
+            return {"error": "API key, use_ai_search, or mode is required"}
         config = load_app_config()
         tm = config.setdefault("talent_market", {})
         if api_key:
             tm["api_key"] = api_key
         if "use_ai_search" in body:
             tm["use_ai_search"] = bool(body["use_ai_search"])
+        if "mode" in body and body["mode"] in ("local", "remote"):
+            tm["mode"] = body["mode"]
         write_text_utf(APP_CONFIG_PATH, yaml.dump(config, default_flow_style=False, allow_unicode=True))
         reload_app_config()
 
@@ -2079,6 +2082,7 @@ async def update_api_settings(body: dict) -> dict:
                 "api_key_set": bool(tm.get("api_key", "")),
                 "api_key_preview": ("..." + api_key[-4:]) if api_key and len(api_key) >= 4 else "",
                 "use_ai_search": tm.get("use_ai_search", False),
+                "mode": tm.get("mode", "local"),
             },
         }
 

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -682,14 +682,18 @@ def _step_execute(
         cfg = yaml.safe_load(read_text_utf(dst_config)) or {}
         # Sandbox toggle
         cfg.setdefault("tools", {}).setdefault("sandbox", {})["enabled"] = sandbox_enabled
-        # Talent Market API key
+        # Talent Market API key + mode
         tm_key = extras.get(ENV_KEY_TALENT_MARKET, "")
+        tm_cfg = cfg.setdefault("talent_market", {})
         if tm_key:
-            cfg.setdefault("talent_market", {})["api_key"] = tm_key
+            tm_cfg["api_key"] = tm_key
+            tm_cfg["mode"] = "remote"  # API key provided → default to remote
+        else:
+            tm_cfg["mode"] = "local"   # No API key → local mode
         # AI Search toggle
         use_ai_val = extras.get("USE_AI_SEARCH", "")
         if use_ai_val:
-            cfg.setdefault("talent_market", {})["use_ai_search"] = use_ai_val == "true"
+            tm_cfg["use_ai_search"] = use_ai_val == "true"
         write_text_utf(dst_config, yaml.dump(cfg, default_flow_style=False, allow_unicode=True))
         if sandbox_enabled:
             console.print("  [green]\u2714[/green] Sandbox tools enabled")

--- a/tests/unit/agents/test_recruitment.py
+++ b/tests/unit/agents/test_recruitment.py
@@ -330,6 +330,11 @@ class TestSearchCandidates:
     async def test_returns_candidates_from_talent_market(self, monkeypatch):
         from onemancompany.agents import recruitment
 
+        monkeypatch.setattr(
+            recruitment, "load_app_config",
+            lambda: {"talent_market": {"mode": "remote"}},
+        )
+
         fake_result = {
             "type": "individual",
             "summary": "Test",
@@ -423,6 +428,11 @@ class TestSessionIdTracking:
     async def test_session_id_stashed_from_search(self, monkeypatch):
         """search_candidates stashes session_id from API response."""
         from onemancompany.agents import recruitment
+
+        monkeypatch.setattr(
+            recruitment, "load_app_config",
+            lambda: {"talent_market": {"mode": "remote"}},
+        )
 
         fake_result = {
             "type": "individual",


### PR DESCRIPTION
## Summary
- Add `mode` setting (`local`/`remote`) to Talent Market config
- Onboarding: default `remote` if API key provided, `local` otherwise
- Settings UI: Local/Remote toggle buttons
- `search_candidates`: error detection + fallback chain:
  1. AI search fails (e.g. no credits) → retry without AI
  2. Non-AI search fails → fallback to local talent pool
  3. Warning message passed to HR agent for CEO notification

## Test plan
- [x] Full suite: 2353 passed
- [ ] Manual: toggle local/remote in settings
- [ ] Manual: simulate insufficient credits → verify fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)