### PR TITLE
fix: replace broken web_search with DuckDuckGo

### DIFF
--- a/company/assets/tools/web_search/tool.yaml
+++ b/company/assets/tools/web_search/tool.yaml
@@ -1,12 +1,12 @@
 id: web_search
 name: Web Search
 description: >
-  Search the web for real-time information using Claude's built-in web search.
+  Search the web for real-time information using DuckDuckGo.
   USE THIS whenever a task requires current information, market research, competitor
   analysis, technical documentation lookup, news, pricing data, or any knowledge
   that may be newer than your training data. Call web_search(query) or
   web_search(query, max_results=10) for more results.
-  Automatically uses the ANTHROPIC_API_KEY from your company .env file.
+  No API key required.
 added_by: CEO
 type: langchain_module
 sprite: desk_equipment

--- a/company/assets/tools/web_search/web_search.py
+++ b/company/assets/tools/web_search/web_search.py
@@ -1,179 +1,16 @@
-"""Web search tool via Anthropic Claude API with built-in web search.
+"""Web search tool via DuckDuckGo.
 
 Provides one LangChain @tool:
 - web_search(query, max_results=5)
+
+No API key required. Uses duckduckgo-search package.
 """
 
 from __future__ import annotations
 
-import json
-import os
-import urllib.error
-import urllib.request
-
+from ddgs import DDGS
 from langchain_core.tools import tool
 from loguru import logger
-
-
-
-
-_ENV_KEY_NAME = "ANTHROPIC_API_KEY"
-_API_URL = "https://api.anthropic.com/v1/messages"
-_MODEL = "claude-sonnet-4-20250514"
-_API_VERSION = "2025-01-01"
-_USER_AGENT = "OneManCompany-WebSearch/1.0"
-_TOOL_TYPE = "web_search_20250305"
-
-# Claude API response block types
-_BLOCK_TYPE_SEARCH_RESULT = "web_search_tool_result"
-_BLOCK_TYPE_RESULT_ITEM = "web_search_result"
-_BLOCK_TYPE_TEXT = "text"
-
-# Response field keys
-_FIELD_CONTENT = "content"
-_FIELD_TYPE = "type"
-_FIELD_TEXT = "text"
-_FIELD_TITLE = "title"
-_FIELD_URL = "url"
-_FIELD_PAGE_SNIPPET = "page_snippet"
-
-
-def _load_env_var(name: str) -> str:
-    """Load an env var, falling back to company .env file."""
-    val = os.environ.get(name, "").strip()
-    if val:
-        return val
-    try:
-        from onemancompany.core.config import DATA_ROOT, DOT_ENV_FILENAME
-        env_path = DATA_ROOT / DOT_ENV_FILENAME
-        if not env_path.exists():
-            return ""
-        for line in env_path.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if line.startswith("#") or "=" not in line:
-                continue
-            key, _, v = line.partition("=")
-            if key.strip() == name:
-                return v.strip().strip("\"'")
-    except Exception:
-        pass
-    return ""
-
-
-def _resolve_anthropic_auth() -> tuple[str, dict]:
-    """Resolve Anthropic API authentication — supports both API key and OAuth.
-
-    Returns (key_or_token, auth_headers_dict). Empty dict if no auth available.
-    For OAuth, returns the stored token WITHOUT refreshing — refresh only on 401.
-    """
-    auth_method = _load_env_var("ANTHROPIC_AUTH_METHOD")
-
-    if auth_method == "oauth":
-        access_token = _load_env_var(_ENV_KEY_NAME)
-        if access_token:
-            return access_token, {"Authorization": f"Bearer {access_token}"}
-        # No access token — try refresh as last resort
-        refresh_token = _load_env_var("ANTHROPIC_REFRESH_TOKEN")
-        if refresh_token:
-            fresh = _refresh_anthropic_token(refresh_token)
-            if fresh:
-                return fresh, {"Authorization": f"Bearer {fresh}"}
-        return "", {}
-
-    # Default: API key auth
-    api_key = _load_env_var(_ENV_KEY_NAME)
-    if not api_key:
-        return "", {}
-    return api_key, {"x-api-key": api_key}
-
-
-_ANTHROPIC_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
-_ANTHROPIC_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-
-
-def _refresh_anthropic_token(refresh_token: str) -> str:
-    """Refresh an Anthropic OAuth access token using PKCE (no client_secret).
-
-    On success, updates .env with the new access token and returns it.
-    Returns empty string on failure.
-    """
-    import urllib.parse
-
-    payload = urllib.parse.urlencode({
-        "grant_type": "refresh_token",
-        "refresh_token": refresh_token,
-        "client_id": _ANTHROPIC_CLIENT_ID,
-    }).encode("utf-8")
-
-    req = urllib.request.Request(
-        _ANTHROPIC_TOKEN_URL,
-        data=payload,
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            body = json.loads(resp.read().decode("utf-8"))
-        new_token = body.get("access_token", "")
-        new_refresh = body.get("refresh_token", "")
-        if new_token:
-            # Update .env so subsequent calls use the fresh token
-            try:
-                from onemancompany.core.config import update_env_var
-                update_env_var(_ENV_KEY_NAME, new_token)
-                if new_refresh:
-                    update_env_var("ANTHROPIC_REFRESH_TOKEN", new_refresh)
-            except Exception as exc:
-                logger.debug("[web_search] Failed to persist refreshed token: {}", exc)
-            return new_token
-    except Exception as exc:
-        logger.debug("[web_search] Anthropic token refresh failed: {}", exc)
-    return ""
-
-
-def _post_json(url: str, headers: dict, payload: dict, timeout: int = 30) -> tuple[dict | None, str | None]:
-    """POST JSON and return (json_body, error)."""
-    req = urllib.request.Request(
-        url,
-        data=json.dumps(payload).encode("utf-8"),
-        headers=headers,
-        method="POST",
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            raw = resp.read().decode("utf-8", errors="replace")
-        return json.loads(raw), None
-    except urllib.error.HTTPError as e:
-        body_text = e.read().decode("utf-8", errors="replace") if e.fp else ""
-        return None, f"HTTP {e.code}: {body_text[:800]}"
-    except json.JSONDecodeError as e:
-        return None, f"Invalid JSON response: {e}"
-    except Exception as e:
-        return None, str(e)
-
-
-def _extract_search_results(response: dict) -> list[dict]:
-    """Extract web search results from Claude API response content blocks."""
-    results = []
-    for block in response.get(_FIELD_CONTENT, []):
-        if block.get(_FIELD_TYPE) == _BLOCK_TYPE_SEARCH_RESULT:
-            for item in block.get(_FIELD_CONTENT, []):
-                if item.get(_FIELD_TYPE) == _BLOCK_TYPE_RESULT_ITEM:
-                    results.append({
-                        _FIELD_TITLE: item.get(_FIELD_TITLE, ""),
-                        _FIELD_URL: item.get(_FIELD_URL, ""),
-                        _FIELD_PAGE_SNIPPET: item.get(_FIELD_PAGE_SNIPPET, ""),
-                    })
-    return results
-
-
-def _extract_text_answer(response: dict) -> str:
-    """Extract the text summary from Claude's response."""
-    parts = []
-    for block in response.get(_FIELD_CONTENT, []):
-        if block.get(_FIELD_TYPE) == _BLOCK_TYPE_TEXT:
-            parts.append(block.get(_FIELD_TEXT, ""))
-    return "\n".join(parts).strip()
 
 
 @tool
