### PR TITLE
fix: AuthMethod enum stringification writes wrong value to .env

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.49",
+  "version": "0.4.50",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.49"
+version = "0.4.50"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -660,9 +660,13 @@ def _step_execute(
     # Also write base_url for OpenRouter (needed by existing code)
     if provider == PROVIDER_OPENROUTER:
         env_lines.append("OPENROUTER_BASE_URL=https://openrouter.ai/api/v1")
+    # Write auth method when Anthropic is the primary or extra provider
+    if provider == PROVIDER_ANTHROPIC:
+        env_lines.append(f"{ENV_KEY_ANTHROPIC_AUTH}={AuthMethod.API_KEY.value}")
     if ENV_KEY_ANTHROPIC in extras:
         env_lines.append(f"{ENV_KEY_ANTHROPIC}={extras[ENV_KEY_ANTHROPIC]}")
-        env_lines.append(f"{ENV_KEY_ANTHROPIC_AUTH}={AuthMethod.API_KEY}")
+        if provider != PROVIDER_ANTHROPIC:  # Don't duplicate if already written above
+            env_lines.append(f"{ENV_KEY_ANTHROPIC_AUTH}={AuthMethod.API_KEY.value}")
     if ENV_KEY_SKILLSMP in extras:
         env_lines.append(f"{ENV_KEY_SKILLSMP}={extras[ENV_KEY_SKILLSMP]}")
 


### PR DESCRIPTION
## Summary

Python 3.11+ changed \`str(StrEnum)\` to return \`ClassName.MEMBER\` instead of the value. \`f"{AuthMethod.API_KEY}"\` wrote \`AuthMethod.API_KEY\` to .env instead of \`api_key\`.

**Fix:** Use \`.value\` explicitly.

Also: write \`ANTHROPIC_AUTH_METHOD\` when Anthropic is the primary provider (previously only written for the extras/secondary key case).

## Test plan
- [x] 2356 unit tests pass
- [ ] Manual: onboarding with Anthropic → check .env has \`ANTHROPIC_AUTH_METHOD=api_key\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)