### PR TITLE
fix: friendly LLM error messages in CEO console

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.52",
+  "version": "0.4.53",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.52"
+version = "0.4.53"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -6625,6 +6625,22 @@ async def list_conversations(type: str | None = None, phase: str | None = None) 
     return {"conversations": [c.to_dict() for c in convs]}
 
 
+def _format_llm_error(exc: Exception) -> str:
+    """Convert LLM API exceptions into friendly CEO-facing error messages."""
+    msg = str(exc).lower()
+    if "insufficient balance" in msg or "exceeded_current_quota" in msg or "quota" in msg:
+        return "LLM API quota exceeded or insufficient balance. Please check your billing at your provider's dashboard."
+    if "401" in msg or "authentication" in msg or "invalid" in msg and "key" in msg:
+        return "LLM API authentication failed. Please check your API key in Settings."
+    if "429" in msg or "rate_limit" in msg or "rate limit" in msg:
+        return "LLM API rate limit reached. Please wait a moment and try again."
+    if "timeout" in msg or "timed out" in msg:
+        return "LLM API request timed out. The model may be overloaded, please try again."
+    if "connection" in msg or "network" in msg:
+        return "Could not connect to LLM API. Please check your network and API settings."
+    return f"Agent error: {type(exc).__name__}: {str(exc)[:200]}"
+
+
 async def _dispatch_conversation_to_adapter(conv_id: str, ceo_message: Message) -> None:
     """Background task: dispatch CEO message to adapter, persist reply."""
     try:
@@ -6666,12 +6682,14 @@ async def _dispatch_conversation_to_adapter(conv_id: str, ceo_message: Message) 
             text=reply_text,
             attachments=attachment_urls,
         )
-    except Exception:
+    except Exception as exc:
         logger.exception("[conversation] adapter dispatch failed for {}", conv_id)
+        # Surface a friendly error message to the CEO console
+        error_text = _format_llm_error(exc)
         try:
             await _conversation_service.send_message(
                 conv_id, sender=SYSTEM_SENDER, role="System",
-                text="Agent is not responding. Please try again.",
+                text=error_text,
             )
         except Exception:
             logger.exception("[conversation] failed to send error message for {}", conv_id)


### PR DESCRIPTION
## Summary

LLM API errors (quota exceeded, 401, rate limit, timeout) now show specific friendly messages in the CEO console instead of generic "Agent is not responding."

### Error messages
- **Quota/balance**: "LLM API quota exceeded or insufficient balance..."
- **Auth failed**: "LLM API authentication failed. Please check your API key..."
- **Rate limit**: "LLM API rate limit reached. Please wait..."
- **Timeout**: "LLM API request timed out..."
- **Connection**: "Could not connect to LLM API..."
- **Other**: Shows exception type and first 200 chars

## Test plan
- [x] 2356 unit tests pass
- [ ] Manual: trigger 429/401 error → verify friendly message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)