### PR TITLE
feat: SVG screenshot export

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -50,7 +50,7 @@
           <button id="dashboard-toolbar-btn" class="toolbar-icon-btn" title="Dashboard">&#128202;</button>
           <button id="bg-tasks-toolbar-btn" class="toolbar-icon-btn" title="Background Tasks">&#9641;</button>
           <button id="announcements-toolbar-btn" class="toolbar-icon-btn" title="Announcements" style="position:relative;">&#128276;<span id="announcements-badge" class="announcement-badge hidden"></span></button>
-          <button id="screenshot-toolbar-btn" class="toolbar-icon-btn" title="Export SVG Screenshot" onclick="exportSVG()">&#128247;</button>
+          <button id="screenshot-toolbar-btn" class="toolbar-icon-btn" title="Export SVG Screenshot">&#128247;</button>
           <button id="settings-toolbar-btn" class="toolbar-icon-btn" title="Settings">&#9881;</button>
           <button id="abort-all-toolbar-btn" class="toolbar-icon-btn" title="Stop All Tasks" style="color: #ff4444;">&#9888;</button>
           <span class="status-item" id="connection-status">&#9679; OFFLINE</span>
@@ -674,9 +674,9 @@
   <script src="office-camera.js?v=4"></script>
   <script src="office-map.js?v=3"></script>
   <script src="office-minimap.js?v=2"></script>
-  <script src="vendor/canvas2svg.js"></script>
+  <script src="vendor/canvas2svg.js?v=1"></script>
   <script src="office.js?v=29"></script>
-  <script src="screenshot.js"></script>
+  <script src="screenshot.js?v=1"></script>
   <script src="task-tree.js"></script>
   <link rel="stylesheet" href="trace-viewer.css">
   <script src="trace-viewer.js"></script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -50,6 +50,7 @@
           <button id="dashboard-toolbar-btn" class="toolbar-icon-btn" title="Dashboard">&#128202;</button>
           <button id="bg-tasks-toolbar-btn" class="toolbar-icon-btn" title="Background Tasks">&#9641;</button>
           <button id="announcements-toolbar-btn" class="toolbar-icon-btn" title="Announcements" style="position:relative;">&#128276;<span id="announcements-badge" class="announcement-badge hidden"></span></button>
+          <button id="screenshot-toolbar-btn" class="toolbar-icon-btn" title="Export SVG Screenshot" onclick="exportSVG()">&#128247;</button>
           <button id="settings-toolbar-btn" class="toolbar-icon-btn" title="Settings">&#9881;</button>
           <button id="abort-all-toolbar-btn" class="toolbar-icon-btn" title="Stop All Tasks" style="color: #ff4444;">&#9888;</button>
           <span class="status-item" id="connection-status">&#9679; OFFLINE</span>
@@ -673,7 +674,9 @@
   <script src="office-camera.js?v=4"></script>
   <script src="office-map.js?v=3"></script>
   <script src="office-minimap.js?v=2"></script>
+  <script src="vendor/canvas2svg.js"></script>
   <script src="office.js?v=29"></script>
+  <script src="screenshot.js"></script>
   <script src="task-tree.js"></script>
   <link rel="stylesheet" href="trace-viewer.css">
   <script src="trace-viewer.js"></script>

--- a/frontend/office.js
+++ b/frontend/office.js
@@ -1286,8 +1286,8 @@ class OfficeRenderer {
     const cssW = isSvgExport ? ctx.width : this.canvas.width  / dpr;
     const cssH = isSvgExport ? ctx.height : this.canvas.height / dpr;
 
-    // Clear buffer
-    ctx.clearRect(0, 0, cssW, cssH);
+    // Clear buffer (skip for SVG — C2S clearRect draws a white rect)
+    if (!isSvgExport) ctx.clearRect(0, 0, cssW, cssH);
 
     // Base DPR scaling (maps CSS pixels → physical pixels)
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);

