### PR TITLE
fix: surface Talent Market balance/search failures to user

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.58",
+  "version": "0.4.59",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.58"
+version = "0.4.59"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/recruitment.py
+++ b/src/onemancompany/agents/recruitment.py
@@ -519,14 +519,14 @@ async def search_candidates(job_description: str) -> dict:
                         logger.warning("[recruitment] Non-AI search also failed: {}, falling back to local", err_msg2)
                         market_warning = f"Cloud search failed ({err_msg}). Using local talent pool instead."
                         grouped = _local_fallback_search(job_description)
+                    elif not grouped.get("roles"):
+                        # Non-AI search returned no roles — treat as empty result, fall back to local
+                        logger.warning("[recruitment] Non-AI search returned no roles (keys={}), falling back to local", list(grouped.keys())[:10])
+                        market_warning = f"AI search unavailable ({err_msg}). Standard search returned no results. Using local talent pool."
+                        grouped = _local_fallback_search(job_description)
                     else:
                         market_warning = f"AI search unavailable ({err_msg}). Showing standard search results."
                         from_market = True
-                        # Debug: log the actual data structure returned by non-AI search
-                        for _rg in grouped.get("roles", []):
-                            for _ci, _cc in enumerate(_rg.get("candidates", [])[:2]):
-                                logger.debug("[recruitment] non-AI candidate sample #{}: keys={}, id={}, talent_id={}, name={}",
-                                             _ci, list(_cc.keys())[:8], _cc.get("id", ""), _cc.get("talent_id", ""), _cc.get("name", ""))
                 else:
                     market_warning = f"Cloud search failed ({err_msg}). Using local talent pool instead."
                     grouped = _local_fallback_search(job_description)


### PR DESCRIPTION
## Summary

When Talent Market AI search fails (insufficient balance) and non-AI fallback returns no roles, the system now falls back to local talent pool with a clear warning instead of silently returning empty results.

**Before:** AI search fails → non-AI returns empty → HR proceeds with 0 candidates → silent completion
**After:** AI search fails → non-AI returns empty → falls back to local pool with warning message

Also suspects Talent Market API format change after AI search upgrade — non-AI search may return different response structure (no \`roles\` key). Debug logs added to diagnose.

## Test plan
- [x] 2356 unit tests pass
- [ ] Manual: trigger search with 0 balance → verify warning surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)