### PR TITLE
fix: enable autoload for proactive-agent, self-improving-agent, ontology

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.83",
+  "version": "0.4.84",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.83"
+version = "0.4.84"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -623,12 +623,25 @@ async def clone_talent_repo(repo_url: str, talent_id: str) -> Path:
 
 
 def _inject_default_skills(skills_dir: Path) -> None:
-    """Copy default skills into the employee's skills folder."""
+    """Copy/update default skills into the employee's skills folder.
+
+    Always overwrites SKILL.md from the source to pick up frontmatter
+    changes (e.g. autoload flag). Preserves employee-specific files
+    in the skill directory that don't exist in the source.
+    """
     for name in _DEFAULT_SKILL_NAMES:
         src = _DEFAULT_SKILLS_DIR / name
+        if not src.exists():
+            continue
         dst = skills_dir / name
-        if src.exists() and not dst.exists():
+        if not dst.exists():
             shutil.copytree(str(src), str(dst))
+        else:
+            # Sync SKILL.md from source to pick up changes
+            src_md = src / "SKILL.md"
+            dst_md = dst / "SKILL.md"
+            if src_md.exists():
+                shutil.copy2(str(src_md), str(dst_md))
 
 
 def _assign_default_avatar(emp_dir: Path, emp_num: str) -> None:

--- a/src/onemancompany/default_skills/ontology/SKILL.md
+++ b/src/onemancompany/default_skills/ontology/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ontology
 description: Typed knowledge graph for structured agent memory and composable skills. Use when creating/querying entities (Person, Project, Task, Event, Document), linking related objects, enforcing constraints, planning multi-step actions as graph transformations, or when skills need to share state. Trigger on "remember", "what do I know about", "link X to Y", "show dependencies", entity CRUD, or cross-skill data access.
+autoload: true
 ---
 
 # Ontology

--- a/src/onemancompany/default_skills/proactive-agent/SKILL.md
+++ b/src/onemancompany/default_skills/proactive-agent/SKILL.md
@@ -3,6 +3,7 @@ name: proactive-agent
 version: 3.0.0
 description: "Transform AI agents from task-followers into proactive partners that anticipate needs and continuously improve. Now with WAL Protocol, Working Buffer for context survival, Compaction Recovery, and battle-tested security patterns. Part of the Hal Stack 🦞"
 author: halthelobster
+autoload: true
 ---
 
 # Proactive Agent 🦞

--- a/src/onemancompany/default_skills/self-improving-agent/SKILL.md
+++ b/src/onemancompany/default_skills/self-improving-agent/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: self-improving-agent
 description: A universal self-improving agent that learns from ALL skill experiences. Uses multi-memory architecture (semantic + episodic + working) to continuously evolve the codebase. Auto-triggers on skill completion/error with hooks-based self-correction.
+autoload: true
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch
 metadata:
   hooks:

--- a/src/onemancompany/main.py
+++ b/src/onemancompany/main.py
@@ -501,6 +501,14 @@ async def lifespan(app: FastAPI):
         register_founding_employee(_fid, _agent_cls, _emp_cfgs, _EMPLOYEES_DIR)
         _registered_founding.add(_fid)
 
+    # Sync default skills (SKILL.md) for all existing employees on startup
+    from onemancompany.agents.onboarding import _inject_default_skills
+    for _emp_dir in sorted(_EMPLOYEES_DIR.iterdir()):
+        if _emp_dir.is_dir() and (_emp_dir / "profile.yaml").exists():
+            _skills_dir = _emp_dir / "skills"
+            _skills_dir.mkdir(exist_ok=True)
+            _inject_default_skills(_skills_dir)
+
     # Register CeoExecutor for CEO (virtual employee — routes to TUI, no LLM)
     from onemancompany.core.ceo_broker import CeoExecutor
     from onemancompany.core.config import CEO_ID


### PR DESCRIPTION
## Summary
Three behavioral framework skills (proactive-agent, self-improving-agent, ontology) were installed but never activated. They sat in employees' skills/ folders as "Available Skills" that agents never called `load_skill()` on.

## Root Cause
Missing `autoload: true` in SKILL.md frontmatter. Without it, skills appear in a catalog but aren't injected into the agent prompt.

## Changes
1. **Add `autoload: true`** to proactive-agent, self-improving-agent, ontology SKILL.md
2. **`_inject_default_skills` now syncs SKILL.md** for existing employees (was skip-if-exists)
3. **Startup syncs all employees** — iterates every employee dir and updates default skills

## Impact
All agents (EA, HR, COO, CSO + any hired employees) will now have these three skills active in every task execution:
- **proactive-agent**: anticipate needs, use tools proactively (like set_cron for recurring tasks)
- **self-improving-agent**: learn from experiences, maintain memory across sessions
- **ontology**: structured knowledge graph for entity relationships

## Test plan
- [x] 2380 unit tests pass
- [ ] Manual: verify skills appear in agent prompt (Active Skills section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)