@@ -191,64 +28,34 @@ def web_search(query: str, max_results: int = 5) -> dict:
     if not query:
         return {"status": "error", "message": "query is empty"}
 
-    api_key, auth_header = _resolve_anthropic_auth()
-    if not auth_header:
-        return {"status": "error", "message": f"{_ENV_KEY_NAME} not configured in .env"}
-
     max_results = max(1, min(int(max_results), 20))
 
-    headers = {
-        **auth_header,
-        "anthropic-version": _API_VERSION,
-        "content-type": "application/json",
-        "User-Agent": _USER_AGENT,
-    }
+    try:
+        with DDGS() as ddgs:
+            raw_results = list(ddgs.text(query, max_results=max_results))
 
-    payload = {
-        "model": _MODEL,
-        "max_tokens": 4096,
-        "tools": [
+        sources = [
             {
-                "type": _TOOL_TYPE,
-                "name": "web_search",
-                "max_uses": max_results,
+                "title": r.get("title", ""),
+                "url": r.get("href", ""),
+                "page_snippet": r.get("body", ""),
             }
-        ],
-        "messages": [
-            {
-                "role": "user",
-                "content": f"Search the web and provide a comprehensive answer: {query}",
-            }
-        ],
-    }
+            for r in raw_results
+        ]
 
