### PR TITLE
feat: model dropdown for all providers in Settings + onboarding

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5445,9 +5445,9 @@ class AppController {
               </div>
               <div style="margin-top:6px;border-top:1px solid var(--border);padding-top:6px;">
                 <label class="api-field-label">Default Model</label>
-                <input type="text" id="api-${providerId}-model" class="api-key-input" style="font-size:6px;"
-                  placeholder="${isDefault ? (defaultModel || 'e.g. gpt-4o') : 'e.g. deepseek-chat'}"
-                  value="${isDefault ? this._escAttr(defaultModel) : ''}" />
+                <select id="api-${providerId}-model" class="emp-model-select" style="font-size:6px;width:100%;padding:3px 4px;background:var(--bg-dark);color:var(--pixel-green);border:1px solid var(--border);">
+                  ${isDefault && defaultModel ? `<option value="${this._escAttr(defaultModel)}" selected>${this._escAttr(defaultModel)}</option>` : '<option value="">Select model...</option>'}
+                </select>
                 <div class="api-card-actions" style="margin-top:4px;">
                   <button class="pixel-btn small${isDefault ? '' : ' api-test-btn'}" onclick="app._setDefaultProvider('${providerId}')"
                     ${!isConfigured ? 'disabled title="Save API key first"' : ''}>${isDefault ? '✓ Default' : 'Set as Default'}</button>
@@ -5508,13 +5508,19 @@ class AppController {
       `;
 
       container.innerHTML = html;
-      // Bind toggle for provider cards
+      // Bind toggle for provider cards + lazy-load models on expand
       container.querySelectorAll('.api-card-toggle').forEach(hdr => {
         hdr.addEventListener('click', () => {
           const body = document.getElementById(hdr.dataset.target);
           if (body) {
+            const wasCollapsed = body.classList.contains('collapsed');
             hdr.classList.toggle('collapsed');
             body.classList.toggle('collapsed');
+            // Load models when expanding a configured provider
+            if (wasCollapsed) {
+              const providerId = hdr.dataset.target.replace('api-', '').replace('-body', '');
+              this._loadProviderModels(providerId);
+            }
           }
         });
       });
@@ -5632,6 +5638,41 @@ class AppController {
       }
     } catch (e) {
       if (resultEl) { resultEl.textContent = 'Error'; resultEl.className = 'api-test-result fail'; }
+    }
+  }
+
+  async _loadProviderModels(providerId) {
+    const select = document.getElementById(`api-${providerId}-model`);
+    if (!select || select.dataset.loaded) return;
+
+    const currentValue = select.value;
+    select.innerHTML = '<option value="">Loading models...</option>';
+
+    try {
+      const resp = await fetch(`/api/models/${providerId}`);
+      const data = await resp.json();
+      if (data.models && data.models.length > 0) {
+        let html = '<option value="">Select model...</option>';
+        for (const m of data.models) {
+          const selected = m.id === currentValue ? ' selected' : '';
+          const label = m.name && m.name !== m.id ? `${m.id}  (${m.name})` : m.id;
+          html += `<option value="${this._escAttr(m.id)}"${selected}>${this._escAttr(label)}</option>`;
+        }
+        select.innerHTML = html;
+        select.dataset.loaded = '1';
+      } else {
+        // No models or error — fall back to editable input
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.id = select.id;
+        input.className = 'api-key-input';
+        input.style.cssText = 'font-size:6px;';
+        input.placeholder = data.error || 'Enter model ID...';
+        input.value = currentValue;
+        select.replaceWith(input);
+      }
+    } catch {
+      select.innerHTML = `<option value="${this._escAttr(currentValue)}">${currentValue || 'Error loading'}</option>`;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-
-  "version": "0.4.74",
+  "version": "0.4.73",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.73",
+  "version": "0.4.76",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.73"
+version = "0.4.76"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [project]
 name = "onemancompany"
-
-version = "0.4.74"
+version = "0.4.73"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -1307,32 +1307,78 @@ async def update_workflow(name: str, body: dict):
 
 @router.get("/api/models")
 async def list_available_models() -> dict:
-    """Fetch available models from OpenRouter API."""
+    """Fetch available models from OpenRouter API (legacy endpoint)."""
+    return await list_provider_models("openrouter")
+
+
+@router.get("/api/models/{provider}")
+async def list_provider_models(provider: str) -> dict:
+    """Fetch available models for any registered provider."""
     import httpx
 
-    from onemancompany.core.config import settings
+    from onemancompany.core.config import PROVIDER_REGISTRY, get_provider, settings
+
+    prov_cfg = get_provider(provider)
+    if not prov_cfg:
+        return {"models": [], "error": f"Unknown provider '{provider}'"}
+
+    # Determine models URL: base_url/models for most, health_url for anthropic/google
+    if prov_cfg.base_url:
+        models_url = f"{prov_cfg.base_url.rstrip('/')}/models"
+    elif prov_cfg.health_url and "/models" in prov_cfg.health_url:
+        models_url = prov_cfg.health_url
+    else:
+        return {"models": [], "error": f"No models endpoint for '{provider}'"}
+
+    # Get API key
+    api_key = getattr(settings, prov_cfg.env_key, "") if prov_cfg.env_key else ""
+    if not api_key:
+        return {"models": [], "error": "No API key configured"}
+
+    # Build auth
+    headers: dict[str, str] = {}
+    params: dict[str, str] = {}
+    if prov_cfg.health_auth == "anthropic":
+        headers["x-api-key"] = api_key
+        headers["anthropic-version"] = "2023-06-01"
+    elif prov_cfg.health_auth == "query_param":
+        params["key"] = api_key
+    else:
+        headers["Authorization"] = f"Bearer {api_key}"
 
     try:
-        async with httpx.AsyncClient(follow_redirects=True) as client:
-            resp = await client.get(
-                f"{settings.openrouter_base_url}/models",
-                headers={"Authorization": f"Bearer {settings.openrouter_api_key}"},
-                timeout=10.0,
-            )
-            if resp.status_code == 200:
-                data = resp.json()
-                models = [
-                    {
-                        "id": m["id"],
-                        "name": m.get("name", m["id"]),
-                        "context_length": m.get("context_length", 0),
-                    }
-                    for m in data.get("data", [])
-                ]
-                return {"models": models}
-            return {"models": [], "error": f"OpenRouter returned {resp.status_code}"}
+        async with httpx.AsyncClient(follow_redirects=True, timeout=15.0) as client:
+            resp = await client.get(models_url, headers=headers, params=params)
+            if resp.status_code != 200:
+                return {"models": [], "error": f"HTTP {resp.status_code}"}
+
+            data = resp.json()
+
+            # Normalize response — handle different API formats
+            raw_models: list[dict] = []
+            if "data" in data:
+                # OpenAI-compatible + Anthropic format
+                raw_models = data["data"]
+            elif "models" in data:
+                # Google format
+                raw_models = data["models"]
+
+            models = []
+            for m in raw_models:
+                # Google uses "name": "models/gemini-..." and "displayName"
+                model_id = m.get("id") or m.get("name", "")
+                if model_id.startswith("models/"):
+                    model_id = model_id[len("models/"):]
+                display_name = m.get("display_name") or m.get("displayName") or m.get("name") or model_id
+                models.append({
+                    "id": model_id,
+                    "name": display_name,
+                })
+
+            models.sort(key=lambda x: x["id"])
+            return {"models": models}
     except Exception as e:
-        return {"models": [], "error": str(e)}
+        return {"models": [], "error": str(e)[:200]}
 
 
 @router.get("/api/employee/{employee_id}")

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -1316,7 +1316,7 @@ async def list_provider_models(provider: str) -> dict:
     """Fetch available models for any registered provider."""
     import httpx
 
-    from onemancompany.core.config import PROVIDER_REGISTRY, get_provider, settings
+    from onemancompany.core.config import get_provider, settings
 
     prov_cfg = get_provider(provider)
     if not prov_cfg:

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -172,31 +172,73 @@ def _format_price(price_str: str | None) -> str:
         return PRICE_NA
 
 
-def _fetch_openrouter_models(console: Console) -> list[dict]:
-    """Fetch model list from OpenRouter API. Returns list of model dicts."""
-    with console.status("  Fetching models from OpenRouter..."):
+def _fetch_provider_models(console: Console, provider: str, api_key: str) -> list[dict]:
+    """Fetch model list from any provider's /models endpoint.
+
+    Returns list of dicts with keys: id, name.
+    Falls back to empty list on failure.
+    """
+    from onemancompany.core.config import get_provider
+
+    prov_cfg = get_provider(provider)
+    if not prov_cfg:
+        return []
+
+    # Determine models URL
+    if prov_cfg.base_url:
+        models_url = f"{prov_cfg.base_url.rstrip('/')}/models"
+    elif prov_cfg.health_url and "/models" in prov_cfg.health_url:
+        models_url = prov_cfg.health_url
+    else:
+        return []
+
+    # Build auth
+    headers: dict[str, str] = {}
+    params: dict[str, str] = {}
+    if prov_cfg.health_auth == "anthropic":
+        headers["x-api-key"] = api_key
+        headers["anthropic-version"] = "2023-06-01"
+    elif prov_cfg.health_auth == "query_param":
+        params["key"] = api_key
+    else:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    label = provider.capitalize()
+    with console.status(f"  Fetching models from {label}..."):
         try:
-            resp = httpx.get(OPENROUTER_MODELS_URL, timeout=15)
+            resp = httpx.get(models_url, headers=headers, params=params, timeout=15)
             resp.raise_for_status()
-            data = resp.json().get(OR_FIELD_DATA, [])
+            data = resp.json()
         except Exception as e:
-            console.print(f"  [yellow]⚠[/yellow] Failed to fetch models: {e}")
+            console.print(f"  [yellow]⚠[/yellow] Failed to fetch models from {label}: {e}")
             return []
 
+    # Normalize response formats
+    raw: list[dict] = data.get("data", []) or data.get("models", [])
     models = []
-    for m in data:
-        model_id = m.get(OR_FIELD_ID, "")
+    for m in raw:
+        model_id = m.get("id") or m.get("name", "")
+        if model_id.startswith("models/"):
+            model_id = model_id[len("models/"):]
+        display_name = m.get("display_name") or m.get("displayName") or model_id
+        # For OpenRouter, include pricing
         pricing = m.get(OR_FIELD_PRICING, {}) or {}
         models.append({
             MODEL_KEY_ID: model_id,
-            MODEL_KEY_NAME: m.get(OR_FIELD_NAME, model_id),
-            MODEL_KEY_PROMPT_PRICE: _format_price(pricing.get(OR_FIELD_PROMPT)),
-            MODEL_KEY_COMPLETION_PRICE: _format_price(pricing.get(OR_FIELD_COMPLETION)),
-            MODEL_KEY_CONTEXT: m.get(OR_FIELD_CONTEXT_LENGTH, 0),
+            MODEL_KEY_NAME: display_name,
+            MODEL_KEY_PROMPT_PRICE: _format_price(pricing.get(OR_FIELD_PROMPT)) if pricing else "",
+            MODEL_KEY_COMPLETION_PRICE: _format_price(pricing.get(OR_FIELD_COMPLETION)) if pricing else "",
+            MODEL_KEY_CONTEXT: m.get(OR_FIELD_CONTEXT_LENGTH) or m.get("context_length") or 0,
         })
 
     models.sort(key=lambda m: m[MODEL_KEY_ID])
     return models
+
+
+def _fetch_openrouter_models(console: Console) -> list[dict]:
+    """Fetch model list from OpenRouter API. Returns list of model dicts."""
+    # Delegate to generic fetcher (no API key needed for OpenRouter model list)
+    return _fetch_provider_models(console, "openrouter", "")
 
 
 def _print_model_page(
@@ -356,18 +398,17 @@ def _step_llm(console: Console) -> tuple[str, str, str, str]:
             style=INQ_STYLE,
         ).execute().strip()
 
-    # 4. Select model
+    # 4. Select model — try fetching from provider, fall back to manual input
     console.print()
-    if provider == PROVIDER_OPENROUTER:
-        all_models = _fetch_openrouter_models(console)
-        if all_models:
-            console.print(f"  [green]✔[/green] Found {len(all_models)} models")
+    all_models = _fetch_provider_models(console, provider, api_key)
+    if all_models:
+        console.print(f"  [green]✔[/green] Found {len(all_models)} models")
         model = _select_model_interactive(console, all_models)
     else:
-        # For non-OpenRouter providers, ask for model ID directly
+        # Fetch failed — fall back to manual input with known defaults
         default_model = PROVIDER_DEFAULT_MODELS.get(provider, "")
         model = _inq.text(
-            message=f"Model ID:",
+            message="Model ID:",
             default=default_model,
             style=INQ_STYLE,
         ).execute().strip()

--- a/tests/unit/agents/test_settings_api_key.py
+++ b/tests/unit/agents/test_settings_api_key.py
@@ -183,3 +183,83 @@ def test_sync_founding_defaults_skips_unchanged(tmp_path):
         count = sync_founding_defaults(provider="openrouter", model="gpt-4")
 
     assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Provider model list endpoint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_provider_models_returns_normalized_list():
+    """GET /api/models/{provider} returns normalized model list for any provider."""
+    from onemancompany.api.routes import list_provider_models
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "data": [
+            {"id": "deepseek-chat", "object": "model"},
+            {"id": "deepseek-coder", "object": "model"},
+        ]
+    }
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=mock_resp)
+
+    mock_settings = MagicMock()
+    mock_settings.deepseek_api_key = "sk-test"
+
+    mock_httpx = MagicMock()
+    mock_httpx.AsyncClient = MagicMock(return_value=mock_client)
+
+    with patch.dict("sys.modules", {"httpx": mock_httpx}), \
+         patch("onemancompany.core.config.settings", mock_settings):
+        result = await list_provider_models("deepseek")
+
+    assert len(result["models"]) == 2
+    assert result["models"][0]["id"] == "deepseek-chat"
+
+
+@pytest.mark.asyncio
+async def test_list_provider_models_google_format():
+    """Google returns {models: [{name: 'models/gemini-...', displayName: ...}]}."""
+    from onemancompany.api.routes import list_provider_models
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {
+        "models": [
+            {"name": "models/gemini-2.0-flash", "displayName": "Gemini 2.0 Flash"},
+        ]
+    }
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=mock_resp)
+
+    mock_settings = MagicMock()
+    mock_settings.google_api_key = "test-key"
+
+    mock_httpx = MagicMock()
+    mock_httpx.AsyncClient = MagicMock(return_value=mock_client)
+
+    with patch.dict("sys.modules", {"httpx": mock_httpx}), \
+         patch("onemancompany.core.config.settings", mock_settings):
+        result = await list_provider_models("google")
+
+    assert len(result["models"]) == 1
+    assert result["models"][0]["id"] == "gemini-2.0-flash"  # models/ prefix stripped
+    assert result["models"][0]["name"] == "Gemini 2.0 Flash"
+
+
+@pytest.mark.asyncio
+async def test_list_provider_models_unknown_provider():
+    """Unknown provider returns empty list with error."""
+    from onemancompany.api.routes import list_provider_models
+    result = await list_provider_models("nonexistent")
+    assert result["models"] == []
+    assert "error" in result


### PR DESCRIPTION
## Summary
- **Settings Default Model**: 文本输入改为 `<select>` 下拉，展开 provider 卡片时自动从 `/api/models/{provider}` 拉取模型列表。获取失败时自动 fallback 为文本输入。
- **Backend**: 新增 `GET /api/models/{provider}` 端点，支持所有注册 provider 的 `/models` 接口，自动处理 OpenAI 兼容格式、Anthropic 格式、Google 格式的响应归一化。
- **Onboarding**: 所有 provider 都走交互式 fuzzy 模型选择（不再只有 OpenRouter），获取失败时 fallback 为手动输入 + 默认值。

## Test plan
- [x] `test_list_provider_models_returns_normalized_list` — DeepSeek 格式
- [x] `test_list_provider_models_google_format` — Google `models/` 前缀剥离 + displayName
- [x] `test_list_provider_models_unknown_provider` — 未知 provider 返回错误
- [x] Full suite: 2374 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)