### PR TITLE
fix: followup completion triggers its own completion card

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.65",
+  "version": "0.4.66",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.65"
+version = "0.4.66"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2531,7 +2531,7 @@ class EmployeeManager:
         # --- CEO confirm node completed → trigger cleanup ---
         # When a CEO_REQUEST confirm node (created below) finishes, run
         # _full_cleanup to archive the project and optionally run retrospective.
-        from onemancompany.core.config import CEO_ID as _CEO_ID
+        from onemancompany.core.config import CEO_ID as _CEO_ID, EA_ID
         if (node.node_type in (NodeType.CEO_REQUEST, NodeType.CEO_REQUEST.value)
             and node.employee_id == _CEO_ID
             and tree.is_project_complete()):
@@ -2560,7 +2560,17 @@ class EmployeeManager:
         # EA done executing + all child subtrees RESOLVED → trigger CEO confirmation.
         # Skip non-project node types (see _SKIP_COMPLETION_TYPES).
         if node.node_type not in SKIP_COMPLETION_TYPES and tree.is_project_complete():
-            ea_node = tree.get_ea_node()
+            # Find the EA node relevant to this completion:
+            # For followup tasks, use the followup's EA child (not the original EA).
+            ea_node = tree.get_ea_node()  # default: first EA
+            # Walk up from completing node to find the closest EA ancestor
+            _walk = node
+            while _walk:
+                if _walk.employee_id == EA_ID and _walk.node_type == NodeType.TASK:
+                    ea_node = _walk
+                    break
+                _walk = tree.get_node(_walk.parent_id) if _walk.parent_id else None
+
             logger.info(
                 "[PROJECT COMPLETE] EA node {} done + all subtrees resolved — scheduling CEO confirmation",
                 ea_node.id,
@@ -2574,7 +2584,7 @@ class EmployeeManager:
                     ea_parent.set_status(TaskPhase.COMPLETED)
                     logger.debug("[TASK LIFECYCLE] CEO parent={} → COMPLETED", ea_parent.id)
 
-            # Guard: don't create duplicate confirm nodes
+            # Guard: don't create duplicate confirm nodes for THIS specific EA
             existing_confirm = any(
                 c for c in tree.get_children(ea_node.id)
                 if (c.node_type == NodeType.CEO_REQUEST.value or c.node_type == NodeType.CEO_REQUEST)


### PR DESCRIPTION
## Summary

After a followup task (CEO gives additional instructions), the completion card was not shown because the system always checked the first EA node, which already had a confirm node from the initial completion.

### Root Cause
\`get_ea_node()\` returns the first EA. For followups, the tree is:
\`\`\`
CEO_PROMPT → EA (first) → CEO_REQUEST (already exists)
           → CEO_FOLLOWUP → EA (followup) → (no confirm node!)
\`\`\`
The duplicate guard saw the first EA's confirm node and skipped.

### Fix
Walk up from the completing node to find the closest EA ancestor. Use that EA (not always the first one) for confirm node creation.

## Test plan
- [x] 2362 unit tests pass
- [ ] Manual: complete initial task → confirm → give followup → verify second completion card appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)