-    resp_json, err = _post_json(_API_URL, headers, payload, timeout=60)
+        # Build a text answer from snippets
+        answer_parts = []
+        for i, s in enumerate(sources, 1):
+            answer_parts.append(f"{i}. **{s['title']}**\n   {s['page_snippet']}\n   Source: {s['url']}")
+        answer = "\n\n".join(answer_parts) if answer_parts else "No results found."
 
-    # On 401 (expired OAuth token), refresh once and retry
-    if err and "HTTP 401" in err and _load_env_var("ANTHROPIC_AUTH_METHOD") == "oauth":
-        refresh_token = _load_env_var("ANTHROPIC_REFRESH_TOKEN")
-        if refresh_token:
-            logger.debug("[web_search] Got 401, refreshing OAuth token")
-            fresh = _refresh_anthropic_token(refresh_token)
-            if fresh:
-                headers = {
-                    "Authorization": f"Bearer {fresh}",
-                    "anthropic-version": _API_VERSION,
-                    "content-type": "application/json",
-                    "User-Agent": _USER_AGENT,
-                }
-                resp_json, err = _post_json(_API_URL, headers, payload, timeout=60)
-
-    if err or resp_json is None:
-        return {"status": "error", "message": err or "empty response from API"}
-
-    answer = _extract_text_answer(resp_json)
-    sources = _extract_search_results(resp_json)
-
-    return {
-        "status": "ok",
-        "query": query,
-        "answer": answer,
-        "sources": sources[:max_results],
-        "source_count": len(sources),
-    }
+        return {
+            "status": "ok",
+            "query": query,
+            "answer": answer,
+            "sources": sources,
+            "source_count": len(sources),
+        }
+    except Exception as exc:
+        logger.debug("[web_search] DuckDuckGo search failed: {}", exc)
+        return {"status": "error", "message": f"Search failed: {exc}"}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.42",
+  "version": "0.4.43",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.42"
+version = "0.4.43"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [
@@ -24,6 +24,7 @@ dependencies = [
     "rich>=13.0",
     "InquirerPy>=0.3",
     "datasets>=4.8.3",
+    "ddgs>=8.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/tools/test_web_search.py
+++ b/tests/unit/tools/test_web_search.py
@@ -1,4 +1,4 @@
-"""Unit tests for web_search tool — OAuth auth resolution and 401 retry."""
+"""Unit tests for web_search tool — DuckDuckGo-based implementation."""
 
 from __future__ import annotations
 
@@ -7,197 +7,109 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 
-# All patches target the web_search module where names are looked up
 _MOD = "company.assets.tools.web_search.web_search"
 
 
-class TestResolveAnthropicAuth:
-    """_resolve_anthropic_auth should use stored token first, only refresh when needed."""
+class TestWebSearchBasic:
+    """Basic web_search behavior."""
 
-    def test_api_key_auth(self):
-        """Non-OAuth: returns x-api-key header."""
-        from company.assets.tools.web_search.web_search import _resolve_anthropic_auth
-
-        with patch(f"{_MOD}._load_env_var") as mock_env:
-            mock_env.side_effect = lambda name: {
-                "ANTHROPIC_AUTH_METHOD": "api_key",
-                "ANTHROPIC_API_KEY": "sk-test-key",
-            }.get(name, "")
-            token, headers = _resolve_anthropic_auth()
-
-        assert token == "sk-test-key"
-        assert headers == {"x-api-key": "sk-test-key"}
-
-    def test_oauth_uses_stored_token_without_refresh(self):
-        """OAuth with valid access token should NOT call _refresh_anthropic_token."""
-        from company.assets.tools.web_search.web_search import _resolve_anthropic_auth
-
-        with patch(f"{_MOD}._load_env_var") as mock_env, \
-             patch(f"{_MOD}._refresh_anthropic_token") as mock_refresh:
-            mock_env.side_effect = lambda name: {
-                "ANTHROPIC_AUTH_METHOD": "oauth",
-                "ANTHROPIC_API_KEY": "stored-access-token",
-                "ANTHROPIC_REFRESH_TOKEN": "some-refresh-token",
-            }.get(name, "")
-            token, headers = _resolve_anthropic_auth()
-
-        assert token == "stored-access-token"
-        assert headers == {"Authorization": "Bearer stored-access-token"}
-        mock_refresh.assert_not_called()
-
-    def test_oauth_no_access_token_tries_refresh(self):
-        """OAuth with no access token but refresh token should try to refresh."""
-        from company.assets.tools.web_search.web_search import _resolve_anthropic_auth
-
-        with patch(f"{_MOD}._load_env_var") as mock_env, \
-             patch(f"{_MOD}._refresh_anthropic_token", return_value="fresh-token") as mock_refresh:
-            mock_env.side_effect = lambda name: {
-                "ANTHROPIC_AUTH_METHOD": "oauth",
-                "ANTHROPIC_API_KEY": "",
-                "ANTHROPIC_REFRESH_TOKEN": "my-refresh-token",
-            }.get(name, "")
-            token, headers = _resolve_anthropic_auth()
-
-        assert token == "fresh-token"
-        assert headers == {"Authorization": "Bearer fresh-token"}
-        mock_refresh.assert_called_once_with("my-refresh-token")
-
-    def test_oauth_no_tokens_returns_empty(self):
-        """OAuth with no tokens at all returns empty."""
-        from company.assets.tools.web_search.web_search import _resolve_anthropic_auth
-
-        with patch(f"{_MOD}._load_env_var", return_value="") as mock_env:
-            # First call for auth_method returns "oauth", rest return ""
-            mock_env.side_effect = lambda name: "oauth" if name == "ANTHROPIC_AUTH_METHOD" else ""
-            token, headers = _resolve_anthropic_auth()
-
-        assert token == ""
-        assert headers == {}
-
-
-class TestWebSearch401Retry:
-    """web_search should retry once on 401 with refreshed token."""
-
-    def test_401_triggers_refresh_and_retry(self):
-        """On 401, web_search should refresh token and retry the API call."""
+    def test_empty_query_returns_error(self):
+        """Empty query should return error status."""
         from company.assets.tools.web_search.web_search import web_search
 
-        success_response = {
-            "content": [
-                {"type": "text", "text": "Search results here"},
-            ]
-        }
+        result = web_search.invoke({"query": ""})
+        assert result["status"] == "error"
+        assert "empty" in result["message"]
 
-        call_count = 0
+    def test_whitespace_query_returns_error(self):
+        """Whitespace-only query should return error status."""
+        from company.assets.tools.web_search.web_search import web_search
 
-        def mock_post_json(url, headers, payload, timeout=30):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                # First call: 401 expired token
-                return None, "HTTP 401: Unauthorized"
-            # Second call: success with fresh token
-            return success_response, None
+        result = web_search.invoke({"query": "   "})
+        assert result["status"] == "error"
 
-        with patch(f"{_MOD}._resolve_anthropic_auth", return_value=("old-token", {"Authorization": "Bearer old-token"})), \
-             patch(f"{_MOD}._post_json", side_effect=mock_post_json), \
-             patch(f"{_MOD}._load_env_var") as mock_env, \
-             patch(f"{_MOD}._refresh_anthropic_token", return_value="fresh-token") as mock_refresh:
-            mock_env.side_effect = lambda name: {
-                "ANTHROPIC_AUTH_METHOD": "oauth",
-                "ANTHROPIC_REFRESH_TOKEN": "my-refresh",
-            }.get(name, "")
+    def test_successful_search(self):
+        """Mocked DDGS.text should return structured results."""
+        from company.assets.tools.web_search.web_search import web_search
 
-            result = web_search.invoke({"query": "test query"})
+        mock_results = [
+            {"title": "Python.org", "href": "https://python.org", "body": "Welcome to Python"},
+            {"title": "Python Tutorial", "href": "https://docs.python.org", "body": "Learn Python"},
+        ]
+
+        mock_ddgs = MagicMock()
+        mock_ddgs.__enter__ = lambda s: mock_ddgs
+        mock_ddgs.__exit__ = MagicMock(return_value=False)
+        mock_ddgs.text.return_value = mock_results
+
+        with patch(f"{_MOD}.DDGS", return_value=mock_ddgs):
+            result = web_search.invoke({"query": "Python programming"})
 
         assert result["status"] == "ok"
-        assert result["answer"] == "Search results here"
-        mock_refresh.assert_called_once_with("my-refresh")
-        assert call_count == 2
+        assert result["source_count"] == 2
+        assert len(result["sources"]) == 2
+        assert result["sources"][0]["title"] == "Python.org"
+        assert result["sources"][0]["url"] == "https://python.org"
+        assert "Python.org" in result["answer"]
 
-    def test_401_no_refresh_token_returns_error(self):
-        """On 401 without refresh token, returns the original error."""
+    def test_max_results_clamped(self):
+        """max_results should be clamped between 1 and 20."""
         from company.assets.tools.web_search.web_search import web_search
 
-        with patch(f"{_MOD}._resolve_anthropic_auth", return_value=("old-token", {"Authorization": "Bearer old-token"})), \
-             patch(f"{_MOD}._post_json", return_value=(None, "HTTP 401: Unauthorized")), \
-             patch(f"{_MOD}._load_env_var") as mock_env:
-            mock_env.side_effect = lambda name: {
-                "ANTHROPIC_AUTH_METHOD": "oauth",
-                "ANTHROPIC_REFRESH_TOKEN": "",
-            }.get(name, "")
+        mock_ddgs = MagicMock()
+        mock_ddgs.__enter__ = lambda s: mock_ddgs
+        mock_ddgs.__exit__ = MagicMock(return_value=False)
+        mock_ddgs.text.return_value = []
 
-            result = web_search.invoke({"query": "test query"})
+        with patch(f"{_MOD}.DDGS", return_value=mock_ddgs):
+            web_search.invoke({"query": "test", "max_results": 50})
+            mock_ddgs.text.assert_called_with("test", max_results=20)
 
-        assert result["status"] == "error"
-        assert "401" in result["message"]
+        with patch(f"{_MOD}.DDGS", return_value=mock_ddgs):
+            web_search.invoke({"query": "test", "max_results": 0})
+            mock_ddgs.text.assert_called_with("test", max_results=1)
 
-    def test_non_401_error_no_retry(self):
-        """Non-401 errors should not trigger refresh/retry."""
+    def test_no_results_returns_ok_with_empty(self):
+        """Zero results should still return ok status with 'No results found'."""
         from company.assets.tools.web_search.web_search import web_search
 
-        with patch(f"{_MOD}._resolve_anthropic_auth", return_value=("token", {"Authorization": "Bearer token"})), \
-             patch(f"{_MOD}._post_json", return_value=(None, "HTTP 500: Internal Server Error")), \
-             patch(f"{_MOD}._refresh_anthropic_token") as mock_refresh:
+        mock_ddgs = MagicMock()
+        mock_ddgs.__enter__ = lambda s: mock_ddgs
+        mock_ddgs.__exit__ = MagicMock(return_value=False)
+        mock_ddgs.text.return_value = []
 
-            result = web_search.invoke({"query": "test query"})
+        with patch(f"{_MOD}.DDGS", return_value=mock_ddgs):
+            result = web_search.invoke({"query": "xyznonexistent12345"})
 
-        assert result["status"] == "error"
-        assert "500" in result["message"]
-        mock_refresh.assert_not_called()
+        assert result["status"] == "ok"
+        assert result["source_count"] == 0
+        assert "No results found" in result["answer"]
 
-    def test_api_key_401_no_retry(self):
-        """API key auth with 401 should not attempt OAuth refresh."""
+
+class TestWebSearchErrors:
+    """Error handling in web_search."""
+
+    def test_ddgs_exception_returns_error(self):
+        """Network/API failure should return error status."""
         from company.assets.tools.web_search.web_search import web_search
 
-        with patch(f"{_MOD}._resolve_anthropic_auth", return_value=("bad-key", {"x-api-key": "bad-key"})), \
-             patch(f"{_MOD}._post_json", return_value=(None, "HTTP 401: Invalid API key")), \
-             patch(f"{_MOD}._load_env_var") as mock_env, \
-             patch(f"{_MOD}._refresh_anthropic_token") as mock_refresh:
-            mock_env.side_effect = lambda name: {
-                "ANTHROPIC_AUTH_METHOD": "api_key",
-            }.get(name, "")
+        mock_ddgs = MagicMock()
+        mock_ddgs.__enter__ = lambda s: mock_ddgs
+        mock_ddgs.__exit__ = MagicMock(return_value=False)
+        mock_ddgs.text.side_effect = Exception("Connection timeout")
 
-            result = web_search.invoke({"query": "test query"})
+        with patch(f"{_MOD}.DDGS", return_value=mock_ddgs):
+            result = web_search.invoke({"query": "test"})
 
         assert result["status"] == "error"
-        mock_refresh.assert_not_called()
+        assert "Connection timeout" in result["message"]
 
+    def test_import_error_returns_error(self):
+        """Missing ddgs package should return helpful error."""
+        from company.assets.tools.web_search.web_search import web_search
 
-class TestRefreshTokenFormat:
-    """_refresh_anthropic_token should use form-urlencoded, not JSON."""
+        with patch(f"{_MOD}.DDGS", side_effect=ImportError("No module named 'ddgs'")):
+            # The ImportError is caught in the except block
+            result = web_search.invoke({"query": "test"})
 
-    def test_refresh_sends_form_urlencoded(self):
-        """Token refresh request must use application/x-www-form-urlencoded."""
-        from company.assets.tools.web_search.web_search import _refresh_anthropic_token
-
-        captured_req = {}
-
-        def mock_urlopen(req, timeout=None):
-            captured_req["content_type"] = req.get_header("Content-type")
-            captured_req["data"] = req.data.decode("utf-8")
-            captured_req["url"] = req.full_url
-
-            resp = MagicMock()
-            resp.read.return_value = b'{"access_token": "new-tok", "refresh_token": "new-ref"}'
-            resp.__enter__ = lambda s: resp
-            resp.__exit__ = MagicMock(return_value=False)
-            return resp
-
-        with patch("urllib.request.urlopen", side_effect=mock_urlopen), \
-             patch("onemancompany.core.config.update_env_var"):
-            result = _refresh_anthropic_token("my-refresh-token")
-
-        assert result == "new-tok"
-        assert captured_req["content_type"] == "application/x-www-form-urlencoded"
-        assert "grant_type=refresh_token" in captured_req["data"]
-        assert "refresh_token=my-refresh-token" in captured_req["data"]
-
-    def test_refresh_failure_returns_empty(self):
-        """On network error, returns empty string."""
-        from company.assets.tools.web_search.web_search import _refresh_anthropic_token
-
-        with patch("urllib.request.urlopen", side_effect=Exception("network error")):
-            result = _refresh_anthropic_token("some-token")
-
-        assert result == ""
+        assert result["status"] == "error"


### PR DESCRIPTION
## Summary

Anthropic Claude API web search tool was not working. Replaced with DuckDuckGo via the `ddgs` package.

- **Zero config** — no API key required
- Same tool interface (`web_search(query, max_results)`) — drop-in replacement
- Same return format (`status`, `query`, `answer`, `sources`, `source_count`)
- 7 unit tests covering: empty query, success, max_results clamping, no results, exceptions

## Files Changed

| File | Change |
|------|--------|
| `company/assets/tools/web_search/web_search.py` | Rewrite: Anthropic API → DuckDuckGo (ddgs) |
| `company/assets/tools/web_search/tool.yaml` | Update description |
| `pyproject.toml` | Add `ddgs>=8.0` dependency |
| `tests/unit/tools/test_web_search.py` | Rewrite tests for new implementation |

## Test plan
- [x] 2356 unit tests pass
- [x] Manual: `web_search("OneManCompany")` returns real results

🤖 Generated with [Claude Code](https://claude.com/claude-code)