### PR TITLE
debug: diagnose missing candidate IDs in shortlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.57",
+  "version": "0.4.58",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.57"
+version = "0.4.58"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/recruitment.py
+++ b/src/onemancompany/agents/recruitment.py
@@ -521,6 +521,11 @@ async def search_candidates(job_description: str) -> dict:
                     else:
                         market_warning = f"AI search unavailable ({err_msg}). Showing standard search results."
                         from_market = True
+                        # Debug: log the actual data structure returned by non-AI search
+                        for _rg in grouped.get("roles", []):
+                            for _ci, _cc in enumerate(_rg.get("candidates", [])[:2]):
+                                logger.debug("[recruitment] non-AI candidate sample #{}: keys={}, id={}, talent_id={}, name={}",
+                                             _ci, list(_cc.keys())[:8], _cc.get("id", ""), _cc.get("talent_id", ""), _cc.get("name", ""))
                 else:
                     market_warning = f"Cloud search failed ({err_msg}). Using local talent pool instead."
                     grouped = _local_fallback_search(job_description)
@@ -564,8 +569,12 @@ async def search_candidates(job_description: str) -> dict:
             cid = _extract_candidate_id(c)
             if cid:
                 _last_search_results[cid] = c
+            else:
+                logger.warning("[recruitment] Candidate has no extractable ID, keys={}, skipping from shortlist cache", list(c.keys())[:10])
             normalized.append(c)
         role_group["candidates"] = normalized
+    logger.debug("[recruitment] Normalized {} candidates into _last_search_results (from {} roles)",
+                 len(_last_search_results), len(grouped.get("roles", [])))
     _persist_candidates()  # persist search cache to survive restarts
 
     # Talent Market results are pre-screened — auto-submit all as shortlist,


### PR DESCRIPTION
## Summary

Shortlist not triggering after Talent Market search. Candidates from non-AI fallback search may have a different data format where \`_extract_candidate_id\` returns empty.

This PR adds debug logging to capture:
- Actual candidate data keys from non-AI search response
- Which candidates have no extractable ID
- Total count after normalization

**This is diagnostic only.** Once we see the actual data, we'll fix the ID extraction.

## Test plan
- [x] 2356 unit tests pass
- [ ] Manual: trigger a search in omc-test-2, check logs for candidate data format

🤖 Generated with [Claude Code](https://claude.com/claude-code)