--- a/frontend/office.js
+++ b/frontend/office.js
@@ -1282,11 +1282,12 @@ class OfficeRenderer {
   render() {
     const dpr  = this.dpr || 1;
     const ctx  = this.ctx;
-    const cssW = this.canvas.width  / dpr;
-    const cssH = this.canvas.height / dpr;
+    const isSvgExport = (typeof C2S !== 'undefined' && ctx instanceof C2S);
+    const cssW = isSvgExport ? ctx.width : this.canvas.width  / dpr;
+    const cssH = isSvgExport ? ctx.height : this.canvas.height / dpr;
 
     // Clear buffer
-    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    ctx.clearRect(0, 0, cssW, cssH);
 
     // Base DPR scaling (maps CSS pixels → physical pixels)
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
@@ -1311,17 +1312,18 @@ class OfficeRenderer {
 
     this.camera.resetTransform(ctx);
 
-    // === Screen space ===
-    // Subtle scanline (screen space — covers full viewport at any zoom/pan)
-    ctx.globalAlpha = 0.02;
-    ctx.fillStyle = '#000';
-    for (let sy = 0; sy < cssH; sy += 2) {
-      ctx.fillRect(0, sy, cssW, 1);
-    }
-    ctx.globalAlpha = 1;
+    // === Screen space (skip scanlines/minimap/tooltip for SVG export) ===
+    if (!isSvgExport) {
+      ctx.globalAlpha = 0.02;
+      ctx.fillStyle = '#000';
+      for (let sy = 0; sy < cssH; sy += 2) {
+        ctx.fillRect(0, sy, cssW, 1);
+      }
+      ctx.globalAlpha = 1;
 
-    this.minimap.draw(ctx, cssW, cssH);
-    this._updateTooltip();
+      this.minimap.draw(ctx, cssW, cssH);
+      this._updateTooltip();
+    }
   }
 
   loop() {

--- a/frontend/screenshot.js
+++ b/frontend/screenshot.js
@@ -4,12 +4,26 @@
  * Exports the entire OneManCompany UI as a single SVG file.
  * - Canvas office scene → pure vector via canvas2svg (C2S)
  * - HTML panels → foreignObject with inline styles
+ *
+ * Known limitation: drawImage sprites are embedded as base64 data URIs
+ * in the SVG. This makes the file self-contained but larger.
  */
 
 function exportSVG() {
   const renderer = window.officeRenderer;
   if (!renderer) { alert('Office renderer not ready'); return; }
 
+  const btn = document.getElementById('screenshot-toolbar-btn');
+  if (btn) btn.disabled = true;
+
+  try {
+    _doExport(renderer);
+  } finally {
+    if (btn) btn.disabled = false;
+  }
+}
+
+function _doExport(renderer) {
   const app = document.getElementById('app');
   const appRect = app.getBoundingClientRect();
   const W = Math.round(appRect.width);
@@ -36,7 +50,8 @@ function exportSVG() {
     renderer.dpr = origDpr;
   }
 
-  const canvasSvgStr = svgCtx.getSerializedSvg(true);
+  // Extract inner SVG content (strip outer <svg> wrapper to avoid nested viewport)
+  const canvasInner = _extractSvgInner(svgCtx.getSerializedSvg(true));
 
   // ── 2. Collect styles for foreignObject ────────────────────────────────
   const styles = _collectStyles();
@@ -77,7 +92,7 @@ ${styles}
   <rect width="${W}" height="${H}" fill="#0d1117"/>
   <!-- Canvas (vector) -->
   <g transform="translate(${canvasOffX},${canvasOffY})">
-    ${canvasSvgStr}
+    ${canvasInner}
   </g>
   <!-- HTML panels -->
   ${foreignObjects}
@@ -93,10 +108,22 @@ ${styles}
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+  setTimeout(() => URL.revokeObjectURL(url), 60000);
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Strip outer <svg> wrapper, return only inner content (defs + groups). */
+function _extractSvgInner(svgStr) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(svgStr, 'image/svg+xml');
+  const root = doc.documentElement;
+  let inner = '';
+  for (const child of root.children) {
+    inner += new XMLSerializer().serializeToString(child);
+  }
+  return inner;
+}
 
 /** Collect all stylesheet rules as a string for embedding in SVG. */
 function _collectStyles() {
@@ -106,12 +133,32 @@ function _collectStyles() {
       for (const rule of sheet.cssRules) {
         lines.push(rule.cssText);
       }
-    } catch (_) {
-      // cross-origin stylesheets (e.g. Google Fonts) can't be read;
-      // we'll inline the font-family references instead
+    } catch (e) {
+      // Cross-origin stylesheets (e.g. Google Fonts) can't be read.
+      // Font references in the SVG will use fallbacks.
+      console.warn('[SVG export] Cannot read cross-origin stylesheet:', sheet.href, e.message);
     }
   }
   return lines.join('\n');
+}
+
+/** Sanitize a cloned DOM tree for safe embedding in SVG foreignObject. */
+function _sanitizeClone(clone) {
+  // Remove dangerous elements
+  for (const el of clone.querySelectorAll('script,iframe,embed,object,base,meta,link[rel="import"]')) {
+    el.remove();
+  }
+  // Remove event handlers and javascript: URIs
+  for (const el of clone.querySelectorAll('*')) {
+    for (const attr of [...el.attributes]) {
+      if (attr.name.startsWith('on') ||
+          (attr.name === 'href' && attr.value.trim().toLowerCase().startsWith('javascript:')) ||
+          (attr.name === 'src' && attr.value.trim().toLowerCase().startsWith('javascript:'))) {
+        el.removeAttribute(attr.name);
+      }
+    }
+  }
+  return clone;
 }
 
 /** Serialize a DOM panel into a <foreignObject> positioned at its layout offset. */
@@ -122,12 +169,7 @@ function _panelToForeignObject(el, appRect) {
   const w = Math.round(r.width);
   const h = Math.round(r.height);
 
-  // Clone and inline computed styles on top-level element
-  const clone = el.cloneNode(true);
-
-  // Remove script tags from clone
-  for (const s of clone.querySelectorAll('script')) s.remove();
-
+  const clone = _sanitizeClone(el.cloneNode(true));
   const html = new XMLSerializer().serializeToString(clone);
 
   return `<foreignObject x="${x}" y="${y}" width="${w}" height="${h}">
@@ -138,3 +180,8 @@ function _panelToForeignObject(el, appRect) {
 }
 
 window.exportSVG = exportSVG;
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('screenshot-toolbar-btn');
+  if (btn) btn.addEventListener('click', exportSVG);
+});

--- a/frontend/screenshot.js
+++ b/frontend/screenshot.js
@@ -1,0 +1,140 @@
+/**
+ * SVG Screenshot Export
+ *
+ * Exports the entire OneManCompany UI as a single SVG file.
+ * - Canvas office scene → pure vector via canvas2svg (C2S)
+ * - HTML panels → foreignObject with inline styles
+ */
+
+function exportSVG() {
+  const renderer = window.officeRenderer;
+  if (!renderer) { alert('Office renderer not ready'); return; }
+
+  const app = document.getElementById('app');
+  const appRect = app.getBoundingClientRect();
+  const W = Math.round(appRect.width);
+  const H = Math.round(appRect.height);
+
+  // ── 1. Render Canvas scene to SVG via C2S ──────────────────────────────
+  const canvasEl = renderer.canvas;
+  const canvasRect = canvasEl.getBoundingClientRect();
+  const cw = Math.round(canvasRect.width);
+  const ch = Math.round(canvasRect.height);
+
+  const svgCtx = new C2S(cw, ch);
+
+  // Swap context: all sub-methods read this.ctx
+  const origCtx = renderer.ctx;
+  const origDpr = renderer.dpr;
+  renderer.ctx = svgCtx;
+  renderer.dpr = 1;  // SVG is resolution-independent
+
+  try {
+    renderer.render();
+  } finally {
+    renderer.ctx = origCtx;
+    renderer.dpr = origDpr;
+  }
+
+  const canvasSvgStr = svgCtx.getSerializedSvg(true);
+
+  // ── 2. Collect styles for foreignObject ────────────────────────────────
+  const styles = _collectStyles();
+
+  // ── 3. Build composite SVG ─────────────────────────────────────────────
+  const canvasOffX = Math.round(canvasRect.left - appRect.left);
+  const canvasOffY = Math.round(canvasRect.top - appRect.top);
+
+  const panels = [
+    'left-top-panel', 'left-bottom-panel',
+    'roster-panel', 'console-panel',
+  ];
+
+  // Also capture the office-panel header (toolbar)
+  const officePanel = document.getElementById('office-panel');
+  const panelHeader = officePanel ? officePanel.querySelector('.panel-header') : null;
+
+  let foreignObjects = '';
+  for (const id of panels) {
+    const el = document.getElementById(id);
+    if (!el) continue;
+    foreignObjects += _panelToForeignObject(el, appRect);
+  }
+  if (panelHeader) {
+    foreignObjects += _panelToForeignObject(panelHeader, appRect);
+  }
+
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="${W}" height="${H}" viewBox="0 0 ${W} ${H}">
+  <defs>
+    <style type="text/css"><![CDATA[
+${styles}
+    ]]></style>
+  </defs>
+  <!-- Background -->
+  <rect width="${W}" height="${H}" fill="#0d1117"/>
+  <!-- Canvas (vector) -->
+  <g transform="translate(${canvasOffX},${canvasOffY})">
+    ${canvasSvgStr}
+  </g>
+  <!-- HTML panels -->
+  ${foreignObjects}
+</svg>`;
+
+  // ── 4. Download ────────────────────────────────────────────────────────
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const blob = new Blob([svg], { type: 'image/svg+xml;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `onemancompany-${ts}.svg`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Collect all stylesheet rules as a string for embedding in SVG. */
+function _collectStyles() {
+  const lines = [];
+  for (const sheet of document.styleSheets) {
+    try {
+      for (const rule of sheet.cssRules) {
+        lines.push(rule.cssText);
+      }
+    } catch (_) {
+      // cross-origin stylesheets (e.g. Google Fonts) can't be read;
+      // we'll inline the font-family references instead
+    }
+  }
+  return lines.join('\n');
+}
+
+/** Serialize a DOM panel into a <foreignObject> positioned at its layout offset. */
+function _panelToForeignObject(el, appRect) {
+  const r = el.getBoundingClientRect();
+  const x = Math.round(r.left - appRect.left);
+  const y = Math.round(r.top - appRect.top);
+  const w = Math.round(r.width);
+  const h = Math.round(r.height);
+
+  // Clone and inline computed styles on top-level element
+  const clone = el.cloneNode(true);
+
+  // Remove script tags from clone
+  for (const s of clone.querySelectorAll('script')) s.remove();
+
+  const html = new XMLSerializer().serializeToString(clone);
+
+  return `<foreignObject x="${x}" y="${y}" width="${w}" height="${h}">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="width:${w}px;height:${h}px;overflow:hidden;">
+      ${html}
+    </div>
+  </foreignObject>\n`;
+}
+
+window.exportSVG = exportSVG;

--- a/frontend/vendor/canvas2svg.js
+++ b/frontend/vendor/canvas2svg.js
@@ -234,14 +234,11 @@
     ctx.prototype.translate = function(x, y) { this.__addTransform(format("translate({x},{y})",{x:x,y:y})); };
     ctx.prototype.transform = function(a, b, c, d, e, f) { this.__addTransform(format("matrix({a},{b},{c},{d},{e},{f})",{a:a,b:b,c:c,d:d,e:e,f:f})); };
 
-    // Patched: setTransform support for OMC
+    // Patched: setTransform support for OMC (respects save/restore group scope)
     ctx.prototype.setTransform = function(a, b, c, d, e, f) {
-        // Reset to identity by wrapping in a new group, then apply the matrix
         var parent = this.__closestGroupOrSvg();
         var group = this.__createElement("g");
-        // Find the root content group (second child of svg root)
-        var rootGroup = this.__root.childNodes[1];
-        rootGroup.appendChild(group);
+        parent.appendChild(group);
         this.__currentElement = group;
         if (a !== 1 || b !== 0 || c !== 0 || d !== 1 || e !== 0 || f !== 0) {
             this.__currentElement.setAttribute("transform",

--- a/frontend/vendor/canvas2svg.js
+++ b/frontend/vendor/canvas2svg.js
@@ -1,0 +1,393 @@
+/*!!
+ *  Canvas 2 Svg v1.0.15
+ *  A low level canvas to SVG converter. Uses a mock canvas context to build an SVG document.
+ *
+ *  Licensed under the MIT license:
+ *  http://www.opensource.org/licenses/mit-license.php
+ *
+ *  Author: Kerry Liu
+ *  Copyright (c) 2014 Gliffy Inc.
+ *
+ *  Patched: added setTransform() support for OMC SVG export.
+ */
+;(function() {
+    "use strict";
+
+    var STYLES, ctx, CanvasGradient, CanvasPattern, namedEntities;
+
+    function format(str, args) {
+        var keys = Object.keys(args), i;
+        for (i=0; i<keys.length; i++) {
+            str = str.replace(new RegExp("\\{" + keys[i] + "\\}", "gi"), args[keys[i]]);
+        }
+        return str;
+    }
+
+    function randomString(holder) {
+        var chars, randomstring, i;
+        if (!holder) { throw new Error("cannot create a random attribute name for an undefined object"); }
+        chars = "ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz";
+        randomstring = "";
+        do {
+            randomstring = "";
+            for (i = 0; i < 12; i++) { randomstring += chars[Math.floor(Math.random() * chars.length)]; }
+        } while (holder[randomstring]);
+        return randomstring;
+    }
+
+    function createNamedToNumberedLookup(items, radix) {
+        var i, entity, lookup = {}, base10;
+        items = items.split(',');
+        radix = radix || 10;
+        for (i = 0; i < items.length; i += 2) {
+            entity = '&' + items[i + 1] + ';';
+            base10 = parseInt(items[i], radix);
+            lookup[entity] = '&#'+base10+';';
+        }
+        lookup["\\xa0"] = '&#160;';
+        return lookup;
+    }
+
+    function getTextAnchor(textAlign) {
+        var mapping = {"left":"start", "right":"end", "center":"middle", "start":"start", "end":"end"};
+        return mapping[textAlign] || mapping.start;
+    }
+
+    function getDominantBaseline(textBaseline) {
+        var mapping = {"alphabetic": "alphabetic", "hanging": "hanging", "top":"text-before-edge", "bottom":"text-after-edge", "middle":"central"};
+        return mapping[textBaseline] || mapping.alphabetic;
+    }
+
+    namedEntities = createNamedToNumberedLookup(
+        '50,nbsp,51,iexcl,52,cent,53,pound,54,curren,55,yen,56,brvbar,57,sect,58,uml,59,copy,' +
+        '5a,ordf,5b,laquo,5c,not,5d,shy,5e,reg,5f,macr,5g,deg,5h,plusmn,5i,sup2,5j,sup3,5k,acute,' +
+        '5l,micro,5m,para,5n,middot,5o,cedil,5p,sup1,5q,ordm,5r,raquo,5s,frac14,5t,frac12,5u,frac34,' +
+        '5v,iquest,60,Agrave,61,Aacute,62,Acirc,63,Atilde,64,Auml,65,Aring,66,AElig,67,Ccedil,' +
+        '68,Egrave,69,Eacute,6a,Ecirc,6b,Euml,6c,Igrave,6d,Iacute,6e,Icirc,6f,Iuml,6g,ETH,6h,Ntilde,' +
+        '6i,Ograve,6j,Oacute,6k,Ocirc,6l,Otilde,6m,Ouml,6n,times,6o,Oslash,6p,Ugrave,6q,Uacute,' +
+        '6r,Ucirc,6s,Uuml,6t,Yacute,6u,THORN,6v,szlig,70,agrave,71,aacute,72,acirc,73,atilde,74,auml,' +
+        '75,aring,76,aelig,77,ccedil,78,egrave,79,eacute,7a,ecirc,7b,euml,7c,igrave,7d,iacute,7e,icirc,' +
+        '7f,iuml,7g,eth,7h,ntilde,7i,ograve,7j,oacute,7k,ocirc,7l,otilde,7m,ouml,7n,divide,7o,oslash,' +
+        '7p,ugrave,7q,uacute,7r,ucirc,7s,uuml,7t,yacute,7u,thorn,7v,yuml,ci,fnof,sh,Alpha,si,Beta,' +
+        'sj,Gamma,sk,Delta,sl,Epsilon,sm,Zeta,sn,Eta,so,Theta,sp,Iota,sq,Kappa,sr,Lambda,ss,Mu,' +
+        'st,Nu,su,Xi,sv,Omicron,t0,Pi,t1,Rho,t3,Sigma,t4,Tau,t5,Upsilon,t6,Phi,t7,Chi,t8,Psi,' +
+        't9,Omega,th,alpha,ti,beta,tj,gamma,tk,delta,tl,epsilon,tm,zeta,tn,eta,to,theta,tp,iota,' +
+        'tq,kappa,tr,lambda,ts,mu,tt,nu,tu,xi,tv,omicron,u0,pi,u1,rho,u2,sigmaf,u3,sigma,u4,tau,' +
+        'u5,upsilon,u6,phi,u7,chi,u8,psi,u9,omega,uh,thetasym,ui,upsih,um,piv,812,bull,816,hellip,' +
+        '81i,prime,81j,Prime,81u,oline,824,frasl,88o,weierp,88h,image,88s,real,892,trade,89l,alefsym,' +
+        '8cg,larr,8ch,uarr,8ci,rarr,8cj,darr,8ck,harr,8dl,crarr,8eg,lArr,8eh,uArr,8ei,rArr,8ej,dArr,' +
+        '8ek,hArr,8g0,forall,8g2,part,8g3,exist,8g5,empty,8g7,nabla,8g8,isin,8g9,notin,8gb,ni,8gf,prod,' +
+        '8gh,sum,8gi,minus,8gn,lowast,8gq,radic,8gt,prop,8gu,infin,8h0,ang,8h7,and,8h8,or,8h9,cap,8ha,cup,' +
+        '8hb,int,8hk,there4,8hs,sim,8i5,cong,8i8,asymp,8j0,ne,8j1,equiv,8j4,le,8j5,ge,8k2,sub,8k3,sup,8k4,' +
+        'nsub,8k6,sube,8k7,supe,8kl,oplus,8kn,otimes,8l5,perp,8m5,sdot,8o8,lceil,8o9,rceil,8oa,lfloor,8ob,' +
+        'rfloor,8p9,lang,8pa,rang,9ea,loz,9j0,spades,9j3,clubs,9j5,hearts,9j6,diams,ai,OElig,aj,oelig,b0,' +
+        'Scaron,b1,scaron,bo,Yuml,m6,circ,ms,tilde,802,ensp,803,emsp,809,thinsp,80c,zwnj,80d,zwj,80e,lrm,' +
+        '80f,rlm,80j,ndash,80k,mdash,80o,lsquo,80p,rsquo,80q,sbquo,80s,ldquo,80t,rdquo,80u,bdquo,810,dagger,' +
+        '811,Dagger,81g,permil,81p,lsaquo,81q,rsaquo,85c,euro', 32);
+
+    STYLES = {
+        "strokeStyle":{ svgAttr:"stroke", canvas:"#000000", svg:"none", apply:"stroke" },
+        "fillStyle":{ svgAttr:"fill", canvas:"#000000", svg:null, apply:"fill" },
+        "lineCap":{ svgAttr:"stroke-linecap", canvas:"butt", svg:"butt", apply:"stroke" },
+        "lineJoin":{ svgAttr:"stroke-linejoin", canvas:"miter", svg:"miter", apply:"stroke" },
+        "miterLimit":{ svgAttr:"stroke-miterlimit", canvas:10, svg:4, apply:"stroke" },
+        "lineWidth":{ svgAttr:"stroke-width", canvas:1, svg:1, apply:"stroke" },
+        "globalAlpha":{ svgAttr:"opacity", canvas:1, svg:1, apply:"fill stroke" },
+        "font":{ canvas:"10px sans-serif" },
+        "shadowColor":{ canvas:"#000000" },
+        "shadowOffsetX":{ canvas:0 },
+        "shadowOffsetY":{ canvas:0 },
+        "shadowBlur":{ canvas:0 },
+        "textAlign":{ canvas:"start" },
+        "textBaseline":{ canvas:"alphabetic" }
+    };
+
+    CanvasGradient = function(gradientNode, ctx) { this.__root = gradientNode; this.__ctx = ctx; };
+    CanvasGradient.prototype.addColorStop = function(offset, color) {
+        var stop = this.__ctx.__createElement("stop"), regex, matches;
+        stop.setAttribute("offset", offset);
+        if(color.indexOf("rgba") !== -1) {
+            regex = /rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d?\.?\d*)\s*\)/gi;
+            matches = regex.exec(color);
+            stop.setAttribute("stop-color", format("rgb({r},{g},{b})", {r:matches[1], g:matches[2], b:matches[3]}));
+            stop.setAttribute("stop-opacity", matches[4]);
+        } else { stop.setAttribute("stop-color", color); }
+        this.__root.appendChild(stop);
+    };
+
+    CanvasPattern = function(pattern, ctx) { this.__root = pattern; this.__ctx = ctx; };
+
+    ctx = function(o) {
+        var defaultOptions = { width:500, height:500, enableMirroring:false }, options;
+        if(arguments.length > 1) { options = defaultOptions; options.width = arguments[0]; options.height = arguments[1]; }
+        else if(!o) { options = defaultOptions; }
+        else { options = o; }
+        if(!(this instanceof ctx)) { return new ctx(options); }
+
+        this.width = options.width || defaultOptions.width;
+        this.height = options.height || defaultOptions.height;
+        this.enableMirroring = options.enableMirroring !== undefined ? options.enableMirroring : defaultOptions.enableMirroring;
+        this.canvas = this;
+        this.__document = options.document || document;
+        this.__canvas = this.__document.createElement("canvas");
+        this.__ctx = this.__canvas.getContext("2d");
+        this.__setDefaultStyles();
+        this.__stack = [this.__getStyleState()];
+        this.__groupStack = [];
+
+        this.__root = this.__document.createElementNS("http://www.w3.org/2000/svg", "svg");
+        this.__root.setAttribute("version", 1.1);
+        this.__root.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+        this.__root.setAttributeNS("http://www.w3.org/2000/xmlns/", "xmlns:xlink", "http://www.w3.org/1999/xlink");
+        this.__root.setAttribute("width", this.width);
+        this.__root.setAttribute("height", this.height);
+        this.__ids = {};
+        this.__defs = this.__document.createElementNS("http://www.w3.org/2000/svg", "defs");
+        this.__root.appendChild(this.__defs);
+        this.__currentElement = this.__document.createElementNS("http://www.w3.org/2000/svg", "g");
+        this.__root.appendChild(this.__currentElement);
+    };
+
+    ctx.prototype.__createElement = function(elementName, properties, resetFill) {
+        if(typeof properties === "undefined") { properties = {}; }
+        var element = this.__document.createElementNS("http://www.w3.org/2000/svg", elementName),
+            keys = Object.keys(properties), i, key;
+        if(resetFill) { element.setAttribute("fill","none"); element.setAttribute("stroke","none"); }
+        for(i=0; i<keys.length; i++) { key=keys[i]; element.setAttribute(key, properties[key]); }
+        return element;
+    };
+
+    ctx.prototype.__setDefaultStyles = function() {
+        var keys = Object.keys(STYLES), i, key;
+        for(i=0; i<keys.length; i++) { key=keys[i]; this[key] = STYLES[key].canvas; }
+    };
+    ctx.prototype.__applyStyleState = function(styleState) {
+        var keys = Object.keys(styleState), i, key;
+        for(i=0; i<keys.length; i++) { key=keys[i]; this[key] = styleState[key]; }
+    };
+    ctx.prototype.__getStyleState = function() {
+        var i, styleState = {}, keys = Object.keys(STYLES), key;
+        for(i=0; i<keys.length; i++) { key=keys[i]; styleState[key] = this[key]; }
+        return styleState;
+    };
+    ctx.prototype.__applyStyleToCurrentElement = function(type) {
+        var keys = Object.keys(STYLES), i, style, value, id, regex, matches;
+        for(i=0; i<keys.length; i++) {
+            style = STYLES[keys[i]]; value = this[keys[i]];
+            if(style.apply) {
+                if(style.apply.indexOf("fill")!==-1 && value instanceof CanvasPattern) {
+                    if(value.__ctx) { while(value.__ctx.__defs.childNodes.length) { id = value.__ctx.__defs.childNodes[0].getAttribute("id"); this.__ids[id] = id; this.__defs.appendChild(value.__ctx.__defs.childNodes[0]); } }
+                    this.__currentElement.setAttribute("fill", format("url(#{id})", {id:value.__root.getAttribute("id")}));
+                } else if(style.apply.indexOf("fill")!==-1 && value instanceof CanvasGradient) {
+                    this.__currentElement.setAttribute("fill", format("url(#{id})", {id:value.__root.getAttribute("id")}));
+                } else if(style.apply.indexOf(type)!==-1 && style.svg !== value) {
+                    if((style.svgAttr === "stroke" || style.svgAttr === "fill") && typeof value === "string" && value.indexOf("rgba") !== -1) {
+                        regex = /rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d?\.?\d*)\s*\)/gi;
+                        matches = regex.exec(value);
+                        this.__currentElement.setAttribute(style.svgAttr, format("rgb({r},{g},{b})", {r:matches[1], g:matches[2], b:matches[3]}));
+                        this.__currentElement.setAttribute(style.svgAttr+"-opacity", matches[4]);
+                    } else { this.__currentElement.setAttribute(style.svgAttr, value); }
+                }
+            }
+        }
+    };
+
+    ctx.prototype.__closestGroupOrSvg = function(node) {
+        node = node || this.__currentElement;
+        if(node.nodeName === "g" || node.nodeName === "svg") { return node; }
+        return this.__closestGroupOrSvg(node.parentNode);
+    };
+
+    ctx.prototype.getSerializedSvg = function(fixNamedEntities) {
+        var serialized = new XMLSerializer().serializeToString(this.__root), keys, i, key, value, regexp, xmlns;
+        xmlns = /xmlns="http:\/\/www\.w3\.org\/2000\/svg".+xmlns="http:\/\/www\.w3\.org\/2000\/svg/gi;
+        if(xmlns.test(serialized)) { serialized = serialized.replace('xmlns="http://www.w3.org/2000/svg','xmlns:xlink="http://www.w3.org/1999/xlink'); }
+        if(fixNamedEntities) {
+            keys = Object.keys(namedEntities);
+            for(i=0; i<keys.length; i++) { key=keys[i]; value=namedEntities[key]; regexp=new RegExp(key,"gi"); if(regexp.test(serialized)){serialized=serialized.replace(regexp,value);} }
+        }
+        return serialized;
+    };
+
+    ctx.prototype.getSvg = function() { return this.__root; };
+
+    ctx.prototype.save = function() {
+        var group = this.__createElement("g"), parent = this.__closestGroupOrSvg();
+        this.__groupStack.push(parent); parent.appendChild(group);
+        this.__currentElement = group; this.__stack.push(this.__getStyleState());
+    };
+    ctx.prototype.restore = function() {
+        this.__currentElement = this.__groupStack.pop();
+        var state = this.__stack.pop(); this.__applyStyleState(state);
+    };
+
+    ctx.prototype.__addTransform = function(t) {
+        var parent = this.__closestGroupOrSvg();
+        if(parent.childNodes.length > 0) { var group = this.__createElement("g"); parent.appendChild(group); this.__currentElement = group; }
+        var transform = this.__currentElement.getAttribute("transform");
+        if(transform) { transform += " "; } else { transform = ""; }
+        transform += t; this.__currentElement.setAttribute("transform", transform);
+    };
+
+    ctx.prototype.scale = function(x, y) { if(y===undefined){y=x;} this.__addTransform(format("scale({x},{y})",{x:x,y:y})); };
+    ctx.prototype.rotate = function(angle) { var degrees=(angle*180/Math.PI); this.__addTransform(format("rotate({angle},{cx},{cy})",{angle:degrees,cx:0,cy:0})); };
+    ctx.prototype.translate = function(x, y) { this.__addTransform(format("translate({x},{y})",{x:x,y:y})); };
+    ctx.prototype.transform = function(a, b, c, d, e, f) { this.__addTransform(format("matrix({a},{b},{c},{d},{e},{f})",{a:a,b:b,c:c,d:d,e:e,f:f})); };
+
+    // Patched: setTransform support for OMC
+    ctx.prototype.setTransform = function(a, b, c, d, e, f) {
+        // Reset to identity by wrapping in a new group, then apply the matrix
+        var parent = this.__closestGroupOrSvg();
+        var group = this.__createElement("g");
+        // Find the root content group (second child of svg root)
+        var rootGroup = this.__root.childNodes[1];
+        rootGroup.appendChild(group);
+        this.__currentElement = group;
+        if (a !== 1 || b !== 0 || c !== 0 || d !== 1 || e !== 0 || f !== 0) {
+            this.__currentElement.setAttribute("transform",
+                format("matrix({a},{b},{c},{d},{e},{f})", {a:a,b:b,c:c,d:d,e:e,f:f}));
+        }
+    };
+
+    ctx.prototype.beginPath = function() {
+        var path, parent;
+        this.__currentDefaultPath = ""; this.__currentPosition = {};
+        path = this.__createElement("path", {}, true);
+        parent = this.__closestGroupOrSvg(); parent.appendChild(path); this.__currentElement = path;
+    };
+    ctx.prototype.__applyCurrentDefaultPath = function() {
+        if(this.__currentElement.nodeName === "path") { this.__currentElement.setAttribute("d", this.__currentDefaultPath); }
+        else { throw new Error("Attempted to apply path command to node " + this.__currentElement.nodeName); }
+    };
+    ctx.prototype.__addPathCommand = function(command) { this.__currentDefaultPath += " "; this.__currentDefaultPath += command; };
+
+    ctx.prototype.moveTo = function(x,y) { if(this.__currentElement.nodeName !== "path"){this.beginPath();} this.__currentPosition={x:x,y:y}; this.__addPathCommand(format("M {x} {y}",{x:x,y:y})); };
+    ctx.prototype.closePath = function() { this.__addPathCommand("Z"); };
+    ctx.prototype.lineTo = function(x,y) { this.__currentPosition={x:x,y:y}; if(this.__currentDefaultPath.indexOf('M')>-1){this.__addPathCommand(format("L {x} {y}",{x:x,y:y}));}else{this.__addPathCommand(format("M {x} {y}",{x:x,y:y}));} };
+    ctx.prototype.bezierCurveTo = function(cp1x,cp1y,cp2x,cp2y,x,y) { this.__currentPosition={x:x,y:y}; this.__addPathCommand(format("C {cp1x} {cp1y} {cp2x} {cp2y} {x} {y}",{cp1x:cp1x,cp1y:cp1y,cp2x:cp2x,cp2y:cp2y,x:x,y:y})); };
+    ctx.prototype.quadraticCurveTo = function(cpx,cpy,x,y) { this.__currentPosition={x:x,y:y}; this.__addPathCommand(format("Q {cpx} {cpy} {x} {y}",{cpx:cpx,cpy:cpy,x:x,y:y})); };
+
+    ctx.prototype.stroke = function() {
+        if(this.__currentElement.nodeName==="path"){this.__currentElement.setAttribute("paint-order","fill stroke markers");}
+        this.__applyCurrentDefaultPath(); this.__applyStyleToCurrentElement("stroke");
+    };
+    ctx.prototype.fill = function() {
+        if(this.__currentElement.nodeName==="path"){this.__currentElement.setAttribute("paint-order","stroke fill markers");}
+        this.__applyCurrentDefaultPath(); this.__applyStyleToCurrentElement("fill");
+    };
+    ctx.prototype.rect = function(x,y,width,height) { if(this.__currentElement.nodeName!=="path"){this.beginPath();} this.moveTo(x,y); this.lineTo(x+width,y); this.lineTo(x+width,y+height); this.lineTo(x,y+height); this.lineTo(x,y); this.closePath(); };
+
+    ctx.prototype.fillRect = function(x, y, width, height) {
+        var rect, parent;
+        rect = this.__createElement("rect",{x:x,y:y,width:width,height:height},true);
+        parent = this.__closestGroupOrSvg(); parent.appendChild(rect);
+        this.__currentElement = rect; this.__applyStyleToCurrentElement("fill");
+    };
+    ctx.prototype.strokeRect = function(x, y, width, height) {
+        var rect, parent;
+        rect = this.__createElement("rect",{x:x,y:y,width:width,height:height},true);
+        parent = this.__closestGroupOrSvg(); parent.appendChild(rect);
+        this.__currentElement = rect; this.__applyStyleToCurrentElement("stroke");
+    };
+    ctx.prototype.clearRect = function(x, y, width, height) {
+        var rect, parent = this.__closestGroupOrSvg();
+        rect = this.__createElement("rect",{x:x,y:y,width:width,height:height,fill:"#FFFFFF"},true);
+        parent.appendChild(rect);
+    };
+
+    ctx.prototype.createLinearGradient = function(x1,y1,x2,y2) {
+        var grad = this.__createElement("linearGradient",{id:randomString(this.__ids),x1:x1+"px",x2:x2+"px",y1:y1+"px",y2:y2+"px","gradientUnits":"userSpaceOnUse"},false);
+        this.__defs.appendChild(grad); return new CanvasGradient(grad, this);
+    };
+    ctx.prototype.createRadialGradient = function(x0,y0,r0,x1,y1,r1) {
+        var grad = this.__createElement("radialGradient",{id:randomString(this.__ids),cx:x1+"px",cy:y1+"px",r:r1+"px",fx:x0+"px",fy:y0+"px","gradientUnits":"userSpaceOnUse"},false);
+        this.__defs.appendChild(grad); return new CanvasGradient(grad, this);
+    };
+
+    ctx.prototype.__parseFont = function() {
+        var regex = /^\s*(?=(?:(?:[-a-z]+\s*){0,2}(italic|oblique))?)(?=(?:(?:[-a-z]+\s*){0,2}(small-caps))?)(?=(?:(?:[-a-z]+\s*){0,2}(bold(?:er)?|lighter|[1-9]00))?)(?:(?:normal|\1|\2|\3)\s*){0,3}((?:xx?-)?(?:small|large)|medium|smaller|larger|[.\d]+(?:\%|in|[cem]m|ex|p[ctx]))(?:\s*\/\s*(normal|[.\d]+(?:\%|in|[cem]m|ex|p[ctx])))?\s*([-,\"\sa-z]+?)\s*$/i;
+        var fontPart = regex.exec(this.font);
+        var data = { style:fontPart[1]||'normal', size:fontPart[4]||'10px', family:fontPart[6]||'sans-serif', weight:fontPart[3]||'normal', decoration:fontPart[2]||'normal', href:null };
+        if(this.__fontUnderline==="underline"){data.decoration="underline";}
+        if(this.__fontHref){data.href=this.__fontHref;}
+        return data;
+    };
+    ctx.prototype.__wrapTextLink = function(font, element) { if(font.href){var a=this.__createElement("a"); a.setAttributeNS("http://www.w3.org/1999/xlink","xlink:href",font.href); a.appendChild(element); return a;} return element; };
+    ctx.prototype.__applyText = function(text, x, y, action) {
+        var font = this.__parseFont(), parent = this.__closestGroupOrSvg(),
+            textElement = this.__createElement("text",{"font-family":font.family,"font-size":font.size,"font-style":font.style,"font-weight":font.weight,"text-decoration":font.decoration,"x":x,"y":y,"text-anchor":getTextAnchor(this.textAlign),"dominant-baseline":getDominantBaseline(this.textBaseline)},true);
+        textElement.appendChild(this.__document.createTextNode(text));
+        this.__currentElement = textElement; this.__applyStyleToCurrentElement(action);
+        parent.appendChild(this.__wrapTextLink(font,textElement));
+    };
+    ctx.prototype.fillText = function(text, x, y) { this.__applyText(text, x, y, "fill"); };
+    ctx.prototype.strokeText = function(text, x, y) { this.__applyText(text, x, y, "stroke"); };
+    ctx.prototype.measureText = function(text) { this.__ctx.font = this.font; return this.__ctx.measureText(text); };
+
+    ctx.prototype.arc = function(x, y, radius, startAngle, endAngle, counterClockwise) {
+        if(startAngle===endAngle){return;} startAngle=startAngle%(2*Math.PI); endAngle=endAngle%(2*Math.PI);
+        if(startAngle===endAngle){endAngle=((endAngle+(2*Math.PI))-0.001*(counterClockwise?-1:1))%(2*Math.PI);}
+        var endX=x+radius*Math.cos(endAngle),endY=y+radius*Math.sin(endAngle),startX=x+radius*Math.cos(startAngle),startY=y+radius*Math.sin(startAngle),sweepFlag=counterClockwise?0:1,largeArcFlag=0,diff=endAngle-startAngle;
+        if(diff<0){diff+=2*Math.PI;} if(counterClockwise){largeArcFlag=diff>Math.PI?0:1;}else{largeArcFlag=diff>Math.PI?1:0;}
+        this.lineTo(startX, startY);
+        this.__addPathCommand(format("A {rx} {ry} {xAxisRotation} {largeArcFlag} {sweepFlag} {endX} {endY}",{rx:radius,ry:radius,xAxisRotation:0,largeArcFlag:largeArcFlag,sweepFlag:sweepFlag,endX:endX,endY:endY}));
+        this.__currentPosition = {x:endX, y:endY};
+    };
+
+    ctx.prototype.clip = function() {
+        var group=this.__closestGroupOrSvg(),clipPath=this.__createElement("clipPath"),id=randomString(this.__ids),newGroup=this.__createElement("g");
+        group.removeChild(this.__currentElement); clipPath.setAttribute("id",id); clipPath.appendChild(this.__currentElement);
+        this.__defs.appendChild(clipPath); group.setAttribute("clip-path",format("url(#{id})",{id:id})); group.appendChild(newGroup); this.__currentElement=newGroup;
+    };
+
+    ctx.prototype.drawImage = function() {
+        var args=Array.prototype.slice.call(arguments),image=args[0],dx,dy,dw,dh,sx=0,sy=0,sw,sh,parent,svg,defs,group,currentElement,svgImage,canvas,context,id;
+        if(args.length===3){dx=args[1];dy=args[2];sw=image.width;sh=image.height;dw=sw;dh=sh;}
+        else if(args.length===5){dx=args[1];dy=args[2];dw=args[3];dh=args[4];sw=image.width;sh=image.height;}
+        else if(args.length===9){sx=args[1];sy=args[2];sw=args[3];sh=args[4];dx=args[5];dy=args[6];dw=args[7];dh=args[8];}
+        else{throw new Error("Invalid number of arguments passed to drawImage: "+arguments.length);}
+
+        parent = this.__closestGroupOrSvg(); currentElement = this.__currentElement;
+        if(image instanceof ctx) {
+            svg=image.getSvg(); defs=svg.childNodes[0];
+            while(defs.childNodes.length){id=defs.childNodes[0].getAttribute("id");this.__ids[id]=id;this.__defs.appendChild(defs.childNodes[0]);}
+            group=svg.childNodes[1]; parent.appendChild(group); this.__currentElement=group; this.translate(dx,dy); this.__currentElement=currentElement;
+        } else if(image.nodeName==="CANVAS"||image.nodeName==="IMG") {
+            svgImage = this.__createElement("image");
+            svgImage.setAttribute("width", dw); svgImage.setAttribute("height", dh);
+            svgImage.setAttribute("preserveAspectRatio", "none");
+            if(sx||sy||sw!==image.width||sh!==image.height) {
+                canvas=this.__document.createElement("canvas"); canvas.width=dw; canvas.height=dh;
+                context=canvas.getContext("2d"); context.drawImage(image,sx,sy,sw,sh,0,0,dw,dh); image=canvas;
+            }
+            svgImage.setAttributeNS("http://www.w3.org/1999/xlink","xlink:href",image.nodeName==="CANVAS"?image.toDataURL():image.getAttribute("src"));
+            parent.appendChild(svgImage); this.__currentElement=svgImage; this.translate(dx,dy); this.__currentElement=currentElement;
+        }
+    };
+
+    ctx.prototype.createPattern = function(image, repetition) {
+        var pattern=this.__document.createElementNS("http://www.w3.org/2000/svg","pattern"),id=randomString(this.__ids),img;
+        pattern.setAttribute("id",id); pattern.setAttribute("width",image.width); pattern.setAttribute("height",image.height);
+        if(image.nodeName==="CANVAS"||image.nodeName==="IMG") {
+            img=this.__document.createElementNS("http://www.w3.org/2000/svg","image"); img.setAttribute("width",image.width); img.setAttribute("height",image.height);
+            img.setAttributeNS("http://www.w3.org/1999/xlink","xlink:href",image.nodeName==="CANVAS"?image.toDataURL():image.getAttribute("src"));
+            pattern.appendChild(img); this.__defs.appendChild(pattern);
+        } else if(image instanceof ctx) { pattern.appendChild(image.__root.childNodes[1]); this.__defs.appendChild(pattern); }
+        return new CanvasPattern(pattern, this);
+    };
+
+    ctx.prototype.drawFocusRing = function(){};
+    ctx.prototype.createImageData = function(){};
+    ctx.prototype.getImageData = function(){};
+    ctx.prototype.putImageData = function(){};
+    ctx.prototype.globalCompositeOperation = function(){};
+
+    // Patched: imageSmoothingEnabled property (no-op for SVG)
+    Object.defineProperty(ctx.prototype, 'imageSmoothingEnabled', {
+        get: function() { return this._imageSmoothingEnabled || false; },
+        set: function(val) { this._imageSmoothingEnabled = val; }
+    });
+
+    if (typeof window === "object") { window.C2S = ctx; }
+    if (typeof module === "object" && typeof module.exports === "object") { module.exports = ctx; }
+}());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.67",
+  "version": "0.4.68",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.68",
+  "version": "0.4.69",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.67"
+version = "0.4.68"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.68"
+version = "0.4.69"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Add 📷 button in toolbar to export the entire UI as a single SVG file
- **Canvas office scene** → pure vector SVG via canvas2svg (C2S library). All fillRect, drawImage, fillText calls become SVG `<rect>`, `<image>`, `<text>` elements
- **HTML panels** (Projects, Team Roster, Activity Log, CEO Console, toolbar) → `<foreignObject>` with inline CSS styles
- Skip scanlines/minimap/tooltip during SVG export for clean output

## Files
| File | Change |
|------|--------|
| `frontend/vendor/canvas2svg.js` | Vendored canvas2svg lib (MIT), patched `setTransform()` + `imageSmoothingEnabled` |
| `frontend/screenshot.js` | `exportSVG()` function: C2S render + foreignObject assembly + download |
| `frontend/office.js` | `render()` detects C2S context, skips screen-space effects |
| `frontend/index.html` | Camera button + script tags |

## How it works
1. Click 📷 in toolbar
2. Temporarily swap `renderer.ctx` with a C2S (SVG) context, set dpr=1
3. Call `renderer.render()` which replays all drawing calls into SVG
4. Serialize HTML panels as foreignObject
5. Compose into single SVG with embedded styles
6. Trigger browser download as `onemancompany-{timestamp}.svg`

## Test plan
- [x] 2364 unit tests pass (pre-commit hook)
- [ ] Manual: click button, verify SVG downloads
- [ ] Manual: open SVG in browser/Illustrator, verify canvas is vector

🤖 Generated with [Claude Code](https://claude.com/claude-code)