### PR TITLE
fix: activity log layout — timestamp padding + right-edge cutoff

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -757,9 +757,10 @@ class AppController {
     const fallback = (e) => ({ agent: (e.type || 'SYS').toUpperCase(), text: `${e.name || e.topic || e.task || e.type || ''}` });
     for (const e of entries) {
       const { agent, text } = (this._activityTypeMap[e.type] || fallback)(e);
-      const ts = e.timestamp ? e.timestamp.substring(11, 19) : '        ';
+      const ts = e.timestamp ? e.timestamp.substring(11, 19) : '';
       const color = this._activityLogAnsi[agent.toLowerCase()] || ANSI.gray;
-      this._activityXterm.writeln(`${ANSI.gray}${ts}${ANSI.reset} ${color}${agent}${ANSI.reset} ${text}`);
+      const prefix = ts ? `${ANSI.gray}${ts}${ANSI.reset} ` : '';
+      this._activityXterm.writeln(`${prefix}${color}${agent}${ANSI.reset} ${text}`);
     }
   }
 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -574,7 +574,7 @@ body.resize-dragging {
   border: 2px solid var(--border);
   border-top: none;
   border-radius: 0 0 2px 2px;
-  padding: 4px 2px 4px 4px;
+  padding: 4px 4px 4px 4px;
   flex: 1;
   overflow: hidden;  /* xterm.js handles its own scrolling */
   min-height: 0;

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -574,7 +574,7 @@ body.resize-dragging {
   border: 2px solid var(--border);
   border-top: none;
   border-radius: 0 0 2px 2px;
-  padding: 8px 16px 8px 10px;
+  padding: 4px 2px 4px 4px;
   flex: 1;
   overflow: hidden;  /* xterm.js handles its own scrolling */
   min-height: 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.95",
+  "version": "0.4.96",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.95"
+version = "0.4.96"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Remove 8-space blank padding when activity log entries have no timestamp — shows agent name immediately without the large gap
- Reduce `#activity-log` container padding (16px→2px right) so xterm.js FitAddon calculates column count correctly, preventing text from being clipped at the right edge

## Test plan
- [ ] Open Activity Log panel, verify no large blank space before employee names
- [ ] Verify right-side text is fully visible without cutoff
- [ ] Verify entries with timestamps still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)