### PR TITLE
fix: cron tasks dispatch under original project context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.89",
+  "version": "0.4.90",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.89"
+version = "0.4.90"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -1267,7 +1267,11 @@ async def set_cron(cron_name: str, interval: str, task_description: str, employe
         employee_id: Your employee ID (auto-filled).
     """
     from onemancompany.core.automation import start_cron
-    return start_cron(employee_id, cron_name, interval, task_description)
+    ctx = _get_current_task_context()
+    project_id = ctx[0] if ctx else ""
+    tree_path = ctx[1] if ctx else ""
+    return start_cron(employee_id, cron_name, interval, task_description,
+                      project_id=project_id, tree_path=tree_path)
 
 
 @tool
@@ -1344,10 +1348,15 @@ def list_automations(employee_id: str = "") -> dict:
 
 
 def _get_current_project_id() -> str | None:
-    """Try to get project_id from current task context.
+    """Try to get project_id from current task context."""
+    ctx = _get_current_task_context()
+    return ctx[0] if ctx else None
 
-    Uses the _current_task_id context var to look up the executing TaskNode
-    and return its project_id.  Returns None if not in a task context.
+
+def _get_current_task_context() -> tuple[str, str] | None:
+    """Get (project_id, tree_path) from current task context.
+
+    Returns None if not in a task context.
     """
     try:
         task_id = _current_task_id.get("")
@@ -1356,7 +1365,6 @@ def _get_current_project_id() -> str | None:
         vessel = _current_vessel.get(None)
         if not vessel:
             return None
-        # Walk the employee_manager schedule to find the tree_path for this node
         from onemancompany.core.vessel import employee_manager
         for _emp_id, entries in employee_manager._schedule.items():
             for entry in entries:
@@ -1365,10 +1373,11 @@ def _get_current_project_id() -> str | None:
                     tree = get_tree(entry.tree_path)
                     node = tree.get_node(task_id)
                     if node and node.project_id:
-                        return node.project_id
+                        return (node.project_id, entry.tree_path)
                     return None
         return None
-    except Exception:
+    except Exception as e:
+        logger.debug("_get_current_task_context failed: {}", e)
         return None
 
 

--- a/src/onemancompany/core/automation.py
+++ b/src/onemancompany/core/automation.py
@@ -89,22 +89,95 @@ def _broadcast_cron_status(employee_id: str, cron_name: str, running: bool) -> N
         logger.warning("[cron] Broadcast cron_status_change failed: {}", e)
 
 
-async def _cron_loop(employee_id: str, cron_name: str, interval_seconds: int, task_description: str) -> None:
-    """Background loop that dispatches a task at regular intervals."""
-    logger.info("[cron] Started '{}' for {} every {}s", cron_name, employee_id, interval_seconds)
+async def _cron_loop(
+    employee_id: str, cron_name: str, interval_seconds: int,
+    task_description: str, project_id: str = "", tree_path: str = "",
+) -> None:
+    """Background loop that dispatches a task at regular intervals.
+
+    If tree_path is set, tasks are added as child nodes in the existing
+    project tree (root-level). Otherwise, falls back to _push_adhoc_task.
+    """
+    logger.info("[cron] Started '{}' for {} every {}s (project={}, tree={})",
+                cron_name, employee_id, interval_seconds, project_id or "none", bool(tree_path))
     try:
         while True:
             await asyncio.sleep(interval_seconds)
             try:
-                from onemancompany.api.routes import _push_adhoc_task
-                node_id, _tree_path = _push_adhoc_task(employee_id, f"[cron:{cron_name}] {task_description}")
+                node_id = _dispatch_cron_task(
+                    employee_id, cron_name, task_description,
+                    project_id=project_id, tree_path=tree_path,
+                )
                 _record_dispatched_task(employee_id, cron_name, node_id)
-                logger.debug("[cron] Dispatched '{}' to {}, node_id={}", cron_name, employee_id, node_id)
+                logger.debug("[cron] Dispatched '{}' to {}, node_id={} project={}",
+                             cron_name, employee_id, node_id, project_id or "adhoc")
             except Exception as e:
                 logger.error("[cron] Failed to dispatch '{}' to {}: {}", cron_name, employee_id, e)
     except asyncio.CancelledError:
-        logger.info(f"[cron] Stopped '{cron_name}' for {employee_id}")
+        logger.info("[cron] Stopped '{}' for {}", cron_name, employee_id)
         raise
+
+
+def _dispatch_cron_task(
+    employee_id: str, cron_name: str, task_description: str,
+    project_id: str = "", tree_path: str = "",
+) -> str:
+    """Dispatch a single cron task. Returns node_id.
+
+    If tree_path points to a valid project tree, adds a child node to it.
+    Otherwise, creates a standalone adhoc task.
+    """
+    desc = f"[cron:{cron_name}] {task_description}"
+
+    if tree_path:
+        try:
+            return _add_to_project_tree(employee_id, desc, tree_path, project_id)
+        except Exception as e:
+            logger.warning("[cron] Failed to add to project tree, falling back to adhoc: {}", e)
+
+    # Fallback: standalone adhoc task
+    from onemancompany.api.routes import _push_adhoc_task
+    node_id, _tp = _push_adhoc_task(employee_id, desc, project_id=project_id)
+    return node_id
+
+
+def _add_to_project_tree(
+    employee_id: str, description: str, tree_path: str, project_id: str,
+) -> str:
+    """Add a cron task as a child node in an existing project tree."""
+    from pathlib import Path
+    from onemancompany.core.task_tree import get_tree, save_tree_async, get_tree_lock
+    from onemancompany.core.vessel import employee_manager
+
+    tp = Path(tree_path)
+    if not tp.exists():
+        raise FileNotFoundError(f"Tree not found: {tree_path}")
+
+    with get_tree_lock(tp):
+        tree = get_tree(tp)
+        parent_id = tree.root_id
+        if not parent_id:
+            raise ValueError("Tree has no root node")
+
+        child = tree.add_child(
+            parent_id=parent_id,
+            employee_id=employee_id,
+            description=description,
+            acceptance_criteria=[],
+        )
+        # Mark as ADHOC so it doesn't block project completion checks
+        from onemancompany.core.task_lifecycle import NodeType
+        child.node_type = NodeType.ADHOC.value
+        child.task_type = "simple"  # auto-skip completed → accepted → finished
+        child.project_id = project_id
+        child.project_dir = str(tp.parent)
+
+    # Save outside lock (save_tree_async acquires its own RLock internally)
+    save_tree_async(tp)
+
+    employee_manager.schedule_node(employee_id, child.id, str(tp))
+    employee_manager._schedule_next(employee_id)
+    return child.id
 
 
 def _record_dispatched_task(employee_id: str, cron_name: str, task_id: str) -> None:
@@ -121,7 +194,7 @@ def _record_dispatched_task(employee_id: str, cron_name: str, task_id: str) -> N
     _save_automations(employee_id, data)
 
 
-def start_cron(employee_id: str, cron_name: str, interval: str, task_description: str) -> dict:
+def start_cron(employee_id: str, cron_name: str, interval: str, task_description: str, project_id: str = "", tree_path: str = "") -> dict:
     """Start a cron job for an employee.
 
     Args:
@@ -129,6 +202,8 @@ def start_cron(employee_id: str, cron_name: str, interval: str, task_description
         cron_name: Unique name for this cron (per employee).
         interval: Interval string like '5m', '1h', '30s'.
         task_description: Task to dispatch each interval.
+        project_id: If set, cron tasks are dispatched under this project.
+        tree_path: If set, cron tasks are added as child nodes in this tree.
     """
     seconds = _parse_interval(interval)
     if seconds is None or seconds < 10:
@@ -142,7 +217,10 @@ def start_cron(employee_id: str, cron_name: str, interval: str, task_description
         existing.cancel()
 
     # Start background task
-    task = asyncio.create_task(_cron_loop(employee_id, cron_name, seconds, task_description))
+    task = asyncio.create_task(_cron_loop(
+        employee_id, cron_name, seconds, task_description,
+        project_id=project_id, tree_path=tree_path,
+    ))
     _cron_tasks[key] = task
 
     # Persist
@@ -153,6 +231,8 @@ def start_cron(employee_id: str, cron_name: str, interval: str, task_description
         _KEY_NAME: cron_name,
         "interval": interval,
         "task_description": task_description,
+        "project_id": project_id,
+        "tree_path": tree_path,
         "created": datetime.now(timezone.utc).isoformat(),
     })
     _save_automations(employee_id, data)
@@ -319,9 +399,14 @@ def restore_all_crons() -> int:
             if name and interval and desc:
                 seconds = _parse_interval(interval)
                 if seconds and seconds >= 10:
+                    pid = c.get("project_id", "")
+                    tp = c.get("tree_path", "")
                     key = f"{employee_id}:{name}"
                     if key not in _cron_tasks or _cron_tasks[key].done():
-                        task = asyncio.create_task(_cron_loop(employee_id, name, seconds, desc))
+                        task = asyncio.create_task(_cron_loop(
+                            employee_id, name, seconds, desc,
+                            project_id=pid, tree_path=tp,
+                        ))
                         _cron_tasks[key] = task
                         count += 1
     return count

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -3351,7 +3351,8 @@ class EmployeeManager:
             project_id = node.project_id
 
             async def _push():
-                if project_id:
+                # Real projects get project conversations; system tasks (_sys_*) go to 1-on-1
+                if project_id and not project_id.startswith("_sys_"):
                     conv = await service.get_or_create_project_conversation(
                         project_id, [node.employee_id]
                     )


### PR DESCRIPTION
## Summary
**Root fix:** Cron tasks now add child nodes to the originating project's task tree instead of creating standalone `_sys_*` adhoc tasks on every trigger.

## Before
```
cron trigger → _push_adhoc_task → new _sys_abc123 tree (orphan)
cron trigger → _push_adhoc_task → new _sys_def456 tree (orphan)
cron trigger → _push_adhoc_task → new _sys_ghi789 tree (orphan)
```
Every trigger created a new system project. Tasks had no relationship to the original project.

## After
```
cron trigger → tree.add_child(root) → child node in project tree
cron trigger → tree.add_child(root) → child node in project tree
cron trigger → tree.add_child(root) → child node in project tree
```
All cron tasks are child nodes of the project's task tree. They share project context, appear in the project's task board, and their results push to the project conversation.

## Implementation
- `_dispatch_cron_task()` — new function that routes to `_add_to_project_tree()` (if tree_path set) or falls back to `_push_adhoc_task` (standalone crons)
- `_add_to_project_tree()` — loads project tree, adds child node via `tree.add_child()`, schedules via `employee_manager.schedule_node()`
- `set_cron` tool captures `tree_path` from current task context via `_get_current_task_context()`
- `tree_path` persisted in `automations.yaml` for restore on restart

## Test plan
- [x] 119 cron/automation/common_tools tests pass
- [ ] Manual: create cron in project, verify tasks appear as child nodes in project tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)