### PR TITLE
fix: CLI banner shows actual app version from pyproject.toml

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -285,21 +285,12 @@ ${green("What gets installed automatically:")}
     return;
   }
 
-  // Read version from package.json (bundled with npm package)
+  // Read version from package.json (bundled with npm package) as fallback
   let cliVersion = "unknown";
   try {
     const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf-8"));
     if (pkg.version) cliVersion = pkg.version;
   } catch {}
-
-  console.log();
-  const verTag = `v${cliVersion}`;
-  const title = `OneManCompany — AI Company OS ${verTag}`;
-  const pad = Math.max(0, 44 - title.length);
-  console.log(cyan("╔═══════════════════════════════════════════════╗"));
-  console.log(cyan(`║   ${title}${" ".repeat(pad)}║`));
-  console.log(cyan("╚═══════════════════════════════════════════════╝"));
-  console.log();
 
   // ── Check git ─────────────────────────────────────────────────────────
   if (!commandExists("git")) {
@@ -358,6 +349,16 @@ ${green("What gets installed automatically:")}
     const verMatch = pyproject.match(/^version\s*=\s*"([^"]+)"/m);
     if (verMatch) appVersion = verMatch[1];
   } catch {}
+
+  // ── Banner (after real version is known) ───────────────────────────
+  console.log();
+  const verTag = `v${appVersion}`;
+  const title = `OneManCompany — AI Company OS ${verTag}`;
+  const pad = Math.max(0, 44 - title.length);
+  console.log(cyan("╔═══════════════════════════════════════════════╗"));
+  console.log(cyan(`║   ${title}${" ".repeat(pad)}║`));
+  console.log(cyan("╚═══════════════════════════════════════════════╝"));
+  console.log();
 
   // ── Check if already running ─────────────────────────────────────────
   const existingPid = readPidFile(installDir);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.77",
+  "version": "0.4.78",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.77"
+version = "0.4.78"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
CLI banner 之前用 package.json 的 npm 包版本（`cliVersion`），而实际 app 版本来自 pyproject.toml（`appVersion`）。两个版本各自 bump，导致用户看到的版本号和 server 启动时显示的不一致。

Fix: 把 banner 打印移到读取 pyproject.toml 之后，用 `appVersion` 显示。

## Test plan
- [x] Full suite: 2374 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)