### PR TITLE
fix: default model save button shows status instead of action

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -5450,7 +5450,7 @@ class AppController {
                 </select>
                 <div class="api-card-actions" style="margin-top:4px;">
                   <button class="pixel-btn small${isDefault ? '' : ' api-test-btn'}" onclick="app._setDefaultProvider('${providerId}')"
-                    ${!isConfigured ? 'disabled title="Save API key first"' : ''}>${isDefault ? '✓ Default' : 'Set as Default'}</button>
+                    ${!isConfigured ? 'disabled title="Save API key first"' : ''}>${isDefault ? 'Save Model' : 'Set as Default'}</button>
                   <span id="api-${providerId}-default-result" class="api-test-result"></span>
                 </div>
               </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.81",
+  "version": "0.4.82",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.81"
+version = "0.4.82"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
当前默认 provider 的按钮显示 "✓ Default"，看起来像状态标记而不是可点击的保存按钮。用户改了模型下拉后找不到保存方式。

Fix: 按钮文字改为 "Save Model"。卡片头部的 DEFAULT 标记已经指示状态。

## Test plan
- [x] Full suite: 2379 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)