### PR TITLE
fix: separate OAuth token from API key to prevent overwrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.50",
+  "version": "0.4.51",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.50"
+version = "0.4.51"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -173,16 +173,21 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
 
     # --- Anthropic (non-OpenAI-compatible) ---
     if prov and prov.chat_class == CHAT_CLASS_ANTHROPIC:
-        effective_key = _resolve_provider_key(api_provider, api_key)
+        from langchain_anthropic import ChatAnthropic
+
+        auth_method = ""
+        if employee_id and employee_id in employee_configs:
+            auth_method = employee_configs[employee_id].auth_method
+        if not auth_method:
+            auth_method = settings.anthropic_auth_method
+
+        # Use OAuth token if auth_method is oauth, otherwise use API key
+        if auth_method == AuthMethod.OAUTH:
+            effective_key = api_key or settings.anthropic_oauth_token or settings.anthropic_api_key
+        else:
+            effective_key = _resolve_provider_key(api_provider, api_key)
+
         if effective_key:
-            from langchain_anthropic import ChatAnthropic
-
-            auth_method = ""
-            if employee_id and employee_id in employee_configs:
-                auth_method = employee_configs[employee_id].auth_method
-            if not auth_method:
-                auth_method = settings.anthropic_auth_method
-
             extra_headers = {}
             if auth_method == AuthMethod.OAUTH or effective_key.startswith("sk-ant-oat"):
                 extra_headers["anthropic-beta"] = "oauth-2025-04-20"

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -2030,6 +2030,7 @@ async def get_api_settings() -> dict:
         "anthropic": {
             "api_key_set": bool(ant_key),
             "api_key_preview": ("..." + ant_key[-4:]) if len(ant_key) >= 4 else "",
+            "oauth_token_set": bool(settings.anthropic_oauth_token),
             "auth_method": settings.anthropic_auth_method,
         },
         "talent_market": {
@@ -2223,9 +2224,9 @@ async def company_oauth_exchange(body: dict) -> dict:
     if not access_token:
         return {"error": "No access_token in response"}
 
-    # Save to .env (company level)
+    # Save to .env (company level) — OAuth token stored separately from API key
     from onemancompany.core.config import update_env_var
-    update_env_var("ANTHROPIC_API_KEY", access_token)
+    update_env_var("ANTHROPIC_OAUTH_TOKEN", access_token)
     update_env_var("ANTHROPIC_AUTH_METHOD", "oauth")
     if refresh_token:
         update_env_var("ANTHROPIC_REFRESH_TOKEN", refresh_token)
@@ -2434,7 +2435,7 @@ async def oauth_callback(code: str = "", state: str = "", error: str = ""):
     # Company-level OAuth: save to .env instead of employee profile
     if employee_id == "__company__":
         from onemancompany.core.config import update_env_var
-        update_env_var("ANTHROPIC_API_KEY", api_key)
+        update_env_var("ANTHROPIC_OAUTH_TOKEN", api_key)
         update_env_var("ANTHROPIC_AUTH_METHOD", "oauth")
         if refresh_token:
             update_env_var("ANTHROPIC_REFRESH_TOKEN", refresh_token)

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -522,6 +522,7 @@ class Settings(BaseSettings):
     openrouter_base_url: str = "https://openrouter.ai/api/v1"
     openai_api_key: str = ""
     anthropic_api_key: str = ""
+    anthropic_oauth_token: str = ""  # OAuth access token (separate from API key to avoid overwriting)
     anthropic_auth_method: str = "api_key"  # "api_key" | "oauth"
     anthropic_refresh_token: str = ""
     kimi_api_key: str = ""

--- a/src/onemancompany/core/heartbeat.py
+++ b/src/onemancompany/core/heartbeat.py
@@ -243,7 +243,8 @@ async def run_heartbeat_cycle() -> list[str]:
             if provider == PROVIDER_ANTHROPIC:
                 auth_method = cfg.auth_method if cfg.auth_method == AuthMethod.OAUTH else settings.anthropic_auth_method
                 if auth_method == AuthMethod.OAUTH:
-                    _update_online(emp_id, bool(key), changed)
+                    oauth_key = cfg.api_key or settings.anthropic_oauth_token
+                    _update_online(emp_id, bool(oauth_key), changed)
                     continue
 
             # Employee has own key → per-employee check


### PR DESCRIPTION
## Summary

OAuth login was overwriting ANTHROPIC_API_KEY with the OAuth access token. When the token expired, the original API key was gone, causing 401 errors.

### Root Cause
Both API key and OAuth token stored in the same env var \`ANTHROPIC_API_KEY\`. OAuth flow replaced the permanent API key with a short-lived token.

### Fix
- New env var \`ANTHROPIC_OAUTH_TOKEN\` stores OAuth access tokens separately
- \`ANTHROPIC_API_KEY\` is never overwritten by OAuth flow
- \`make_llm\` checks \`auth_method\`: oauth → use oauth_token, api_key → use api_key
- Heartbeat OAuth check reads from \`anthropic_oauth_token\`
- Settings status shows both \`api_key_set\` and \`oauth_token_set\`

## Files Changed
| File | Change |
|------|--------|
| \`config.py\` | Add \`anthropic_oauth_token\` field to Settings |
| \`base.py\` | \`make_llm\` selects key source by auth_method |
| \`routes.py\` | OAuth exchange writes to OAUTH_TOKEN, not API_KEY |
| \`heartbeat.py\` | OAuth health check reads from oauth_token |

## Test plan
- [x] 2356 unit tests pass
- [ ] Manual: set API key via onboarding → OAuth login → verify API key preserved
- [ ] Manual: switch back to api_key auth → verify original key still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)