### PR TITLE
fix: tool call dedup + CEO console scroll v3

### DIFF
--- a/frontend/ceo-terminal.js
+++ b/frontend/ceo-terminal.js
@@ -153,41 +153,18 @@ class CeoTerminal {
     const pending = this._pendingToolCalls.get(pendingKey);
     let card;
 
-    if (pending) {
-      card = pending.element;
-      const durationMs = Date.now() - pending.startTime;
-      const durationStr = durationMs < 1000
-        ? `${durationMs}ms`
-        : `${(durationMs / 1000).toFixed(1)}s`;
-      card.querySelector('.ceo-tool-duration').textContent = durationStr;
-      this._pendingToolCalls.delete(pendingKey);
-    } else {
-      // No pending match — render as standalone done element
-      card = document.createElement('div');
-      card.className = 'ceo-tool-call';
-      card.dataset.employee = employeeId;
-      card.dataset.toolName = toolName;
-
-      const headerEl = document.createElement('div');
-      headerEl.className = 'ceo-tool-call-header';
-      headerEl.innerHTML = `
-        <span class="ceo-tool-icon">\u2699</span>
-        <span class="ceo-tool-name">${this._esc(toolName)}</span>
-        <span class="ceo-tool-status"></span>
-        <span class="ceo-tool-duration"></span>
-      `;
-      card.appendChild(headerEl);
-
-      const details = document.createElement('div');
-      details.className = 'ceo-tool-call-details';
-      const resultDiv = document.createElement('div');
-      resultDiv.className = 'ceo-tool-result';
-      details.appendChild(resultDiv);
-      card.appendChild(details);
-
-      headerEl.addEventListener('click', () => card.classList.toggle('expanded'));
-      this._container.appendChild(card);
+    if (!pending) {
+      // No pending match — skip. The tool_call card already shows the tool name.
+      return;
     }
+
+    card = pending.element;
+    const durationMs = Date.now() - pending.startTime;
+    const durationStr = durationMs < 1000
+      ? `${durationMs}ms`
+      : `${(durationMs / 1000).toFixed(1)}s`;
+    card.querySelector('.ceo-tool-duration').textContent = durationStr;
+    this._pendingToolCalls.delete(pendingKey);
 
     // Update status
     if (error) {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5392,6 +5392,7 @@ body.resize-dragging {
   flex-direction: column;
   min-width: 0;
   min-height: 0;
+  overflow: hidden;
 }
 
 #ceo-conv-messages {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.46",
+  "version": "0.4.47",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.46"
+version = "0.4.47"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary

1. **Tool call dedup** — `updateToolCall` was creating a standalone card when pending lookup failed, causing every tool to show twice. Fix: skip instead of creating duplicate. The tool_call card already shows the tool name.

2. **Scroll** — `#ceo-conv-panel` needed `overflow: hidden` to constrain its flex children. Without it, `#ceo-conv-messages` grew unbounded instead of scrolling.

## Test plan
- [x] 2356 unit tests pass
- [ ] Manual: verify no duplicate tool cards
- [ ] Manual: verify scrolling works

🤖 Generated with [Claude Code](https://claude.com/claude-code)