### PR TITLE
fix: sync hook scripts for existing employees

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.84",
+  "version": "0.4.85",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.84"
+version = "0.4.85"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -642,6 +642,21 @@ def _inject_default_skills(skills_dir: Path) -> None:
             dst_md = dst / "SKILL.md"
             if src_md.exists():
                 shutil.copy2(str(src_md), str(dst_md))
+            # Sync hooks/ and other subdirectories (new scripts, templates)
+            for sub in src.iterdir():
+                if sub.is_dir() and sub.name != "__pycache__":
+                    dst_sub = dst / sub.name
+                    if not dst_sub.exists():
+                        shutil.copytree(str(sub), str(dst_sub))
+                    else:
+                        # Copy new files into existing subdir
+                        for f in sub.iterdir():
+                            dst_f = dst_sub / f.name
+                            if not dst_f.exists():
+                                if f.is_file():
+                                    shutil.copy2(str(f), str(dst_f))
+                                elif f.is_dir():
+                                    shutil.copytree(str(f), str(dst_f))
 
 
 def _assign_default_avatar(emp_dir: Path, emp_num: str) -> None:


### PR DESCRIPTION
## Summary
`_inject_default_skills` only synced SKILL.md for existing employees, skipping new files in subdirectories like `hooks/`. This caused employees 00002-00005 to miss `session-logger.sh` while 00001 (fresh copytree) had it.

Now also copies new files in `hooks/`, `templates/`, `memory/`, and other subdirectories without overwriting existing employee-specific files.

## Test plan
- [x] 76 onboarding tests pass
- [ ] Manual: restart, verify all employees have session-logger.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)