### PR TITLE
fix: custom provider tasks fail with 401 — not in PROVIDER_REGISTRY

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.85",
+  "version": "0.4.86",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.85"
+version = "0.4.86"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -210,7 +210,7 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
             # Allow custom base_url override: provider-specific or global
             if api_provider == "openrouter":
                 base_url = settings.openrouter_base_url
-            elif settings.default_api_base_url and api_provider == settings.default_api_provider:
+            elif api_provider == "custom" or (settings.default_api_base_url and api_provider == settings.default_api_provider):
                 base_url = settings.default_api_base_url
             return ChatOpenAI(
                 model=model,

--- a/src/onemancompany/core/auth_apply/api_key.py
+++ b/src/onemancompany/core/auth_apply/api_key.py
@@ -26,13 +26,10 @@ async def apply_api_key_company(
     )
 
     provider_cfg = get_provider(provider)
-    if not provider_cfg and provider != "custom":
+    if not provider_cfg:
         return {"error": "Unknown provider", "code": "invalid_provider"}
 
-    if provider == "custom":
-        env_key = "custom_api_key"
-    else:
-        env_key = provider_cfg.env_key
+    env_key = provider_cfg.env_key
 
     if not env_key:
         return {"error": f"No env_key configured for provider {provider}", "code": "config_error"}

--- a/src/onemancompany/core/auth_choices.py
+++ b/src/onemancompany/core/auth_choices.py
@@ -87,8 +87,6 @@ def validate_registry_consistency() -> list[str]:
     from onemancompany.core.config import PROVIDER_REGISTRY
     warnings = []
     for group in AUTH_CHOICE_GROUPS:
-        if group.group_id == "custom":
-            continue
         if group.group_id not in PROVIDER_REGISTRY:
             warnings.append(
                 f"AUTH_CHOICE_GROUPS group_id '{group.group_id}' "

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -458,6 +458,10 @@ PROVIDER_REGISTRY: dict[str, ProviderConfig] = {
         env_key="minimax_api_key",
         health_url="https://api.minimax.chat/v1/models",
     ),
+    "custom": ProviderConfig(
+        base_url="",  # user-provided via DEFAULT_API_BASE_URL
+        env_key="custom_api_key",
+    ),
 }
 
 
@@ -534,6 +538,7 @@ class Settings(BaseSettings):
     together_api_key: str = ""
     google_api_key: str = ""
     minimax_api_key: str = ""
+    custom_api_key: str = ""
 
     # Default provider & model
     default_api_provider: str = "openrouter"

--- a/tests/unit/agents/test_settings_api_key.py
+++ b/tests/unit/agents/test_settings_api_key.py
@@ -61,8 +61,10 @@ def test_test_provider_key_uses_valid_model():
     # a) Use the provider's health_url for verification, or
     # b) Use a sensible default model name
 
-    # Verify all providers have health_url configured
+    # Verify all providers have health_url configured (custom excluded — user-provided)
     for name, prov in PROVIDER_REGISTRY.items():
+        if name == "custom":
+            continue
         assert prov.health_url, f"Provider '{name}' missing health_url for key verification"
 
 


### PR DESCRIPTION
## Summary
Custom provider 配置后，任务分发报 401 Missing Authentication header。

**Root cause**: `custom` provider 只在 `auth_apply` 里特殊处理（写 `CUSTOM_API_KEY` 到 .env），但没注册到 `PROVIDER_REGISTRY`。`make_llm` 找不到 → 跳过正常的 OpenAI/Anthropic 分支 → fallback 到 OpenRouter（空 key）→ 401。

**Fix**:
- `PROVIDER_REGISTRY` 加 `custom` 条目（`env_key="custom_api_key"`，`base_url=""` 由用户提供）
- `Settings` 加 `custom_api_key` 字段
- `make_llm` 对 custom provider 使用 `default_api_base_url`
- 删除 `auth_apply` 和 `auth_choices` 里的 custom 特殊处理

## Test plan
- [x] Full suite: 2401 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)