### PR TITLE
fix: onboarding remaps custom provider to openai — loses identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.86",
+  "version": "0.4.87",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.86"
+version = "0.4.87"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -173,8 +173,13 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
 
     prov = get_provider(api_provider)
 
+    # For custom provider, override chat_class from runtime settings
+    effective_chat_class = prov.chat_class if prov else CHAT_CLASS_OPENAI
+    if api_provider == "custom" and settings.custom_chat_class:
+        effective_chat_class = settings.custom_chat_class
+
     # --- Anthropic (non-OpenAI-compatible) ---
-    if prov and prov.chat_class == CHAT_CLASS_ANTHROPIC:
+    if prov and effective_chat_class == CHAT_CLASS_ANTHROPIC:
         from langchain_anthropic import ChatAnthropic
 
         auth_method = ""
@@ -203,7 +208,7 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
             )
 
     # --- OpenAI-compatible providers (openrouter, openai, kimi, deepseek, etc.) ---
-    if prov and prov.chat_class == CHAT_CLASS_OPENAI:
+    if prov and effective_chat_class == CHAT_CLASS_OPENAI:
         effective_key = _resolve_provider_key(api_provider, api_key)
         if effective_key:
             base_url = prov.base_url

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -1321,8 +1321,10 @@ async def _fetch_provider_models(provider: str) -> dict:
     if not prov_cfg:
         return {"models": [], "error": f"Unknown provider '{provider}'"}
 
-    # Determine models URL: base_url/models for most, health_url for anthropic/google
-    if prov_cfg.base_url:
+    # Determine models URL: custom base_url → registry base_url → health_url
+    if provider == "custom" and settings.default_api_base_url:
+        models_url = f"{settings.default_api_base_url.rstrip('/')}/models"
+    elif prov_cfg.base_url:
         models_url = f"{prov_cfg.base_url.rstrip('/')}/models"
     elif prov_cfg.health_url and "/models" in prov_cfg.health_url:
         models_url = prov_cfg.health_url

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -543,6 +543,7 @@ class Settings(BaseSettings):
     # Default provider & model
     default_api_provider: str = "openrouter"
     default_api_base_url: str = ""  # Custom base URL override for the default provider
+    custom_chat_class: str = "openai"  # "openai" | "anthropic" — API format for custom provider
     default_llm_model: str = "google/gemini-3.1-flash-lite-preview"
 
     # FastSkills MCP

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -360,9 +360,10 @@ def _step_llm(console: Console) -> tuple[str, str, str, str]:
 
     # 3. Custom provider: ask for API compatibility and base URL
     base_url = ""
+    custom_chat_class = ""
     if provider == "custom":
-        # Custom provider must map to a real API format
-        compat = _inq.select(
+        # Custom provider — ask API format, keep provider as "custom"
+        custom_chat_class = _inq.select(
             message="API compatibility:",
             choices=[
                 {"name": "OpenAI-compatible (most providers)", "value": "openai"},
@@ -371,7 +372,6 @@ def _step_llm(console: Console) -> tuple[str, str, str, str]:
             default="openai",
             style=INQ_STYLE,
         ).execute()
-        provider = compat  # Remap to real provider for make_llm
         console.print(
             f"\n  [dim]Enter your API base URL.[/dim]\n"
             f"  [dim]Examples: https://api.openai.com/v1, https://your-server.com/v1[/dim]"
@@ -413,7 +413,7 @@ def _step_llm(console: Console) -> tuple[str, str, str, str]:
             style=INQ_STYLE,
         ).execute().strip()
 
-    return provider, api_key.strip(), model, base_url
+    return provider, api_key.strip(), model, base_url, custom_chat_class
 
 
 def _step_server(console: Console) -> tuple[str, int]:
@@ -691,6 +691,7 @@ def _step_execute(
     sandbox_enabled: bool = False,
     founder_families: dict[str, str] | None = None,
     base_url: str = "",
+    custom_chat_class: str = "",
 ) -> None:
     console.print()
     _print_step(console, 6, "GENESIS", "Company Initialization")
@@ -744,6 +745,9 @@ def _step_execute(
     # Custom base URL (for non-default provider endpoints)
     if base_url and prov_cfg and base_url != prov_cfg.base_url:
         env_lines.append(f"DEFAULT_API_BASE_URL={base_url}")
+    # Custom provider chat class
+    if custom_chat_class:
+        env_lines.append(f"CUSTOM_CHAT_CLASS={custom_chat_class}")
     # Also write base_url for OpenRouter (needed by existing code)
     if provider == PROVIDER_OPENROUTER:
         env_lines.append("OPENROUTER_BASE_URL=https://openrouter.ai/api/v1")
@@ -1004,13 +1008,13 @@ def run_wizard() -> None:
             return
 
     founder_families = _step_agent_family(console)      # Step 1: Agent Family
-    provider, api_key, model, base_url = _step_llm(console)  # Step 2: LLM Provider & Key
+    provider, api_key, model, base_url, custom_chat_class = _step_llm(console)  # Step 2: LLM Provider & Key
     extras = _step_optional(console)                     # Step 3: External Integrations
     sandbox_enabled = _step_sandbox(console)             # Step 4: Sandbox
     host, port = _step_server(console)                   # Step 5: Server
     _step_execute(console, provider, api_key, model, host, port, extras,
                   sandbox_enabled=sandbox_enabled, founder_families=founder_families,
-                  base_url=base_url)
+                  base_url=base_url, custom_chat_class=custom_chat_class)
     _step_done(console, host, port)
 
 


### PR DESCRIPTION
## Summary
Onboarding 选 custom provider 后，代码把 provider 改写为 "openai"/"anthropic"（line 374），导致：
1. `.env` 写 `DEFAULT_API_PROVIDER=openai` 而非 `custom`
2. API key 存到 `OPENAI_API_KEY` 而非 `CUSTOM_API_KEY`
3. Settings 面板显示 OpenAI 卡片而非 Custom
4. 模型下拉从 api.openai.com 拉列表，不是用户配的自定义 URL

**Fix**:
- Onboarding 保留 `provider="custom"`，API 格式存为 `CUSTOM_CHAT_CLASS` env var
- `make_llm` 读 `custom_chat_class` 决定用 ChatOpenAI 还是 ChatAnthropic
- Models 端点对 custom provider 用 `default_api_base_url` 拉模型

## Test plan
- [x] Full suite: 2401 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)