### PR TITLE
fix: COO infinite loop from stale cancelled children

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.55",
+  "version": "0.4.56",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.55"
+version = "0.4.56"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2414,14 +2414,12 @@ class EmployeeManager:
                     c for c in non_review_children
                     if c.status == TaskPhase.FAILED.value
                 )
-                # Check for cancelled children when parent is HOLDING — resume parent
+                # Check if the CURRENT completing node was cancelled — resume parent
                 # so it can reassess (e.g. cancelled CEO_REQUEST should unblock parent).
-                # Check ALL children (including system nodes like CEO_REQUEST) because
-                # a cancelled system node should also unblock the parent.
-                has_cancelled_child = any(
-                    c for c in children
-                    if c.status == TaskPhase.CANCELLED.value
-                )
+                # Only trigger on the node that just completed, NOT on stale cancelled
+                # siblings — otherwise WATCHDOG_NUDGE completions re-trigger the cancelled
+                # branch in an infinite loop.
+                has_cancelled_child = node.status == TaskPhase.CANCELLED.value
                 if has_failed_child and parent_node.status in (TaskPhase.HOLDING.value, TaskPhase.PROCESSING.value):
                     failed_children = [
                         c for c in non_review_children


### PR DESCRIPTION
## Summary

COO entered infinite loop: child task cancelled → parent re-dispatches WATCHDOG_NUDGE → nudge completes → \`_on_child_complete\` sees stale cancelled siblings → re-dispatches again → forever.

### Root Cause

\`has_cancelled_child\` checked \`any(children is CANCELLED)\` which matched OLD cancelled siblings, not the current completing node. Every WATCHDOG_NUDGE completion re-triggered the cancelled branch.

### Fix

Changed from \`any(c for c in children if c.status == CANCELLED)\` to \`node.status == CANCELLED\` — only the node that just completed should trigger the cancelled-child re-dispatch path.

## Test plan
- [x] 2356 unit tests pass
- [ ] Manual: cancel a child task → verify parent re-dispatches once, not infinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)