### PR TITLE
fix: task tree avatar images + description display

### DIFF
--- a/frontend/task-tree-g6.js
+++ b/frontend/task-tree-g6.js
@@ -97,7 +97,7 @@ G6.registerNode('org-card', {
             name: 'status-bar',
         });
 
-        // --- Right-side avatar circle ---
+        // --- Right-side avatar ---
         const avatarX = w - 28;
         const avatarY = 24;
         const avatarR = 16;
@@ -108,16 +108,36 @@ G6.registerNode('org-card', {
             },
             name: 'avatar-bg',
         });
-        group.addShape('text', {
-            attrs: {
-                x: avatarX, y: avatarY,
-                text: cfg.avatar || '?',
-                fontSize: 12, fontWeight: 'bold',
-                fill: deptColor.text,
-                textAlign: 'center', textBaseline: 'middle',
-            },
-            name: 'avatar-text',
-        });
+        // Use avatar image if available, fallback to initials text
+        if (cfg.avatarUrl) {
+            group.addShape('image', {
+                attrs: {
+                    x: avatarX - avatarR, y: avatarY - avatarR,
+                    width: avatarR * 2, height: avatarR * 2,
+                    img: cfg.avatarUrl,
+                },
+                name: 'avatar-img',
+            });
+            // Clip circle over image
+            group.addShape('circle', {
+                attrs: {
+                    x: avatarX, y: avatarY, r: avatarR,
+                    fill: 'transparent', stroke: deptColor.badge, lineWidth: 2,
+                },
+                name: 'avatar-border',
+            });
+        } else {
+            group.addShape('text', {
+                attrs: {
+                    x: avatarX, y: avatarY,
+                    text: cfg.avatar || '?',
+                    fontSize: 12, fontWeight: 'bold',
+                    fill: deptColor.text,
+                    textAlign: 'center', textBaseline: 'middle',
+                },
+                name: 'avatar-text',
+            });
+        }
 
         // --- Name (bold) ---
         group.addShape('text', {
@@ -355,9 +375,10 @@ class TaskTreeRenderer {
                 id: n.id,
                 name: info.nickname || info.name || n.employee_id || n.id,
                 avatar: this._getAvatar(info, n.node_type),
+                avatarUrl: info.avatar_url || '',
                 dept: dept,
                 role: info.role || '',
-                desc: n.title || n.description_preview || n.description || '',
+                desc: n.description_preview || n.title || n.description || '',
                 status: n.status || 'pending',
                 _raw: n,
                 children: [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.93",
+  "version": "0.4.94",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.93"
+version = "0.4.94"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
Two fixes for the G6 task tree nodes:

1. **Avatar**: was showing first 2 chars of name as text. Now renders actual employee avatar image (`avatar_url` from API), with circle border. Falls back to initials only when no image.

2. **Description**: was prioritizing `title` (often empty) over `description_preview`. Now prioritizes `description_preview` (always has the 200-char task content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)