### PR TITLE
fix: show full task result in CEO console

### DIFF
--- a/frontend/ceo-terminal.js
+++ b/frontend/ceo-terminal.js
@@ -213,8 +213,20 @@ class CeoTerminal {
       const src = msg.source || 'system';
       const cls = src === 'ea_auto_reply' ? 'ceo-msg--system' : 'ceo-msg--agent';
       el.className = `ceo-msg ${cls}`;
-      el.innerHTML = `<span class="ceo-msg-sender">[${this._esc(src)}]</span>`
-        + `<span class="ceo-msg-text">${this._esc(msg.text || '')}</span>`;
+      const text = msg.text || '';
+      const lines = text.split('\n');
+      const COLLAPSE_THRESHOLD = 5;
+      if (lines.length > COLLAPSE_THRESHOLD) {
+        const preview = lines.slice(0, COLLAPSE_THRESHOLD).join('\n');
+        const full = text;
+        el.innerHTML = `<span class="ceo-msg-sender">[${this._esc(src)}]</span>`
+          + `<span class="ceo-msg-text ceo-msg-collapsed">${this._esc(preview)}</span>`
+          + `<span class="ceo-msg-text ceo-msg-full" style="display:none">${this._esc(full)}</span>`
+          + `<span class="ceo-msg-toggle" onclick="this.parentElement.querySelector('.ceo-msg-collapsed').style.display=this.parentElement.querySelector('.ceo-msg-collapsed').style.display==='none'?'':'none';this.parentElement.querySelector('.ceo-msg-full').style.display=this.parentElement.querySelector('.ceo-msg-full').style.display==='none'?'':'none';this.textContent=this.textContent==='▼ Show more'?'▲ Show less':'▼ Show more'">▼ Show more</span>`;
+      } else {
+        el.innerHTML = `<span class="ceo-msg-sender">[${this._esc(src)}]</span>`
+          + `<span class="ceo-msg-text">${this._esc(text)}</span>`;
+      }
     }
 
     this._container.appendChild(el);

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5617,3 +5617,14 @@ body.resize-dragging {
 .completion-card-body div {
   padding: 1px 0;
 }
+
+/* ===== Message Collapse/Expand ===== */
+.ceo-msg-toggle {
+  display: inline-block;
+  color: var(--pixel-cyan);
+  font-size: calc(9px + var(--font-boost));
+  cursor: pointer;
+  margin-top: 4px;
+  user-select: none;
+}
+.ceo-msg-toggle:hover { text-decoration: underline; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.64",
+  "version": "0.4.65",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.64"
+version = "0.4.65"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1632,10 +1632,10 @@ class EmployeeManager:
                 self._append_history_from_node(employee_id, node)
                 summary = node.result or ""
                 _append_progress(employee_id, f"Completed: {node.description_preview} → {summary}")
-                # Push result to CEO session
-                result_first_line = (node.result or "").strip().split("\n")[0]
-                if result_first_line:
-                    self._push_to_ceo_session(node, f"✓ {result_first_line}")
+                # Push full result to CEO session
+                result_text = (node.result or "").strip()
+                if result_text:
+                    self._push_to_ceo_session(node, f"✓ {result_text}")
 
             # Post-task hook
             post_task_hook = self._hooks.get(employee_id, {}).get("post_task")


### PR DESCRIPTION
## Summary

Task results were truncated to first line only in CEO console. Employee writes a full report but CEO only sees the opening sentence.

**Root cause:** \`_push_to_ceo_session\` at line 1636 did \`result.split('\\n')[0]\` — only the first line.

**Fix:** Send the full \`result_text\` without splitting on newlines.

## Test plan
- [x] 2362 unit tests pass
- [ ] Manual: task produces multi-line result → verify full text in CEO console

🤖 Generated with [Claude Code](https://claude.com/claude-code)