### PR TITLE
feat: CC-style skill hooks for company-hosted agents

### DIFF
--- a/src/onemancompany/core/skill_hooks.py
+++ b/src/onemancompany/core/skill_hooks.py
@@ -299,15 +299,15 @@ def _build_env(
 
 
 def _expand_command(command: str, env: dict[str, str]) -> str:
-    """Expand ${VAR} and $VAR references in command string using env dict."""
+    """Expand ${VAR} references in command string.
+
+    Only expands ${BRACED} syntax to avoid prefix-collision issues
+    (e.g. $OMC matching before $OMC_TOOL_NAME). The shell handles
+    bare $VAR expansion at runtime via the env dict.
+    """
     result = command
-    # Expand ${VAR} first, then $VAR (longer match first to avoid partial replace)
     for key, val in env.items():
         result = result.replace(f"${{{key}}}", val)
-    for key, val in env.items():
-        # Only replace $VAR if not already expanded as ${VAR}
-        # and followed by word boundary (space, quote, end)
-        result = result.replace(f"${key}", val)
     return result
 
 

--- a/src/onemancompany/core/skill_hooks.py
+++ b/src/onemancompany/core/skill_hooks.py
@@ -1,0 +1,411 @@
+"""Skill Hooks — CC-style lifecycle hooks for company-hosted agents.
+
+Skills can define hooks in SKILL.md frontmatter that fire at key
+lifecycle points: tool calls (pre/post) and task lifecycle (start/
+complete/error). Hooks execute shell commands with JSON I/O.
+
+Hook events:
+  pre_tool, post_tool, post_tool_failure  — tool-level
+  task_start, task_complete, task_error    — task-level
+
+Exit codes (CC-compatible):
+  0  — success, continue
+  2  — block (pre_tool only: abort tool execution)
+  other — warning, continue
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Awaitable
+
+from loguru import logger
+
+from onemancompany.core.config import EMPLOYEES_DIR
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+class HookEvent(str, Enum):
+    PRE_TOOL = "pre_tool"
+    POST_TOOL = "post_tool"
+    POST_TOOL_FAILURE = "post_tool_failure"
+    TASK_START = "task_start"
+    TASK_COMPLETE = "task_complete"
+    TASK_ERROR = "task_error"
+
+
+TOOL_EVENTS = frozenset({HookEvent.PRE_TOOL, HookEvent.POST_TOOL, HookEvent.POST_TOOL_FAILURE})
+TASK_EVENTS = frozenset({HookEvent.TASK_START, HookEvent.TASK_COMPLETE, HookEvent.TASK_ERROR})
+
+EXIT_BLOCK = 2
+DEFAULT_TIMEOUT = 30
+
+
+@dataclass
+class HookConfig:
+    """Single hook definition parsed from SKILL.md metadata."""
+    event: HookEvent
+    command: str = ""
+    callback: Callable[..., Awaitable[dict]] | None = None
+    matcher: str = ""       # tool name filter (exact, pipe-separated, regex)
+    mode: str = "auto"      # auto | ask_first
+    timeout: int = DEFAULT_TIMEOUT
+    skill_name: str = ""    # source skill for logging
+
+
+@dataclass
+class HookResult:
+    """Result from a single hook execution."""
+    exit_code: int = 0
+    decision: str = "allow"     # allow | block
+    reason: str = ""
+    updated_input: dict | None = None
+    additional_context: str = ""
+    error: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+# (employee_id, event) → list of HookConfig
+_registry: dict[tuple[str, HookEvent], list[HookConfig]] = {}
+
+
+def register_skill_hooks(employee_id: str, skill_name: str, hooks_meta: dict) -> int:
+    """Parse hooks from SKILL.md metadata and register them.
+
+    Args:
+        employee_id: Employee ID.
+        skill_name: Name of the skill defining these hooks.
+        hooks_meta: The metadata.hooks dict from SKILL.md frontmatter.
+
+    Returns:
+        Number of hooks registered.
+    """
+    count = 0
+    for event_name, hook_list in hooks_meta.items():
+        try:
+            event = HookEvent(event_name)
+        except ValueError:
+            logger.warning("[hooks] Unknown event '{}' in skill {} for {}", event_name, skill_name, employee_id)
+            continue
+
+        if not isinstance(hook_list, list):
+            hook_list = [hook_list]
+
+        for h in hook_list:
+            if not isinstance(h, dict):
+                continue
+            mode = h.get("mode", "auto")
+            if mode == "ask_first":
+                continue  # company-hosted agents can't ask for confirmation
+
+            config = HookConfig(
+                event=event,
+                command=h.get("command", h.get("trigger", "")),
+                matcher=h.get("matcher", ""),
+                mode=mode,
+                timeout=h.get("timeout", DEFAULT_TIMEOUT),
+                skill_name=skill_name,
+            )
+            if not config.command:
+                continue
+
+            key = (employee_id, event)
+            _registry.setdefault(key, []).append(config)
+            count += 1
+
+    if count:
+        logger.debug("[hooks] Registered {} hooks from skill '{}' for {}", count, skill_name, employee_id)
+    return count
+
+
+def register_callback_hook(
+    employee_id: str,
+    event: HookEvent,
+    callback: Callable[..., Awaitable[dict]],
+    matcher: str = "",
+    skill_name: str = "_internal",
+) -> None:
+    """Register a Python callback hook (internal use)."""
+    config = HookConfig(
+        event=event,
+        callback=callback,
+        matcher=matcher,
+        skill_name=skill_name,
+    )
+    key = (employee_id, event)
+    _registry.setdefault(key, []).append(config)
+
+
+def clear_hooks(employee_id: str) -> None:
+    """Remove all hooks for an employee (used on re-registration)."""
+    keys = [k for k in _registry if k[0] == employee_id]
+    for k in keys:
+        del _registry[k]
+
+
+def get_hooks(employee_id: str, event: HookEvent) -> list[HookConfig]:
+    """Get all hooks registered for (employee_id, event)."""
+    return _registry.get((employee_id, event), [])
+
+
+# ---------------------------------------------------------------------------
+# Matcher
+# ---------------------------------------------------------------------------
+
+def _matches(matcher: str, tool_name: str) -> bool:
+    """Check if a hook matcher matches a tool name.
+
+    Supports: exact, pipe-separated, regex.
+    Empty matcher matches everything.
+    """
+    if not matcher:
+        return True
+    # Pipe-separated list (no regex chars other than pipe)
+    if "|" in matcher and not any(c in matcher for c in "^$.*+?[]()\\"):
+        return tool_name in matcher.split("|")
+    # Try regex
+    try:
+        return bool(re.fullmatch(matcher, tool_name))
+    except re.error:
+        return matcher == tool_name
+
+
+# ---------------------------------------------------------------------------
+# Execution
+# ---------------------------------------------------------------------------
+
+def _build_env(
+    employee_id: str,
+    event: HookEvent,
+    tool_name: str = "",
+    tool_input: dict | None = None,
+    task_id: str = "",
+) -> dict[str, str]:
+    """Build environment variables for hook subprocess."""
+    skills_dir = str(EMPLOYEES_DIR / employee_id / "skills")
+    env = {
+        **os.environ,
+        "OMC_EMPLOYEE_ID": employee_id,
+        "OMC_TASK_ID": task_id,
+        "OMC_HOOK_EVENT": event.value,
+        "OMC_SKILLS_DIR": skills_dir,
+    }
+    if tool_name:
+        env["OMC_TOOL_NAME"] = tool_name
+    if tool_input is not None:
+        env["OMC_TOOL_INPUT"] = json.dumps(tool_input, ensure_ascii=False, default=str)[:10000]
+    return env
+
+
+def _expand_command(command: str, employee_id: str) -> str:
+    """Expand ${SKILLS_DIR} and similar variables in command string."""
+    skills_dir = str(EMPLOYEES_DIR / employee_id / "skills")
+    return command.replace("${SKILLS_DIR}", skills_dir).replace("$SKILLS_DIR", skills_dir)
+
+
+async def _exec_command_hook(
+    config: HookConfig,
+    hook_input: dict,
+    env: dict[str, str],
+    employee_id: str,
+) -> HookResult:
+    """Execute a single command hook."""
+    command = _expand_command(config.command, employee_id)
+    input_json = json.dumps(hook_input, ensure_ascii=False, default=str)
+
+    try:
+        proc = await asyncio.create_subprocess_shell(
+            command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(input=input_json.encode()),
+            timeout=config.timeout,
+        )
+        exit_code = proc.returncode or 0
+
+        # Parse JSON output from stdout
+        result = HookResult(exit_code=exit_code)
+        stdout_str = stdout.decode().strip()
+        if stdout_str:
+            try:
+                data = json.loads(stdout_str)
+                result.decision = data.get("decision", "allow")
+                result.reason = data.get("reason", "")
+                result.updated_input = data.get("updatedInput")
+                result.additional_context = data.get("additionalContext", "")
+            except json.JSONDecodeError:
+                result.additional_context = stdout_str
+
+        if stderr:
+            result.error = stderr.decode().strip()
+            if exit_code == EXIT_BLOCK:
+                logger.warning("[hooks] {} blocked by '{}': {}", config.event.value, config.skill_name, result.error)
+            elif exit_code != 0:
+                logger.warning("[hooks] {} warning from '{}': {}", config.event.value, config.skill_name, result.error)
+
+        return result
+
+    except asyncio.TimeoutError:
+        logger.warning("[hooks] {} timed out after {}s (skill: {})", config.event.value, config.timeout, config.skill_name)
+        return HookResult(exit_code=1, error=f"Hook timed out after {config.timeout}s")
+    except Exception as e:
+        logger.warning("[hooks] {} error (skill: {}): {}", config.event.value, config.skill_name, e)
+        return HookResult(exit_code=1, error=str(e))
+
+
+async def _exec_callback_hook(
+    config: HookConfig,
+    hook_input: dict,
+) -> HookResult:
+    """Execute a single callback hook."""
+    try:
+        data = await asyncio.wait_for(config.callback(hook_input), timeout=config.timeout)
+        return HookResult(
+            decision=data.get("decision", "allow"),
+            reason=data.get("reason", ""),
+            updated_input=data.get("updatedInput"),
+            additional_context=data.get("additionalContext", ""),
+        )
+    except asyncio.TimeoutError:
+        return HookResult(exit_code=1, error=f"Callback timed out after {config.timeout}s")
+    except Exception as e:
+        logger.warning("[hooks] callback error (skill: {}): {}", config.skill_name, e)
+        return HookResult(exit_code=1, error=str(e))
+
+
+async def run_hooks(
+    employee_id: str,
+    event: HookEvent,
+    tool_name: str = "",
+    tool_input: dict | None = None,
+    tool_output: dict | None = None,
+    task_id: str = "",
+    task_description: str = "",
+    error_message: str = "",
+) -> list[HookResult]:
+    """Run all matching hooks for an event. Returns list of results.
+
+    For pre_tool: if any result has exit_code==2 or decision=="block",
+    the caller should abort the tool execution.
+    """
+    hooks = get_hooks(employee_id, event)
+    if not hooks:
+        return []
+
+    # Filter by matcher for tool events
+    if event in TOOL_EVENTS and tool_name:
+        hooks = [h for h in hooks if _matches(h.matcher, tool_name)]
+    if not hooks:
+        return []
+
+    # Build hook input
+    hook_input: dict[str, Any] = {
+        "employee_id": employee_id,
+        "event": event.value,
+        "task_id": task_id,
+    }
+    if tool_name:
+        hook_input["tool_name"] = tool_name
+    if tool_input is not None:
+        hook_input["tool_input"] = tool_input
+    if tool_output is not None:
+        hook_input["tool_output"] = tool_output
+    if task_description:
+        hook_input["task_description"] = task_description
+    if error_message:
+        hook_input["error_message"] = error_message
+
+    env = _build_env(employee_id, event, tool_name, tool_input, task_id)
+
+    # Execute all hooks in parallel
+    tasks = []
+    for h in hooks:
+        if h.callback:
+            tasks.append(_exec_callback_hook(h, hook_input))
+        elif h.command:
+            tasks.append(_exec_command_hook(h, hook_input, env, employee_id))
+
+    if not tasks:
+        return []
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    # Convert exceptions to HookResults
+    final = []
+    for r in results:
+        if isinstance(r, Exception):
+            final.append(HookResult(exit_code=1, error=str(r)))
+        else:
+            final.append(r)
+
+    return final
+
+
+def should_block(results: list[HookResult]) -> tuple[bool, str]:
+    """Check if any hook result indicates blocking.
+
+    Returns (should_block, reason).
+    """
+    for r in results:
+        if r.exit_code == EXIT_BLOCK or r.decision == "block":
+            return True, r.reason or r.error or "Blocked by hook"
+    return False, ""
+
+
+def get_updated_input(results: list[HookResult], original: dict) -> dict:
+    """Apply updatedInput from hook results. Last writer wins."""
+    result = dict(original)
+    for r in results:
+        if r.updated_input:
+            result.update(r.updated_input)
+    return result
+
+
+def collect_context(results: list[HookResult]) -> str:
+    """Collect additionalContext from all hook results."""
+    parts = [r.additional_context for r in results if r.additional_context]
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Skill hooks loading
+# ---------------------------------------------------------------------------
+
+def load_hooks_from_skills(employee_id: str) -> int:
+    """Load hooks from all of an employee's skills. Called on startup.
+
+    Returns total number of hooks registered.
+    """
+    from onemancompany.core.config import load_employee_skills
+    from onemancompany.agents.base import _parse_skill_frontmatter
+
+    clear_hooks(employee_id)
+    skills = load_employee_skills(employee_id)
+    total = 0
+    for skill_name, content in skills.items():
+        meta, _body = _parse_skill_frontmatter(content)
+        hooks_meta = meta.get("metadata", {})
+        if isinstance(hooks_meta, dict):
+            hooks_meta = hooks_meta.get("hooks", {})
+        else:
+            hooks_meta = {}
+        if hooks_meta:
+            total += register_skill_hooks(employee_id, skill_name, hooks_meta)
+
+    return total

--- a/src/onemancompany/core/skill_hooks.py
+++ b/src/onemancompany/core/skill_hooks.py
@@ -46,6 +46,38 @@ class HookEvent(str, Enum):
 TOOL_EVENTS = frozenset({HookEvent.PRE_TOOL, HookEvent.POST_TOOL, HookEvent.POST_TOOL_FAILURE})
 TASK_EVENTS = frozenset({HookEvent.TASK_START, HookEvent.TASK_COMPLETE, HookEvent.TASK_ERROR})
 
+# CC event names → our event names (CC compat layer)
+_CC_EVENT_MAP: dict[str, HookEvent] = {
+    # CC names
+    "PreToolUse": HookEvent.PRE_TOOL,
+    "PostToolUse": HookEvent.POST_TOOL,
+    "PostToolUseFailure": HookEvent.POST_TOOL_FAILURE,
+    "SessionStart": HookEvent.TASK_START,
+    "Stop": HookEvent.TASK_COMPLETE,
+    "StopFailure": HookEvent.TASK_ERROR,
+    # frontmatter names
+    "before_start": HookEvent.TASK_START,
+    "after_complete": HookEvent.TASK_COMPLETE,
+    "on_error": HookEvent.TASK_ERROR,
+    # our names (passthrough)
+    "pre_tool": HookEvent.PRE_TOOL,
+    "post_tool": HookEvent.POST_TOOL,
+    "post_tool_failure": HookEvent.POST_TOOL_FAILURE,
+    "task_start": HookEvent.TASK_START,
+    "task_complete": HookEvent.TASK_COMPLETE,
+    "task_error": HookEvent.TASK_ERROR,
+}
+
+
+def _resolve_event(name: str) -> HookEvent | None:
+    """Resolve any event name format (CC, frontmatter, or ours) to HookEvent."""
+    if name in _CC_EVENT_MAP:
+        return _CC_EVENT_MAP[name]
+    try:
+        return HookEvent(name)
+    except ValueError:
+        return None
+
 EXIT_BLOCK = 2
 DEFAULT_TIMEOUT = 30
 
@@ -82,21 +114,36 @@ _registry: dict[tuple[str, HookEvent], list[HookConfig]] = {}
 
 
 def register_skill_hooks(employee_id: str, skill_name: str, hooks_meta: dict) -> int:
-    """Parse hooks from SKILL.md metadata and register them.
+    """Parse hooks from SKILL.md and register them.
 
-    Args:
-        employee_id: Employee ID.
-        skill_name: Name of the skill defining these hooks.
-        hooks_meta: The metadata.hooks dict from SKILL.md frontmatter.
+    Supports three configuration formats:
 
-    Returns:
-        Number of hooks registered.
+    1. Our format (flat):
+       hooks:
+         pre_tool:
+           - command: "bash script.sh"
+             matcher: "bash"
+
+    2. CC settings.json format (nested):
+       hooks:
+         PreToolUse:
+           - matcher: "Bash|Write"
+             hooks:
+               - type: command
+                 command: "bash script.sh"
+
+    3. CC frontmatter format (trigger-based):
+       hooks:
+         before_start:
+           - trigger: session-logger
+             mode: auto
+
+    Returns number of hooks registered.
     """
     count = 0
     for event_name, hook_list in hooks_meta.items():
-        try:
-            event = HookEvent(event_name)
-        except ValueError:
+        event = _resolve_event(event_name)
+        if event is None:
             logger.warning("[hooks] Unknown event '{}' in skill {} for {}", event_name, skill_name, employee_id)
             continue
 
@@ -106,28 +153,61 @@ def register_skill_hooks(employee_id: str, skill_name: str, hooks_meta: dict) ->
         for h in hook_list:
             if not isinstance(h, dict):
                 continue
-            mode = h.get("mode", "auto")
-            if mode == "ask_first":
-                continue  # company-hosted agents can't ask for confirmation
 
-            config = HookConfig(
-                event=event,
-                command=h.get("command", h.get("trigger", "")),
-                matcher=h.get("matcher", ""),
-                mode=mode,
-                timeout=h.get("timeout", DEFAULT_TIMEOUT),
-                skill_name=skill_name,
-            )
-            if not config.command:
-                continue
-
-            key = (employee_id, event)
-            _registry.setdefault(key, []).append(config)
-            count += 1
+            # CC nested format: {matcher: "...", hooks: [{type: command, command: "..."}]}
+            if "hooks" in h:
+                outer_matcher = h.get("matcher", "")
+                for inner in h["hooks"]:
+                    if not isinstance(inner, dict):
+                        continue
+                    count += _register_single_hook(
+                        employee_id, event, skill_name,
+                        command=inner.get("command", ""),
+                        matcher=outer_matcher,
+                        mode=inner.get("mode", "auto"),
+                        timeout=inner.get("timeout", DEFAULT_TIMEOUT),
+                    )
+            else:
+                # Flat format or frontmatter trigger format
+                count += _register_single_hook(
+                    employee_id, event, skill_name,
+                    command=h.get("command", h.get("trigger", "")),
+                    matcher=h.get("matcher", ""),
+                    mode=h.get("mode", "auto"),
+                    timeout=h.get("timeout", DEFAULT_TIMEOUT),
+                )
 
     if count:
         logger.debug("[hooks] Registered {} hooks from skill '{}' for {}", count, skill_name, employee_id)
     return count
+
+
+def _register_single_hook(
+    employee_id: str,
+    event: HookEvent,
+    skill_name: str,
+    command: str,
+    matcher: str = "",
+    mode: str = "auto",
+    timeout: int = DEFAULT_TIMEOUT,
+) -> int:
+    """Register one hook. Returns 1 if registered, 0 if skipped."""
+    if mode == "ask_first":
+        return 0  # company-hosted agents can't ask for confirmation
+    if not command:
+        return 0
+
+    config = HookConfig(
+        event=event,
+        command=command,
+        matcher=matcher,
+        mode=mode,
+        timeout=timeout,
+        skill_name=skill_name,
+    )
+    key = (employee_id, event)
+    _registry.setdefault(key, []).append(config)
+    return 1
 
 
 def register_callback_hook(
@@ -193,26 +273,42 @@ def _build_env(
     tool_input: dict | None = None,
     task_id: str = "",
 ) -> dict[str, str]:
-    """Build environment variables for hook subprocess."""
+    """Build environment variables for hook subprocess.
+
+    Sets both OMC_* vars (our convention) and CC-compatible vars
+    ($TOOL_NAME, $TOOL_INPUT, $SKILLS_DIR, etc.) so hook scripts
+    from either ecosystem work without modification.
+    """
     skills_dir = str(EMPLOYEES_DIR / employee_id / "skills")
+    tool_input_json = json.dumps(tool_input, ensure_ascii=False, default=str)[:10000] if tool_input else ""
     env = {
         **os.environ,
+        # Our vars
         "OMC_EMPLOYEE_ID": employee_id,
         "OMC_TASK_ID": task_id,
         "OMC_HOOK_EVENT": event.value,
         "OMC_SKILLS_DIR": skills_dir,
+        "OMC_TOOL_NAME": tool_name or "",
+        "OMC_TOOL_INPUT": tool_input_json,
+        # CC-compatible vars
+        "SKILLS_DIR": skills_dir,
+        "TOOL_NAME": tool_name or "",
+        "TOOL_INPUT": tool_input_json,
     }
-    if tool_name:
-        env["OMC_TOOL_NAME"] = tool_name
-    if tool_input is not None:
-        env["OMC_TOOL_INPUT"] = json.dumps(tool_input, ensure_ascii=False, default=str)[:10000]
     return env
 
 
-def _expand_command(command: str, employee_id: str) -> str:
-    """Expand ${SKILLS_DIR} and similar variables in command string."""
-    skills_dir = str(EMPLOYEES_DIR / employee_id / "skills")
-    return command.replace("${SKILLS_DIR}", skills_dir).replace("$SKILLS_DIR", skills_dir)
+def _expand_command(command: str, env: dict[str, str]) -> str:
+    """Expand ${VAR} and $VAR references in command string using env dict."""
+    result = command
+    # Expand ${VAR} first, then $VAR (longer match first to avoid partial replace)
+    for key, val in env.items():
+        result = result.replace(f"${{{key}}}", val)
+    for key, val in env.items():
+        # Only replace $VAR if not already expanded as ${VAR}
+        # and followed by word boundary (space, quote, end)
+        result = result.replace(f"${key}", val)
+    return result
 
 
 async def _exec_command_hook(
@@ -222,7 +318,7 @@ async def _exec_command_hook(
     employee_id: str,
 ) -> HookResult:
     """Execute a single command hook."""
-    command = _expand_command(config.command, employee_id)
+    command = _expand_command(config.command, env)
     input_json = json.dumps(hook_input, ensure_ascii=False, default=str)
 
     try:
@@ -332,6 +428,15 @@ async def run_hooks(
         hook_input["error_message"] = error_message
 
     env = _build_env(employee_id, event, tool_name, tool_input, task_id)
+    # CC-compat: add TOOL_OUTPUT and EXIT_CODE for post-tool hooks
+    if tool_output is not None:
+        env["TOOL_OUTPUT"] = json.dumps(tool_output, ensure_ascii=False, default=str)[:10000]
+        env["OMC_TOOL_OUTPUT"] = env["TOOL_OUTPUT"]
+    if error_message:
+        env["EXIT_CODE"] = "1"
+        env["OMC_ERROR_MESSAGE"] = error_message
+    else:
+        env["EXIT_CODE"] = "0"
 
     # Execute all hooks in parallel
     tasks = []

--- a/src/onemancompany/core/skill_hooks.py
+++ b/src/onemancompany/core/skill_hooks.py
@@ -168,10 +168,14 @@ def register_skill_hooks(employee_id: str, skill_name: str, hooks_meta: dict) ->
                         timeout=inner.get("timeout", DEFAULT_TIMEOUT),
                     )
             else:
-                # Flat format or frontmatter trigger format
+                # Flat format (command) or frontmatter trigger format
+                command = h.get("command", "")
+                if not command and h.get("trigger"):
+                    # Resolve trigger name to script in skill's hooks/ dir
+                    command = _resolve_trigger(employee_id, skill_name, h["trigger"])
                 count += _register_single_hook(
                     employee_id, event, skill_name,
-                    command=h.get("command", h.get("trigger", "")),
+                    command=command,
                     matcher=h.get("matcher", ""),
                     mode=h.get("mode", "auto"),
                     timeout=h.get("timeout", DEFAULT_TIMEOUT),
@@ -180,6 +184,26 @@ def register_skill_hooks(employee_id: str, skill_name: str, hooks_meta: dict) ->
     if count:
         logger.debug("[hooks] Registered {} hooks from skill '{}' for {}", count, skill_name, employee_id)
     return count
+
+
+def _resolve_trigger(employee_id: str, skill_name: str, trigger_name: str) -> str:
+    """Resolve a trigger name to a hook script path.
+
+    Convention: trigger 'session-logger' → hooks/session-logger.sh
+    in the skill's directory. Tries .sh, then bare name.
+    """
+    skills_dir = EMPLOYEES_DIR / employee_id / "skills" / skill_name / "hooks"
+    for suffix in (".sh", ""):
+        script = skills_dir / f"{trigger_name}{suffix}"
+        if script.exists():
+            logger.debug("[hooks] Resolved trigger '{}' → {}", trigger_name, script)
+            return f"bash {script}"
+
+    logger.warning(
+        "[hooks] Trigger '{}' in skill '{}' for {} has no script at {}/",
+        trigger_name, skill_name, employee_id, skills_dir,
+    )
+    return ""
 
 
 def _register_single_hook(

--- a/src/onemancompany/core/tool_registry.py
+++ b/src/onemancompany/core/tool_registry.py
@@ -316,6 +316,18 @@ async def execute_tool(employee_id: str, tool_name: str, args: dict) -> dict:
         if employee_id and not args.get("employee_id"):
             args["employee_id"] = employee_id
 
+        # Pre-tool hooks
+        from onemancompany.core.skill_hooks import run_hooks, should_block, get_updated_input, HookEvent
+        task_id = existing_task or ""
+        pre_results = await run_hooks(
+            employee_id, HookEvent.PRE_TOOL,
+            tool_name=tool_name, tool_input=args, task_id=task_id,
+        )
+        blocked, block_reason = should_block(pre_results)
+        if blocked:
+            return {"status": "blocked", "message": f"Blocked by hook: {block_reason}"}
+        args = get_updated_input(pre_results, args)
+
         # Call the tool
         if hasattr(fn, "ainvoke"):
             result = await fn.ainvoke(args)
@@ -328,12 +340,31 @@ async def execute_tool(employee_id: str, tool_name: str, args: dict) -> dict:
 
         # Normalize result
         if isinstance(result, dict):
-            return result
-        if isinstance(result, list):
-            return {"result": result}
-        return {"result": str(result)}
+            norm = result
+        elif isinstance(result, list):
+            norm = {"result": result}
+        else:
+            norm = {"result": str(result)}
+
+        # Post-tool hooks (fire-and-forget, don't block return)
+        await run_hooks(
+            employee_id, HookEvent.POST_TOOL,
+            tool_name=tool_name, tool_input=args, tool_output=norm, task_id=task_id,
+        )
+
+        return norm
     except Exception as e:
         logger.error("Tool '{}' failed: {}", tool_name, e)
+        # Post-tool-failure hooks
+        try:
+            from onemancompany.core.skill_hooks import run_hooks, HookEvent
+            await run_hooks(
+                employee_id, HookEvent.POST_TOOL_FAILURE,
+                tool_name=tool_name, tool_input=args, error_message=str(e),
+                task_id=existing_task or "",
+            )
+        except Exception as hook_err:
+            logger.debug("Post-tool-failure hook error (suppressed): {}", hook_err)
         return {"status": "error", "message": str(e)}
     finally:
         if vessel_token is not None:

--- a/src/onemancompany/core/tool_registry.py
+++ b/src/onemancompany/core/tool_registry.py
@@ -346,7 +346,7 @@ async def execute_tool(employee_id: str, tool_name: str, args: dict) -> dict:
         else:
             norm = {"result": str(result)}
 
-        # Post-tool hooks (fire-and-forget, don't block return)
+        # Post-tool hooks (awaited for observability, results don't affect return)
         await run_hooks(
             employee_id, HookEvent.POST_TOOL,
             tool_name=tool_name, tool_input=args, tool_output=norm, task_id=task_id,

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1016,7 +1016,8 @@ class EmployeeManager:
         Wraps sync callables as async callbacks with compatible signatures.
         """
         self._hooks[employee_id] = hooks
-        from onemancompany.core.skill_hooks import register_callback_hook, HookEvent
+        from onemancompany.core.skill_hooks import register_callback_hook, clear_hooks, HookEvent
+        clear_hooks(employee_id)  # prevent duplicate accumulation on re-registration
         if hooks.get("pre_task"):
             _pre = hooks["pre_task"]
             async def _pre_wrap(hook_input, _fn=_pre):
@@ -1462,12 +1463,15 @@ class EmployeeManager:
             )
 
             # Task start hooks (unified skill_hooks system)
-            from onemancompany.core.skill_hooks import run_hooks as _run_hooks, HookEvent as _HE
+            from onemancompany.core.skill_hooks import run_hooks, collect_context, HookEvent
             try:
-                await _run_hooks(
-                    employee_id, _HE.TASK_START,
+                _start_results = await run_hooks(
+                    employee_id, HookEvent.TASK_START,
                     task_id=entry.node_id, task_description=task_with_ctx,
                 )
+                _extra = collect_context(_start_results)
+                if _extra:
+                    task_with_ctx = f"{task_with_ctx}\n\n[Hook context]\n{_extra}"
             except Exception:
                 logger.warning("Task start hooks failed for {}", employee_id)
 
@@ -1583,8 +1587,8 @@ class EmployeeManager:
             logger.exception("Unhandled error")
             # Task error hooks
             try:
-                await _run_hooks(
-                    employee_id, _HE.TASK_ERROR,
+                await run_hooks(
+                    employee_id, HookEvent.TASK_ERROR,
                     task_id=entry.node_id, error_message=str(e),
                 )
             except Exception as hook_err:
@@ -1672,8 +1676,8 @@ class EmployeeManager:
 
             # Task complete hooks (unified skill_hooks system)
             try:
-                await _run_hooks(
-                    employee_id, _HE.TASK_COMPLETE,
+                await run_hooks(
+                    employee_id, HookEvent.TASK_COMPLETE,
                     task_id=entry.node_id, task_description=node.result or "",
                 )
             except Exception:

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1013,20 +1013,27 @@ class EmployeeManager:
         """Register lifecycle hooks (pre_task, post_task) for an employee.
 
         Bridges legacy vessel.yaml hooks into the unified skill_hooks system.
+        Wraps sync callables as async callbacks with compatible signatures.
         """
         self._hooks[employee_id] = hooks
-        # Bridge into unified hook system
         from onemancompany.core.skill_hooks import register_callback_hook, HookEvent
         if hooks.get("pre_task"):
             _pre = hooks["pre_task"]
             async def _pre_wrap(hook_input, _fn=_pre):
-                result = _fn(hook_input.get("task_description", ""), hook_input)
-                return {"additionalContext": result if isinstance(result, str) else ""}
+                try:
+                    result = _fn(hook_input.get("task_description", ""), None)
+                    return {"additionalContext": result if isinstance(result, str) else ""}
+                except Exception as e:
+                    logger.warning("Legacy pre_task hook failed: {}", e)
+                    return {}
             register_callback_hook(employee_id, HookEvent.TASK_START, _pre_wrap, skill_name="_vessel")
         if hooks.get("post_task"):
             _post = hooks["post_task"]
             async def _post_wrap(hook_input, _fn=_post):
-                _fn(hook_input, hook_input.get("task_description", ""))
+                try:
+                    _fn(None, hook_input.get("task_description", ""))
+                except Exception as e:
+                    logger.warning("Legacy post_task hook failed: {}", e)
                 return {}
             register_callback_hook(employee_id, HookEvent.TASK_COMPLETE, _post_wrap, skill_name="_vessel")
 
@@ -1035,6 +1042,8 @@ class EmployeeManager:
         self.vessels.pop(employee_id, None)
         self.configs.pop(employee_id, None)
         self._hooks.pop(employee_id, None)
+        from onemancompany.core.skill_hooks import clear_hooks
+        clear_hooks(employee_id)
 
     def get_handle(self, employee_id: str) -> Vessel | None:
         return self.vessels.get(employee_id)

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1010,8 +1010,25 @@ class EmployeeManager:
             self._schedule_next(employee_id)
 
     def register_hooks(self, employee_id: str, hooks: dict[str, Callable]) -> None:
-        """Register lifecycle hooks (pre_task, post_task) for an employee."""
+        """Register lifecycle hooks (pre_task, post_task) for an employee.
+
+        Bridges legacy vessel.yaml hooks into the unified skill_hooks system.
+        """
         self._hooks[employee_id] = hooks
+        # Bridge into unified hook system
+        from onemancompany.core.skill_hooks import register_callback_hook, HookEvent
+        if hooks.get("pre_task"):
+            _pre = hooks["pre_task"]
+            async def _pre_wrap(hook_input, _fn=_pre):
+                result = _fn(hook_input.get("task_description", ""), hook_input)
+                return {"additionalContext": result if isinstance(result, str) else ""}
+            register_callback_hook(employee_id, HookEvent.TASK_START, _pre_wrap, skill_name="_vessel")
+        if hooks.get("post_task"):
+            _post = hooks["post_task"]
+            async def _post_wrap(hook_input, _fn=_post):
+                _fn(hook_input, hook_input.get("task_description", ""))
+                return {}
+            register_callback_hook(employee_id, HookEvent.TASK_COMPLETE, _post_wrap, skill_name="_vessel")
 
     def unregister(self, employee_id: str) -> None:
         self.executors.pop(employee_id, None)
@@ -1435,16 +1452,15 @@ class EmployeeManager:
                 task_id=entry.node_id,
             )
 
-            # Pre-task hook
-            hooks = self._hooks.get(employee_id, {})
-            pre_task = hooks.get("pre_task")
-            if pre_task:
-                try:
-                    result = pre_task(task_with_ctx, context)
-                    if isinstance(result, str):
-                        task_with_ctx = result
-                except Exception:
-                    logger.warning("Pre-task hook failed for {}", employee_id)
+            # Task start hooks (unified skill_hooks system)
+            from onemancompany.core.skill_hooks import run_hooks as _run_hooks, HookEvent as _HE
+            try:
+                await _run_hooks(
+                    employee_id, _HE.TASK_START,
+                    task_id=entry.node_id, task_description=task_with_ctx,
+                )
+            except Exception:
+                logger.warning("Task start hooks failed for {}", employee_id)
 
             # Universal timeout — asyncio.wait_for wraps ALL executor types.
             task_timeout = node.timeout_seconds or 3600
@@ -1556,6 +1572,14 @@ class EmployeeManager:
             self._push_to_ceo_session(node, f"\u2717 {str(e)[:500]}")
             _append_progress(employee_id, f"Failed: {node.description_preview} \u2014 {e!s}")
             logger.exception("Unhandled error")
+            # Task error hooks
+            try:
+                await _run_hooks(
+                    employee_id, _HE.TASK_ERROR,
+                    task_id=entry.node_id, error_message=str(e),
+                )
+            except Exception as hook_err:
+                logger.debug("Task error hook failed (suppressed): {}", hook_err)
         finally:
             _current_vessel.reset(loop_token)
             _current_task_id.reset(task_token)
@@ -1637,13 +1661,14 @@ class EmployeeManager:
                 if result_text:
                     self._push_to_ceo_session(node, f"✓ {result_text}")
 
-            # Post-task hook
-            post_task_hook = self._hooks.get(employee_id, {}).get("post_task")
-            if post_task_hook:
-                try:
-                    post_task_hook(node, node.result or "")
-                except Exception:
-                    logger.warning("Post-task hook failed for {}", employee_id)
+            # Task complete hooks (unified skill_hooks system)
+            try:
+                await _run_hooks(
+                    employee_id, _HE.TASK_COMPLETE,
+                    task_id=entry.node_id, task_description=node.result or "",
+                )
+            except Exception:
+                logger.warning("Task complete hooks failed for {}", employee_id)
 
             await _store.save_employee_runtime(employee_id, current_task_summary="")
 

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -843,7 +843,7 @@ class EmployeeManager:
         self._current_entries: dict[str, ScheduleEntry] = {}  # currently executing entry per employee
         self._system_tasks: dict[str, asyncio.Task] = {}  # system operation tracking
         self._deferred_schedule: set[str] = set()
-        self._hooks: dict[str, dict[str, Callable]] = {}
+        self._hooks: dict[str, dict[str, Callable]] = {}  # bridge cache only — execution goes through skill_hooks
         self._event_loop: asyncio.AbstractEventLoop | None = None  # set by drain_pending
         self._restart_pending: bool = False
         # ScheduleEntry-based scheduling (replaces boards for new code paths)
@@ -1016,8 +1016,9 @@ class EmployeeManager:
         Wraps sync callables as async callbacks with compatible signatures.
         """
         self._hooks[employee_id] = hooks
-        from onemancompany.core.skill_hooks import register_callback_hook, clear_hooks, HookEvent
-        clear_hooks(employee_id)  # prevent duplicate accumulation on re-registration
+        from onemancompany.core.skill_hooks import register_callback_hook, clear_hooks, load_hooks_from_skills, HookEvent
+        clear_hooks(employee_id)  # wipe all, then re-register both sources
+        load_hooks_from_skills(employee_id)  # re-load SKILL.md hooks first
         if hooks.get("pre_task"):
             _pre = hooks["pre_task"]
             async def _pre_wrap(hook_input, _fn=_pre):

--- a/src/onemancompany/default_skills/self-improving-agent/hooks/session-logger.sh
+++ b/src/onemancompany/default_skills/self-improving-agent/hooks/session-logger.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Session logger hook for self-improving-agent.
+# Reads JSON from stdin, logs session event to episodic memory.
+
+EVENT="${OMC_HOOK_EVENT:-unknown}"
+EMPLOYEE="${OMC_EMPLOYEE_ID:-unknown}"
+TASK="${OMC_TASK_ID:-unknown}"
+SKILLS_DIR="${OMC_SKILLS_DIR:-}"
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# Memory directory
+MEMORY_DIR="${SKILLS_DIR}/self-improving-agent/memory/working"
+mkdir -p "$MEMORY_DIR"
+
+# Read stdin (JSON hook input)
+INPUT=$(cat)
+
+# Log session event
+cat > "$MEMORY_DIR/session_${EVENT}.json" << EOF
+{
+  "event": "$EVENT",
+  "employee_id": "$EMPLOYEE",
+  "task_id": "$TASK",
+  "timestamp": "$TIMESTAMP",
+  "input": $INPUT
+}
+EOF
+
+echo "[self-improving-agent] Session logged: $EVENT for $EMPLOYEE" >&2

--- a/src/onemancompany/main.py
+++ b/src/onemancompany/main.py
@@ -545,6 +545,15 @@ async def lifespan(app: FastAPI):
         register_agent(emp_id, _runner, config=_vessel_cfg)
         print(f"[startup] Registered {emp_data.get('name', emp_id)} ({emp_id}) — LangChain agent")
 
+    # Load skill hooks for all registered employees
+    from onemancompany.core.skill_hooks import load_hooks_from_skills
+    _total_hooks = 0
+    for _emp_dir in sorted(_EMPLOYEES_DIR.iterdir()):
+        if _emp_dir.is_dir() and (_emp_dir / "profile.yaml").exists():
+            _total_hooks += load_hooks_from_skills(_emp_dir.name)
+    if _total_hooks:
+        logger.info("[startup] Loaded {} skill hook(s) across all employees", _total_hooks)
+
     await start_all_loops()
 
     # Restore persisted tasks from per-employee task files

--- a/tests/unit/core/test_skill_hooks.py
+++ b/tests/unit/core/test_skill_hooks.py
@@ -1,0 +1,213 @@
+"""Unit tests for core/skill_hooks.py — CC-style skill hooks system."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from onemancompany.core.skill_hooks import (
+    HookConfig, HookEvent, HookResult,
+    _matches, _registry,
+    clear_hooks, collect_context, get_hooks, get_updated_input,
+    register_callback_hook, register_skill_hooks,
+    run_hooks, should_block,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Clear hook registry before each test."""
+    _registry.clear()
+    yield
+    _registry.clear()
+
+
+# ---------------------------------------------------------------------------
+# Matcher
+# ---------------------------------------------------------------------------
+
+class TestMatches:
+    def test_empty_matches_everything(self):
+        assert _matches("", "anything") is True
+
+    def test_exact_match(self):
+        assert _matches("bash", "bash") is True
+        assert _matches("bash", "write") is False
+
+    def test_pipe_separated(self):
+        assert _matches("bash|write|edit", "write") is True
+        assert _matches("bash|write|edit", "read") is False
+
+    def test_regex(self):
+        assert _matches("^web_.*", "web_search") is True
+        assert _matches("^web_.*", "bash") is False
+
+    def test_regex_fullmatch(self):
+        assert _matches("bash.*", "bash_exec") is True
+        assert _matches("bash.*", "prebash") is False
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+class TestRegistration:
+    def test_register_from_skill_metadata(self):
+        hooks_meta = {
+            "task_start": [
+                {"command": "echo start", "mode": "auto"},
+            ],
+            "post_tool": [
+                {"command": "echo post", "matcher": "bash", "mode": "auto"},
+            ],
+        }
+        count = register_skill_hooks("00004", "test-skill", hooks_meta)
+        assert count == 2
+        assert len(get_hooks("00004", HookEvent.TASK_START)) == 1
+        assert len(get_hooks("00004", HookEvent.POST_TOOL)) == 1
+
+    def test_skip_ask_first_mode(self):
+        hooks_meta = {
+            "task_complete": [
+                {"command": "echo done", "mode": "ask_first"},
+            ],
+        }
+        count = register_skill_hooks("00004", "test-skill", hooks_meta)
+        assert count == 0
+
+    def test_skip_unknown_event(self):
+        hooks_meta = {"unknown_event": [{"command": "echo x"}]}
+        count = register_skill_hooks("00004", "test-skill", hooks_meta)
+        assert count == 0
+
+    def test_clear_hooks(self):
+        register_skill_hooks("00004", "s1", {"task_start": [{"command": "echo x"}]})
+        assert len(get_hooks("00004", HookEvent.TASK_START)) == 1
+        clear_hooks("00004")
+        assert len(get_hooks("00004", HookEvent.TASK_START)) == 0
+
+    def test_register_callback(self):
+        async def my_hook(inp):
+            return {}
+
+        register_callback_hook("00004", HookEvent.TASK_START, my_hook)
+        hooks = get_hooks("00004", HookEvent.TASK_START)
+        assert len(hooks) == 1
+        assert hooks[0].callback is my_hook
+
+
+# ---------------------------------------------------------------------------
+# should_block / get_updated_input / collect_context
+# ---------------------------------------------------------------------------
+
+class TestResultHelpers:
+    def test_should_block_on_exit_2(self):
+        results = [HookResult(exit_code=2, error="blocked")]
+        blocked, reason = should_block(results)
+        assert blocked is True
+        assert "blocked" in reason
+
+    def test_should_block_on_decision(self):
+        results = [HookResult(decision="block", reason="no")]
+        blocked, reason = should_block(results)
+        assert blocked is True
+
+    def test_no_block_on_success(self):
+        results = [HookResult(exit_code=0)]
+        blocked, _ = should_block(results)
+        assert blocked is False
+
+    def test_updated_input(self):
+        results = [HookResult(updated_input={"key": "new"})]
+        updated = get_updated_input(results, {"key": "old", "other": 1})
+        assert updated == {"key": "new", "other": 1}
+
+    def test_collect_context(self):
+        results = [
+            HookResult(additional_context="from hook1"),
+            HookResult(additional_context=""),
+            HookResult(additional_context="from hook3"),
+        ]
+        ctx = collect_context(results)
+        assert "from hook1" in ctx
+        assert "from hook3" in ctx
+
+
+# ---------------------------------------------------------------------------
+# Callback hook execution
+# ---------------------------------------------------------------------------
+
+class TestCallbackExecution:
+    @pytest.mark.asyncio
+    async def test_callback_hook_runs(self):
+        captured = {}
+
+        async def my_hook(hook_input):
+            captured.update(hook_input)
+            return {"decision": "allow", "additionalContext": "hello"}
+
+        register_callback_hook("00004", HookEvent.TASK_START, my_hook)
+        results = await run_hooks("00004", HookEvent.TASK_START, task_id="t1", task_description="do stuff")
+
+        assert len(results) == 1
+        assert results[0].additional_context == "hello"
+        assert captured["employee_id"] == "00004"
+        assert captured["task_id"] == "t1"
+
+    @pytest.mark.asyncio
+    async def test_callback_timeout(self):
+        async def slow_hook(hook_input):
+            await asyncio.sleep(10)
+            return {}
+
+        register_callback_hook("00004", HookEvent.TASK_START, slow_hook)
+        # Override timeout to 0.1s
+        get_hooks("00004", HookEvent.TASK_START)[0].timeout = 0.1
+
+        results = await run_hooks("00004", HookEvent.TASK_START)
+        assert len(results) == 1
+        assert "timed out" in results[0].error.lower()
+
+    @pytest.mark.asyncio
+    async def test_no_hooks_returns_empty(self):
+        results = await run_hooks("00004", HookEvent.TASK_START)
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Tool event filtering
+# ---------------------------------------------------------------------------
+
+class TestToolEventFiltering:
+    @pytest.mark.asyncio
+    async def test_matcher_filters_tool_name(self):
+        called = []
+
+        async def hook_a(inp):
+            called.append("a")
+            return {}
+
+        async def hook_b(inp):
+            called.append("b")
+            return {}
+
+        register_callback_hook("00004", HookEvent.PRE_TOOL, hook_a, matcher="bash")
+        register_callback_hook("00004", HookEvent.PRE_TOOL, hook_b, matcher="write")
+
+        await run_hooks("00004", HookEvent.PRE_TOOL, tool_name="bash")
+        assert called == ["a"]
+
+    @pytest.mark.asyncio
+    async def test_empty_matcher_matches_all(self):
+        called = []
+
+        async def hook(inp):
+            called.append(inp["tool_name"])
+            return {}
+
+        register_callback_hook("00004", HookEvent.POST_TOOL, hook)
+        await run_hooks("00004", HookEvent.POST_TOOL, tool_name="anything")
+        assert called == ["anything"]

--- a/tests/unit/core/test_skill_hooks.py
+++ b/tests/unit/core/test_skill_hooks.py
@@ -99,8 +99,13 @@ class TestRegistration:
         # Stop → TASK_COMPLETE
         assert len(get_hooks("00004", HookEvent.TASK_COMPLETE)) == 1
 
-    def test_register_cc_frontmatter_format(self):
+    def test_register_cc_frontmatter_format(self, tmp_path):
         """CC frontmatter format: before_start/after_complete/on_error with trigger."""
+        # Create hook script files so trigger resolution works
+        hooks_dir = tmp_path / "00004" / "skills" / "sia" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "session-logger.sh").write_text("#!/bin/bash\necho ok")
+
         hooks_meta = {
             "before_start": [
                 {"trigger": "session-logger", "mode": "auto"},
@@ -113,12 +118,16 @@ class TestRegistration:
                 {"trigger": "session-logger", "mode": "auto"},
             ],
         }
-        count = register_skill_hooks("00004", "sia", hooks_meta)
-        # ask_first skipped, 3 registered (before_start + after_complete + on_error)
+        with patch("onemancompany.core.skill_hooks.EMPLOYEES_DIR", tmp_path):
+            count = register_skill_hooks("00004", "sia", hooks_meta)
+        # ask_first skipped, 3 triggers resolved to session-logger.sh
         assert count == 3
         assert len(get_hooks("00004", HookEvent.TASK_START)) == 1
         assert len(get_hooks("00004", HookEvent.TASK_COMPLETE)) == 1
         assert len(get_hooks("00004", HookEvent.TASK_ERROR)) == 1
+        # Verify the command points to the script
+        hook = get_hooks("00004", HookEvent.TASK_START)[0]
+        assert "session-logger.sh" in hook.command
 
     def test_skip_ask_first_mode(self):
         hooks_meta = {

--- a/tests/unit/core/test_skill_hooks.py
+++ b/tests/unit/core/test_skill_hooks.py
@@ -69,6 +69,57 @@ class TestRegistration:
         assert len(get_hooks("00004", HookEvent.TASK_START)) == 1
         assert len(get_hooks("00004", HookEvent.POST_TOOL)) == 1
 
+    def test_register_cc_nested_format(self):
+        """CC settings.json format: {matcher: ..., hooks: [{type: command, command: ...}]}"""
+        hooks_meta = {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash|Write",
+                    "hooks": [
+                        {"type": "command", "command": "echo pre-tool"},
+                    ],
+                },
+            ],
+            "Stop": [
+                {
+                    "matcher": "",
+                    "hooks": [
+                        {"type": "command", "command": "echo session-end"},
+                    ],
+                },
+            ],
+        }
+        count = register_skill_hooks("00004", "cc-skill", hooks_meta)
+        assert count == 2
+        # PreToolUse → PRE_TOOL
+        hooks = get_hooks("00004", HookEvent.PRE_TOOL)
+        assert len(hooks) == 1
+        assert hooks[0].matcher == "Bash|Write"
+        assert hooks[0].command == "echo pre-tool"
+        # Stop → TASK_COMPLETE
+        assert len(get_hooks("00004", HookEvent.TASK_COMPLETE)) == 1
+
+    def test_register_cc_frontmatter_format(self):
+        """CC frontmatter format: before_start/after_complete/on_error with trigger."""
+        hooks_meta = {
+            "before_start": [
+                {"trigger": "session-logger", "mode": "auto"},
+            ],
+            "after_complete": [
+                {"trigger": "create-pr", "mode": "ask_first"},
+                {"trigger": "session-logger", "mode": "auto"},
+            ],
+            "on_error": [
+                {"trigger": "session-logger", "mode": "auto"},
+            ],
+        }
+        count = register_skill_hooks("00004", "sia", hooks_meta)
+        # ask_first skipped, 3 registered (before_start + after_complete + on_error)
+        assert count == 3
+        assert len(get_hooks("00004", HookEvent.TASK_START)) == 1
+        assert len(get_hooks("00004", HookEvent.TASK_COMPLETE)) == 1
+        assert len(get_hooks("00004", HookEvent.TASK_ERROR)) == 1
+
     def test_skip_ask_first_mode(self):
         hooks_meta = {
             "task_complete": [


### PR DESCRIPTION
## Summary
Implements a unified hooks engine matching CC's lifecycle hook pattern for company-hosted LangChain agents.

### Events (6)
| Event | Trigger | Location |
|-------|---------|----------|
| `pre_tool` | Before tool execution | execute_tool |
| `post_tool` | After tool success | execute_tool |
| `post_tool_failure` | After tool failure | execute_tool |
| `task_start` | Task begins | _execute_task PROCESSING |
| `task_complete` | Task finishes | _execute_task COMPLETED |
| `task_error` | Task fails | _execute_task FAILED |

### Hook types
- **command**: shell script with JSON stdin/stdout, CC exit codes (0=ok, 2=block)
- **callback**: Python callable (internal, for bridging legacy vessel.yaml hooks)

### Key design
- **Single system**: replaces old vessel._hooks dict. Legacy hooks bridged via `register_callback_hook()`
- **SKILL.md frontmatter**: hooks defined in `metadata.hooks` section
- **Startup loading**: all employee skills scanned for hooks on server start
- **Extensible**: designed for seamless expansion to CC's full 26-event set

### Files
| File | Change |
|------|--------|
| `core/skill_hooks.py` | New: 400-line hook engine (registry, matcher, executor) |
| `core/tool_registry.py` | pre/post tool hooks in execute_tool |
| `core/vessel.py` | task lifecycle hooks + legacy bridge in register_hooks |
| `main.py` | startup hook loading |
| `tests/unit/core/test_skill_hooks.py` | 20 tests |

## Test plan
- [x] 2400 unit tests pass
- [x] 20 new hook-specific tests (matcher, registration, callback execution, filtering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)