### PR TITLE
fix: zip download crashes on Chinese project names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.56",
+  "version": "0.4.57",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.56"
+version = "0.4.57"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -3684,10 +3684,13 @@ async def download_project_files(project_id: str):
     buf.seek(0)
 
     slug = project_id.split("/")[0]
+    from urllib.parse import quote as _quote_url
+    _safe = slug.encode("ascii", "ignore").decode() or "project"
+    _enc = _quote_url(f"{slug}-files.zip", safe="")
     return StreamingResponse(
         buf,
         media_type="application/zip",
-        headers={"Content-Disposition": f'attachment; filename="{slug}-files.zip"'},
+        headers={"Content-Disposition": f'attachment; filename="{_safe}-files.zip"; filename*=UTF-8\'\'{_enc}'},
     )
 
 
@@ -3773,10 +3776,13 @@ async def download_employee_workspace(employee_id: str):
 
     _dl_emp = _load_emp(employee_id)
     name = _dl_emp.get("nickname", employee_id) if _dl_emp else employee_id
+    from urllib.parse import quote as _quote_url
+    _safe = name.encode("ascii", "ignore").decode() or employee_id
+    _enc = _quote_url(f"{name}_workspace.zip", safe="")
     return StreamingResponse(
         buf,
         media_type="application/zip",
-        headers={"Content-Disposition": f'attachment; filename="{name}_workspace.zip"'},
+        headers={"Content-Disposition": f'attachment; filename="{_safe}_workspace.zip"; filename*=UTF-8\'\'{_enc}'},
     )
 
 
@@ -3814,10 +3820,14 @@ async def download_project_workspace(project_id: str):
                 zf.write(fpath, fpath.relative_to(pdir))
     buf.seek(0)
 
+    # RFC 5987: use filename* for non-ASCII project names, fallback ASCII filename for old clients
+    from urllib.parse import quote
+    safe_name = project_id.encode("ascii", "ignore").decode() or "workspace"
+    encoded_name = quote(f"{project_id}_workspace.zip", safe="")
     return StreamingResponse(
         buf,
         media_type="application/zip",
-        headers={"Content-Disposition": f'attachment; filename="{project_id}_workspace.zip"'},
+        headers={"Content-Disposition": f'attachment; filename="{safe_name}_workspace.zip"; filename*=UTF-8\'\'{encoded_name}'},
     )
 
 


### PR DESCRIPTION
## Summary

Downloading project workspace zip crashed with \`UnicodeEncodeError: 'latin-1' codec can't encode characters\` when project name contains Chinese characters.

**Root cause:** HTTP headers only support latin-1 encoding. \`Content-Disposition: filename="{中文名}_workspace.zip"\` fails.

**Fix:** Use RFC 5987 \`filename*=UTF-8''...\` encoding with ASCII fallback for older clients.

## Test plan
- [x] 2356 unit tests pass
- [ ] Manual: download zip from a project with Chinese name

🤖 Generated with [Claude Code](https://claude.com/claude-code)