### PR TITLE
feat: UI scale control with default 1.15x for readability

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1126,6 +1126,25 @@ class AppController {
       });
     });
 
+    // UI Scale buttons
+    document.querySelectorAll('.ui-scale-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const scale = btn.dataset.scale;
+        document.documentElement.style.setProperty('--ui-zoom', scale);
+        localStorage.setItem('ui-scale', scale);
+        document.querySelectorAll('.ui-scale-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+      });
+    });
+    // Restore saved scale
+    const savedScale = localStorage.getItem('ui-scale');
+    if (savedScale) {
+      document.documentElement.style.setProperty('--ui-zoom', savedScale);
+      document.querySelectorAll('.ui-scale-btn').forEach(b => {
+        b.classList.toggle('active', b.dataset.scale === savedScale);
+      });
+    }
+
     // Listen for OAuth popup completion (company-level)
     window.addEventListener('message', (e) => {
       if (e.data === 'oauth_done' && this._settingsLoaded) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -139,6 +139,20 @@
       <div id="settings-crons-body" class="settings-section-body collapsed">
         <div id="system-crons-content"></div>
       </div>
+      <div class="settings-section-header" data-target="settings-display-body">
+        <span class="settings-collapse-arrow">&#9654;</span>
+        <span class="settings-section-title">&#128065; Display</span>
+      </div>
+      <div id="settings-display-body" class="settings-section-body collapsed">
+        <div style="padding: 8px;">
+          <label style="color: #aaa; font-size: 10px; display: block; margin-bottom: 6px;">UI Scale</label>
+          <div style="display: flex; gap: 6px;">
+            <button class="ui-scale-btn" data-scale="0.9" title="Small">A-</button>
+            <button class="ui-scale-btn" data-scale="1.0" title="Medium">A</button>
+            <button class="ui-scale-btn active" data-scale="1.15" title="Large (default)">A+</button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -15,6 +15,7 @@
   --pixel-white: #e0e0f0;
   --pixel-gray: #888899;
   --text-dim: #6666aa;
+  --ui-zoom: 1.15;  /* UI scale: 0.9 (small), 1.0 (medium), 1.15 (large, default) */
 }
 
 * {
@@ -40,9 +41,12 @@ body {
   grid-template-areas:
     "left-top    canvas   roster"
     "left-bottom console  console";
-  height: 100vh;
+  height: calc(100vh / var(--ui-zoom));
+  width: calc(100vw / var(--ui-zoom));
   gap: 4px;
   padding: 4px;
+  zoom: var(--ui-zoom);
+  transform-origin: top left;
 }
 
 /* During resize drag: prevent canvas/iframes from stealing pointer events */
@@ -3021,6 +3025,22 @@ body.resize-dragging {
 }
 .settings-section-body.collapsed {
   display: none;
+}
+
+.ui-scale-btn {
+  background: var(--bg-dark);
+  border: 1px solid var(--border);
+  color: var(--pixel-white);
+  padding: 4px 12px;
+  cursor: pointer;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 10px;
+}
+.ui-scale-btn:hover { border-color: var(--pixel-cyan); }
+.ui-scale-btn.active {
+  background: var(--pixel-cyan);
+  color: #000;
+  border-color: var(--pixel-cyan);
 }
 
 .api-provider-card {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.53",
+  "version": "0.4.54",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.53"
+version = "0.4.54"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary

Addresses user feedback about text being too small. Default UI zoom increased from 1.0 to 1.15x.

### Changes
- **CSS zoom on #app** — uses CSS \`zoom\` property with \`--ui-zoom\` variable
- **Settings > Display** — three scale options: Small (0.9x), Medium (1.0x), Large (1.15x, default)
- **Persisted** — saved to localStorage, restored on reload
- **Non-invasive** — doesn't modify any of the 310 font-size declarations

### How it works
CSS \`zoom\` scales everything proportionally (text, padding, layout) at the container level. The canvas pixel art is unaffected since it has its own rendering.

## Test plan
- [x] 2356 unit tests pass
- [ ] Manual: verify default 1.15x scale looks good
- [ ] Manual: click A-/A/A+ buttons → verify scale changes
- [ ] Manual: refresh page → verify scale persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)