### PR TITLE
fix: inject employee_id at proxy level, strip from LLM schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.79",
+  "version": "0.4.80",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.79"
+version = "0.4.80"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/tool_registry.py
+++ b/src/onemancompany/core/tool_registry.py
@@ -238,21 +238,33 @@ class ToolRegistry:
         for both LangChain agents and Claude CLI agents.
         """
         from langchain_core.tools import StructuredTool
+        from pydantic import create_model
 
         direct_tools = self.get_tools_for(employee_id)
         proxied = []
         for tool in direct_tools:
             tool_name = tool.name
 
-            # Build async wrapper that calls execute_tool
+            # Inject employee_id at system level — LLM should never fill this
             async def _proxy(emp_id=employee_id, tname=tool_name, **kwargs):
+                kwargs["employee_id"] = emp_id
                 return await execute_tool(emp_id, tname, kwargs)
+
+            # Strip employee_id from schema so LLM never sees it
+            schema = getattr(tool, "args_schema", None)
+            if schema and "employee_id" in schema.model_fields:
+                fields = {
+                    k: (v.annotation, v)
+                    for k, v in schema.model_fields.items()
+                    if k != "employee_id"
+                }
+                schema = create_model(schema.__name__, **fields)
 
             wrapper = StructuredTool.from_function(
                 coroutine=_proxy,
                 name=tool.name,
                 description=tool.description,
-                args_schema=tool.args_schema if hasattr(tool, "args_schema") else None,
+                args_schema=schema,
             )
             proxied.append(wrapper)
         return proxied

--- a/tests/unit/core/test_tool_registry.py
+++ b/tests/unit/core/test_tool_registry.py
@@ -522,6 +522,59 @@ class TestExecuteToolEmployeeIdAutoFill:
         assert mock_tool.ainvoke.call_args[0][0]["employee_id"] == "00004"
 
 
+# ---------------------------------------------------------------------------
+# Proxied tools — employee_id injection + schema stripping
+# ---------------------------------------------------------------------------
+
+class TestProxiedToolsEmployeeId:
+    """Proxied tools inject employee_id at system level, hidden from LLM."""
+
+    def test_schema_strips_employee_id(self):
+        from onemancompany.core.tool_registry import ToolRegistry, ToolMeta
+        from langchain_core.tools import tool as lc_tool
+
+        @lc_tool
+        def my_tool(name: str, employee_id: str = "") -> dict:
+            """A test tool."""
+            return {}
+
+        reg = ToolRegistry()
+        reg.register(my_tool, ToolMeta(name="my_tool", category="base"))
+
+        with patch("onemancompany.core.store.load_employee", return_value={"role": "EA"}):
+            proxied = reg.get_proxied_tools_for("00004")
+
+        field_names = list(proxied[0].args_schema.model_fields.keys())
+        assert "employee_id" not in field_names
+        assert "name" in field_names
+
+    @pytest.mark.asyncio
+    async def test_proxy_injects_employee_id(self):
+        from onemancompany.core.tool_registry import ToolRegistry, ToolMeta, tool_registry
+        from langchain_core.tools import tool as lc_tool
+
+        captured = {}
+
+        @lc_tool
+        async def my_tool(name: str, employee_id: str = "") -> dict:
+            """A test tool."""
+            captured["employee_id"] = employee_id
+            return {"status": "ok"}
+
+        reg = ToolRegistry()
+        reg.register(my_tool, ToolMeta(name="my_tool", category="base"))
+
+        with patch("onemancompany.core.store.load_employee", return_value={"role": "EA"}):
+            proxied = reg.get_proxied_tools_for("00004")
+
+        # Simulate LLM calling the tool WITHOUT employee_id
+        with patch("onemancompany.core.tool_registry.tool_registry", reg):
+            with patch("onemancompany.core.vessel._current_vessel"):
+                await proxied[0].ainvoke({"name": "test"})
+
+        assert captured["employee_id"] == "00004"
+
+
 class TestModuleSingleton:
     def test_singleton_exists(self):
         from onemancompany.core.tool_registry import tool_registry


### PR DESCRIPTION
## Summary
employee_id is a system concern. LLM should never see or fill it.

- `_proxy` wrapper now force-sets `kwargs["employee_id"] = emp_id`
- `args_schema` rebuilt via `pydantic.create_model` without employee_id field
- LLM never sees the parameter, can't forget or hallucinate it
- `execute_tool` auto-fill remains as defense-in-depth for MCP/CLI path

## Root Cause
Previous fix (PR #282) added auto-fill in `execute_tool`, but LLM often omitted the key entirely from args, so `"employee_id" in args` never triggered. The real fix is to not expose it to the LLM at all.

## Test plan
- [x] 2380 unit tests pass
- [x] New test: schema strips employee_id from LLM-visible fields
- [x] New test: proxy injects employee_id when LLM doesn't provide it

🤖 Generated with [Claude Code](https://claude.com/claude-code)