### PR TITLE
fix: restore CEO console scrolling + add /clear command

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2575,6 +2575,17 @@ class AppController {
         await this._startMeetingInConsole('discussion', arg);
       }},
       { cmd: '/attach', desc: 'Attach file or image', action: () => document.getElementById('ceo-file-input')?.click() },
+      { cmd: '/clear', desc: 'Clear EA chat history', action: async () => {
+        if (this._currentCeoProject !== this._EA_CHAT) {
+          this._ceoTerm?.appendMessage({ role: 'system', text: '/clear only works in EA chat.', source: 'system' });
+          return;
+        }
+        // Forget old conversation and create a new one
+        this._eaChatConvId = null;
+        localStorage.removeItem('ea-chat-conv-id');
+        await this._ensureEaChatConversation();
+        this._ceoTerm?.showChat(this._EA_CHAT, []);
+      }},
     ];
   }
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5397,7 +5397,7 @@ body.resize-dragging {
 #ceo-conv-messages {
   flex: 1;
   min-height: 0;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 #ceo-conv-input-area {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.43",
+  "version": "0.4.44",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.43"
+version = "0.4.44"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary

Two fixes:

1. **Scroll regression** — `#ceo-conv-messages` had `overflow: hidden` (for xterm.js which handles its own scrolling). The DOM rewrite needs `overflow-y: auto`. One-line CSS fix.

2. **`/clear` command** — New slash command to reset EA chat history. Creates a new conversation (old messages preserved on disk). Only works in EA chat mode.

## Root Cause

PR #250 replaced xterm.js CeoTerminal with DOM renderer but didn't update the container's overflow CSS. The ID selector `#ceo-conv-messages { overflow: hidden }` (higher specificity) overrode the class selector `.ceo-conv-scroll { overflow-y: auto }`.

## Test plan
- [x] 2356 unit tests pass
- [ ] Manual: verify scrolling works in CEO conversation
- [ ] Manual: verify /clear resets EA chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)