### PR TITLE
fix: handle Talent Market API format change (results → roles)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.59",
+  "version": "0.4.60",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.59"
+version = "0.4.60"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/recruitment.py
+++ b/src/onemancompany/agents/recruitment.py
@@ -470,6 +470,27 @@ def _local_fallback_search(job_description: str) -> dict:
     }
 
 
+def _normalize_api_response(resp: dict) -> dict:
+    """Normalize Talent Market API response to expected format.
+
+    The API may return {results: [...]} instead of {roles: [...]}.
+    Convert to {roles: [{role: "...", candidates: [...]}]} format.
+    """
+    if resp.get("roles"):
+        return resp  # Already in expected format
+    results = resp.get("results")
+    if isinstance(results, list) and results:
+        # "results" is a flat list of candidates or a list of role groups
+        if results and isinstance(results[0], dict) and "candidates" in results[0]:
+            # Already role-grouped: [{role: ..., candidates: [...]}, ...]
+            resp["roles"] = results
+        else:
+            # Flat candidate list — wrap in a single role group
+            resp["roles"] = [{"role": "General", "candidates": results}]
+        logger.debug("[recruitment] Normalized API response: 'results' → 'roles' ({} entries)", len(resp["roles"]))
+    return resp
+
+
 def _is_error_response(grouped: dict) -> str:
     """Check if a Talent Market response is an error. Returns error message or empty string."""
     if "error" in grouped:
@@ -520,10 +541,12 @@ async def search_candidates(job_description: str) -> dict:
                         market_warning = f"Cloud search failed ({err_msg}). Using local talent pool instead."
                         grouped = _local_fallback_search(job_description)
                     elif not grouped.get("roles"):
-                        # Non-AI search returned no roles — treat as empty result, fall back to local
-                        logger.warning("[recruitment] Non-AI search returned no roles (keys={}), falling back to local", list(grouped.keys())[:10])
-                        market_warning = f"AI search unavailable ({err_msg}). Standard search returned no results. Using local talent pool."
-                        grouped = _local_fallback_search(job_description)
+                        # Talent Market API may return "results" instead of "roles" (format change)
+                        grouped = _normalize_api_response(grouped)
+                        if not grouped.get("roles"):
+                            logger.warning("[recruitment] Non-AI search returned no roles (keys={}), falling back to local", list(grouped.keys())[:10])
+                            market_warning = f"AI search unavailable ({err_msg}). Standard search returned no results. Using local talent pool."
+                            grouped = _local_fallback_search(job_description)
                     else:
                         market_warning = f"AI search unavailable ({err_msg}). Showing standard search results."
                         from_market = True
@@ -531,6 +554,7 @@ async def search_candidates(job_description: str) -> dict:
                     market_warning = f"Cloud search failed ({err_msg}). Using local talent pool instead."
                     grouped = _local_fallback_search(job_description)
             else:
+                grouped = _normalize_api_response(grouped)
                 total = sum(len(r.get("candidates", [])) for r in grouped.get("roles", []))
                 logger.info("Talent Market returned {} candidates in {} roles for JD: {}",
                             total, len(grouped.get("roles", [])), job_description[:80])


### PR DESCRIPTION
## Summary

Talent Market API upgraded and now returns \`{type, results}\` instead of \`{roles}\`. The candidate pipeline expected \`roles\` key, so non-AI search returned 0 candidates.

### Root Cause
Confirmed via debug logs: \`parsed response keys=['type', 'results'], roles_count=0\`

### Fix
Added \`_normalize_api_response()\` that converts \`results\` → \`roles\` format:
- If \`results\` contains role-grouped dicts (with \`candidates\` key): use as-is
- If \`results\` is a flat candidate list: wrap in a single \`{role: "General", candidates: [...]}\` group

Applied at both initial success path and non-AI fallback path.

## Test plan
- [x] 2356 unit tests pass
- [ ] Manual: trigger Talent Market search → verify candidates appear in shortlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)