### PR TITLE
feat: custom provider base URL in onboarding and settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.51",
+  "version": "0.4.52",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.51"
+version = "0.4.52"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -205,9 +205,11 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
         effective_key = _resolve_provider_key(api_provider, api_key)
         if effective_key:
             base_url = prov.base_url
-            # OpenRouter allows custom base_url override from settings
+            # Allow custom base_url override: provider-specific or global
             if api_provider == "openrouter":
                 base_url = settings.openrouter_base_url
+            elif settings.default_api_base_url and api_provider == settings.default_api_provider:
+                base_url = settings.default_api_base_url
             return ChatOpenAI(
                 model=model,
                 api_key=effective_key,

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -2101,8 +2101,11 @@ async def update_api_settings(body: dict) -> dict:
         # Write to the provider's env key (e.g. OPENAI_API_KEY, OPENROUTER_API_KEY)
         update_env_var(prov_cfg.env_key.upper(), api_key)
     base_url = body.get("base_url", "")
-    if base_url and provider == "openrouter":
-        update_env_var("OPENROUTER_BASE_URL", base_url)
+    if base_url:
+        if provider == "openrouter":
+            update_env_var("OPENROUTER_BASE_URL", base_url)
+        else:
+            update_env_var("DEFAULT_API_BASE_URL", base_url)
     default_model = body.get("default_model", "")
     if default_model:
         update_env_var("DEFAULT_LLM_MODEL", default_model)

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -536,6 +536,7 @@ class Settings(BaseSettings):
 
     # Default provider & model
     default_api_provider: str = "openrouter"
+    default_api_base_url: str = ""  # Custom base URL override for the default provider
     default_llm_model: str = "google/gemini-3.1-flash-lite-preview"
 
     # FastSkills MCP

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -267,7 +267,7 @@ def _select_model_interactive(console: Console, all_models: list[dict]) -> str:
     return model
 
 
-def _step_llm(console: Console) -> tuple[str, str, str]:
+def _step_llm(console: Console) -> tuple[str, str, str, str]:
     """Select provider, enter API key, choose model. Returns (provider, api_key, model)."""
     from onemancompany.core.auth_choices import AUTH_CHOICE_GROUPS
     from onemancompany.core.config import PROVIDER_REGISTRY
@@ -315,7 +315,23 @@ def _step_llm(console: Console) -> tuple[str, str, str]:
             break
         console.print("  [red]API key is required — your employees can't think without it.[/red]")
 
-    # 3. Select model
+    # 3. Optional custom base URL (for non-OpenRouter providers)
+    base_url = ""
+    if provider != PROVIDER_OPENROUTER:
+        console.print(
+            f"  [dim]Custom API base URL (press Enter to keep default).[/dim]\n"
+            f"  [dim]Examples: https://api.openai.com/v1, https://your-server.com/v1[/dim]"
+        )
+        from onemancompany.core.config import PROVIDER_REGISTRY
+        default_url = PROVIDER_REGISTRY.get(provider, None)
+        default_url = default_url.base_url if default_url else ""
+        base_url = _inq.text(
+            message="Base URL:",
+            default=default_url,
+            style=INQ_STYLE,
+        ).execute().strip()
+
+    # 4. Select model
     console.print()
     if provider == PROVIDER_OPENROUTER:
         all_models = _fetch_openrouter_models(console)
@@ -331,7 +347,7 @@ def _step_llm(console: Console) -> tuple[str, str, str]:
             style=INQ_STYLE,
         ).execute().strip()
 
-    return provider, api_key.strip(), model
+    return provider, api_key.strip(), model, base_url
 
 
 def _step_server(console: Console) -> tuple[str, int]:
@@ -608,6 +624,7 @@ def _step_execute(
     extras: dict[str, str],
     sandbox_enabled: bool = False,
     founder_families: dict[str, str] | None = None,
+    base_url: str = "",
 ) -> None:
     console.print()
     _print_step(console, 6, "GENESIS", "Company Initialization")
@@ -657,6 +674,9 @@ def _step_execute(
         f"{ENV_KEY_HOST}={host}",
         f"{ENV_KEY_PORT}={port}",
     ]
+    # Custom base URL (for non-default provider endpoints)
+    if base_url and prov_cfg and base_url != prov_cfg.base_url:
+        env_lines.append(f"DEFAULT_API_BASE_URL={base_url}")
     # Also write base_url for OpenRouter (needed by existing code)
     if provider == PROVIDER_OPENROUTER:
         env_lines.append("OPENROUTER_BASE_URL=https://openrouter.ai/api/v1")
@@ -932,12 +952,13 @@ def run_wizard() -> None:
             return
 
     founder_families = _step_agent_family(console)      # Step 1: Agent Family
-    provider, api_key, model = _step_llm(console)       # Step 2: LLM Provider & Key
+    provider, api_key, model, base_url = _step_llm(console)  # Step 2: LLM Provider & Key
     extras = _step_optional(console)                     # Step 3: External Integrations
     sandbox_enabled = _step_sandbox(console)             # Step 4: Sandbox
     host, port = _step_server(console)                   # Step 5: Server
     _step_execute(console, provider, api_key, model, host, port, extras,
-                  sandbox_enabled=sandbox_enabled, founder_families=founder_families)
+                  sandbox_enabled=sandbox_enabled, founder_families=founder_families,
+                  base_url=base_url)
     _step_done(console, host, port)
 
 


### PR DESCRIPTION
## Summary

Non-OpenRouter providers now prompt for optional custom base URL during onboarding. This enables self-hosted or custom API endpoints (e.g. Azure OpenAI, local LLM servers).

### Changes
- **Onboarding**: Step 2 now asks for base URL after API key (default: provider's registered URL)
- **Settings**: base_url saved as \`DEFAULT_API_BASE_URL\` for non-OpenRouter providers
- **make_llm**: uses custom base URL when set and provider matches default
- **config.py**: new \`default_api_base_url\` field in Settings

## Test plan
- [x] 2356 unit tests pass
- [ ] Manual: onboarding with custom provider URL
- [ ] Manual: Settings → change base URL → verify LLM uses it

🤖 Generated with [Claude Code](https://claude.com/claude-code)