### PR TITLE
fix: sync api_provider to founding employees during onboarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.47",
+  "version": "0.4.48",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.47"
+version = "0.4.48"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -700,7 +700,7 @@ def _step_execute(
         if tm_key:
             console.print("  [green]\u2714[/green] Talent Market API key saved")
 
-    # 4. Sync founding employees' llm_model to user-selected default
+    # 4. Sync founding employees' llm_model and api_provider to user-selected defaults
     import yaml as _yaml
     from onemancompany.core.config import FOUNDING_IDS, EMPLOYEES_DIR
     _synced = 0
@@ -708,12 +708,18 @@ def _step_execute(
         _profile = EMPLOYEES_DIR / _fid / "profile.yaml"
         if _profile.exists():
             _pdata = _yaml.safe_load(read_text_utf(_profile)) or {}
+            _changed = False
             if _pdata.get("llm_model") != model:
                 _pdata["llm_model"] = model
+                _changed = True
+            if _pdata.get("api_provider") != provider:
+                _pdata["api_provider"] = provider
+                _changed = True
+            if _changed:
                 write_text_utf(_profile, _yaml.dump(_pdata, default_flow_style=False, allow_unicode=True))
                 _synced += 1
     if _synced:
-        console.print(f"  [green]\u2714[/green] Founding employees model set to {model}")
+        console.print(f"  [green]\u2714[/green] Founding employees set to {provider}/{model}")
 
     # 5. Assign random default avatars to founding employees
     _assign_default_avatars(console)


### PR DESCRIPTION
## Summary

When onboarding selects a provider (e.g. openai), only `llm_model` was synced to founding employee profiles. `api_provider` stayed as the template default (openrouter). This caused 401 errors when founding employees tried to call LLMs.

**Root cause:** `onboard.py` line 703-716 synced model but not provider.

**Fix:** Also sync `api_provider` to founding profiles during onboarding genesis step.

## Test plan
- [x] 2356 unit tests pass
- [ ] Manual: fresh onboarding with openai → founding employees use openai provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)