### PR TITLE
fix: allow re-triggering project completion card after CEO responds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.88",
+  "version": "0.4.89",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.88"
+version = "0.4.89"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -2623,14 +2623,19 @@ class EmployeeManager:
                     ea_parent.set_status(TaskPhase.COMPLETED)
                     logger.debug("[TASK LIFECYCLE] CEO parent={} → COMPLETED", ea_parent.id)
 
-            # Guard: don't create duplicate confirm nodes for THIS specific EA
+            # Guard: don't create duplicate confirm nodes for THIS specific EA.
+            # Only block if there's an UNRESOLVED confirm node (pending/processing).
+            # Resolved ones (finished/cancelled) should not block re-completion
+            # after CEO gives new instructions.
+            _terminal = {TaskPhase.FINISHED.value, TaskPhase.CANCELLED.value, TaskPhase.ACCEPTED.value}
             existing_confirm = any(
                 c for c in tree.get_children(ea_node.id)
                 if (c.node_type == NodeType.CEO_REQUEST.value or c.node_type == NodeType.CEO_REQUEST)
                 and c.employee_id == _CEO_ID
+                and c.status not in _terminal
             )
             if existing_confirm:
-                logger.debug("[PROJECT COMPLETE] Confirm node already exists for EA {} — skipping", ea_node.id)
+                logger.debug("[PROJECT COMPLETE] Unresolved confirm node already exists for EA {} — skipping", ea_node.id)
             else:
                 # Build completion summary for CEO
                 _pdir = ea_node.project_dir or str(Path(entry.tree_path).parent)

--- a/tests/unit/core/test_completion_card.py
+++ b/tests/unit/core/test_completion_card.py
@@ -1,0 +1,86 @@
+"""Regression test: completion card should be re-creatable after CEO responds.
+
+Bug: existing_confirm guard blocked ALL CEO_REQUEST children, even already-resolved
+ones. After CEO replied to a completion card and the project got new work, the second
+completion never triggered because the old (finished) CEO_REQUEST still existed.
+
+Fix: Only block on unresolved (pending/processing) CEO_REQUEST nodes.
+"""
+
+from onemancompany.core.task_lifecycle import TaskPhase, NodeType
+from onemancompany.core.task_tree import TaskNode
+
+
+def _make_node(node_id, parent_id="", employee_id="00004", node_type=NodeType.TASK, status=TaskPhase.FINISHED.value):
+    node = TaskNode(
+        id=node_id,
+        parent_id=parent_id,
+        employee_id=employee_id,
+        node_type=node_type.value if hasattr(node_type, 'value') else node_type,
+        description=f"test node {node_id}",
+        status=status,
+    )
+    return node
+
+
+class TestCompletionCardGuard:
+    """The existing_confirm guard should only block on unresolved CEO_REQUEST nodes."""
+
+    def test_no_existing_confirm_allows_creation(self):
+        """No CEO_REQUEST children → should allow creation."""
+        children = [
+            _make_node("child1", parent_id="ea1", employee_id="00006"),
+        ]
+        _terminal = {TaskPhase.FINISHED.value, TaskPhase.CANCELLED.value, TaskPhase.ACCEPTED.value}
+        existing_confirm = any(
+            c for c in children
+            if (c.node_type == NodeType.CEO_REQUEST.value or c.node_type == NodeType.CEO_REQUEST)
+            and c.employee_id == "00001"
+            and c.status not in _terminal
+        )
+        assert existing_confirm is False
+
+    def test_finished_confirm_allows_re_creation(self):
+        """A FINISHED CEO_REQUEST should NOT block a new completion card."""
+        children = [
+            _make_node("confirm1", parent_id="ea1", employee_id="00001",
+                       node_type=NodeType.CEO_REQUEST, status=TaskPhase.FINISHED.value),
+        ]
+        _terminal = {TaskPhase.FINISHED.value, TaskPhase.CANCELLED.value, TaskPhase.ACCEPTED.value}
+        existing_confirm = any(
+            c for c in children
+            if (c.node_type == NodeType.CEO_REQUEST.value or c.node_type == NodeType.CEO_REQUEST)
+            and c.employee_id == "00001"
+            and c.status not in _terminal
+        )
+        assert existing_confirm is False  # should allow re-creation
+
+    def test_pending_confirm_blocks_duplicate(self):
+        """A PENDING CEO_REQUEST should block duplicate creation."""
+        children = [
+            _make_node("confirm1", parent_id="ea1", employee_id="00001",
+                       node_type=NodeType.CEO_REQUEST, status=TaskPhase.PENDING.value),
+        ]
+        _terminal = {TaskPhase.FINISHED.value, TaskPhase.CANCELLED.value, TaskPhase.ACCEPTED.value}
+        existing_confirm = any(
+            c for c in children
+            if (c.node_type == NodeType.CEO_REQUEST.value or c.node_type == NodeType.CEO_REQUEST)
+            and c.employee_id == "00001"
+            and c.status not in _terminal
+        )
+        assert existing_confirm is True  # should block
+
+    def test_cancelled_confirm_allows_re_creation(self):
+        """A CANCELLED CEO_REQUEST should NOT block a new completion card."""
+        children = [
+            _make_node("confirm1", parent_id="ea1", employee_id="00001",
+                       node_type=NodeType.CEO_REQUEST, status=TaskPhase.CANCELLED.value),
+        ]
+        _terminal = {TaskPhase.FINISHED.value, TaskPhase.CANCELLED.value, TaskPhase.ACCEPTED.value}
+        existing_confirm = any(
+            c for c in children
+            if (c.node_type == NodeType.CEO_REQUEST.value or c.node_type == NodeType.CEO_REQUEST)
+            and c.employee_id == "00001"
+            and c.status not in _terminal
+        )
+        assert existing_confirm is False  # should allow re-creation


### PR DESCRIPTION
## Summary
After CEO replies to a project completion card and gives new instructions, the project could never send a second completion card.

## Root Cause
The `existing_confirm` guard matched ALL CEO_REQUEST children including already-finished ones.

## Fix
Only block on unresolved (pending/processing) CEO_REQUEST nodes. Finished/cancelled/accepted ones no longer prevent re-completion.

## Test plan
- [x] 4 regression tests
- [x] 2288 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)