### PR TITLE
fix: set_cron tool fails with 'no running event loop'

### DIFF
--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -1250,7 +1250,7 @@ def manage_tool_access(employee_id: str, tool_name: str, action: str, manager_id
 # ---------------------------------------------------------------------------
 
 @tool
-def set_cron(cron_name: str, interval: str, task_description: str, employee_id: str = "") -> dict:
+async def set_cron(cron_name: str, interval: str, task_description: str, employee_id: str = "") -> dict:
     """Schedule a recurring task that runs automatically at a fixed interval.
 
     The task is dispatched to YOU (the caller) each interval. Use this for
@@ -1271,7 +1271,7 @@ def set_cron(cron_name: str, interval: str, task_description: str, employee_id: 
 
 
 @tool
-def stop_cron_job(cron_name: str, employee_id: str = "") -> dict:
+async def stop_cron_job(cron_name: str, employee_id: str = "") -> dict:
     """Stop a recurring cron job by name.
 
     Use list_automations() first to see your active cron jobs and their names.

--- a/src/onemancompany/core/automation.py
+++ b/src/onemancompany/core/automation.py
@@ -67,8 +67,8 @@ def _broadcast_cron_status(employee_id: str, cron_name: str, running: bool) -> N
     try:
         from onemancompany.core.events import event_bus, CompanyEvent
         from onemancompany.core.models import EventType
-        from onemancompany.core.async_utils import spawn_background
-        spawn_background(event_bus.publish(CompanyEvent(
+
+        coro = event_bus.publish(CompanyEvent(
             type=EventType.CRON_STATUS_CHANGE,
             payload={
                 "employee_id": employee_id,
@@ -76,7 +76,15 @@ def _broadcast_cron_status(employee_id: str, cron_name: str, running: bool) -> N
                 "running": running,
             },
             agent="SYSTEM",
-        )))
+        ))
+        try:
+            asyncio.get_running_loop()
+            from onemancompany.core.async_utils import spawn_background
+            spawn_background(coro)
+        except RuntimeError:
+            # No running event loop (called from thread or startup) — skip broadcast
+            coro.close()
+            logger.debug("[cron] Skipped broadcast (no event loop): {}:{}", employee_id, cron_name)
     except Exception as e:
         logger.warning("[cron] Broadcast cron_status_change failed: {}", e)
 


### PR DESCRIPTION
## Summary
- **Fix set_cron/stop_cron_job "no running event loop" error**: LangChain's `ainvoke()` runs sync tools in a thread executor which has no event loop. `asyncio.create_task()` inside `start_cron()` then fails. Made both tools `async def` so LangChain runs them in the event loop directly.
- **Graceful broadcast skip**: `_broadcast_cron_status` now detects missing event loop (startup/test context) and skips silently instead of spamming warnings.

## Root Cause
`execute_tool` calls `await fn.ainvoke(args)` → LangChain runs sync `@tool` in thread → `start_cron()` → `asyncio.create_task()` → RuntimeError: no running event loop.

## Changes
- `common_tools.py`: `set_cron` and `stop_cron_job` changed from `def` to `async def`
- `automation.py`: `_broadcast_cron_status` checks for running loop before `spawn_background`, gracefully skips with debug log if absent

## Test plan
- [x] All 2365 unit tests pass
- [x] 26 cron/automation-specific tests pass
- [x] `set_cron` tool confirmed to have `coroutine` attribute (LangChain async detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)