### PR TITLE
feat: request_api_key tool — secure API key exchange via chat

### DIFF
--- a/company/shared_prompts/tool_usage.md
+++ b/company/shared_prompts/tool_usage.md
@@ -10,6 +10,7 @@
 - pull_meeting: ONLY for multi-person communication/discussion (2+ colleagues). Never call a meeting with yourself alone — if you need to think, just think internally.
 - use_tool: Access company equipment/tools registered by COO.
 - request_tool_access: Apply for access to tools you don't have permission to use.
+- request_api_key: Request an API key from the CEO. The key is stored securely as an environment variable. Fails if CEO is in Do Not Disturb mode — use alternatives in that case.
 
 ## Modifying Company-Level Knowledge
 When your task involves updating **company direction, culture, workflows, SOPs, or shared guidance**, you do NOT have direct write access to these resources. Instead:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.4.99",
+  "version": "0.5.0",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.4.99"
+version = "0.5.0"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -1413,7 +1413,9 @@ async def report_to_ceo(message: str, employee_id: str = "") -> dict:
 
 def _credential_env_key(service_name: str) -> str:
     """Convert service name to env var key: 'stripe' -> 'STRIPE_API_KEY'."""
-    return f"{service_name.upper().replace('-', '_').replace(' ', '_')}_API_KEY"
+    import re
+    clean = re.sub(r'[^A-Za-z0-9_]', '_', service_name.upper())
+    return f"{clean}_API_KEY"
 
 
 @tool

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -1411,6 +1411,107 @@ async def report_to_ceo(message: str, employee_id: str = "") -> dict:
     return {"status": "ok", "channel": conv.type, "conv_id": conv.id}
 
 
+def _credential_env_key(service_name: str) -> str:
+    """Convert service name to env var key: 'stripe' -> 'STRIPE_API_KEY'."""
+    return f"{service_name.upper().replace('-', '_').replace(' ', '_')}_API_KEY"
+
+
+@tool
+async def request_api_key(service_name: str, reason: str, employee_id: str = "") -> dict:
+    """Request an API key from the CEO via the chat channel.
+
+    CEO will see your request in the conversation and can type the key directly.
+    The key is stored securely as an environment variable and masked in chat history.
+
+    IMPORTANT: If CEO has Do Not Disturb mode on, this tool will fail immediately.
+    In that case, check if the key already exists via bash (echo $SERVICE_API_KEY),
+    or try an alternative approach that doesn't require the key.
+
+    Args:
+        service_name: The service name (e.g. "stripe", "openai", "github").
+            Stored as {SERVICE_NAME}_API_KEY environment variable.
+        reason: Why you need this API key — shown to CEO.
+        employee_id: Your employee ID (auto-filled).
+    """
+    if err := _validate_employee_id(employee_id):
+        return err
+
+    import os
+    from onemancompany.core.config import get_ceo_dnd
+    from onemancompany.core.conversation import get_conversation_service, Interaction
+
+    env_key = _credential_env_key(service_name)
+
+    # Check if key already exists
+    existing = os.environ.get(env_key)
+    if existing:
+        return {
+            "status": "already_exists",
+            "env_key": env_key,
+            "message": f"API key already available as ${env_key}.",
+        }
+
+    # DND guard — refuse immediately
+    if get_ceo_dnd():
+        return {
+            "status": "dnd_active",
+            "env_key": env_key,
+            "message": (
+                f"CEO is not available (Do Not Disturb). Cannot request API key for {service_name}. "
+                f"Try an alternative approach that doesn't require this key, "
+                f"or wait and retry when CEO is back."
+            ),
+        }
+
+    service = get_conversation_service()
+
+    # Use project conversation if in project context, else 1-on-1
+    project_id = _get_current_project_id()
+    if project_id:
+        conv = await service.get_or_create_project_conversation(project_id, [employee_id])
+    else:
+        conv = await service.get_or_create_oneonone(employee_id)
+
+    # Create interaction with credential_request type
+    import asyncio
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+
+    # Use a synthetic node_id for credential requests
+    import uuid
+    node_id = f"cred_{uuid.uuid4().hex[:8]}"
+
+    interaction = Interaction(
+        node_id=node_id,
+        tree_path="",
+        project_id=project_id or "",
+        source_employee=employee_id,
+        interaction_type="credential_request",
+        message=f"🔑 I need an API key for **{service_name}**.\nReason: {reason}\n\nPlease type the key below — it will be stored securely as `${env_key}` and masked in chat history.",
+        future=future,
+        credential_env_key=env_key,
+    )
+
+    await service.enqueue_interaction(conv.id, interaction)
+    logger.info("[request_api_key] employee={} service={} env_key={} conv={}", employee_id, service_name, env_key, conv.id)
+
+    # Block until CEO replies (or auto-reply if DND turns on later)
+    ceo_response = await future
+
+    # Check if we actually got a key (auto-reply would give a text response, not a key)
+    if ceo_response and len(ceo_response.strip()) > 0:
+        return {
+            "status": "ok",
+            "env_key": env_key,
+            "message": f"API key saved as ${env_key}. You can now use it.",
+        }
+    return {
+        "status": "no_key",
+        "env_key": env_key,
+        "message": "CEO did not provide an API key. Try an alternative approach.",
+    }
+
+
 # ---------------------------------------------------------------------------
 # Skill loading — on-demand skill content retrieval (Claude-style)
 # ---------------------------------------------------------------------------
@@ -1784,7 +1885,7 @@ def _register_all_internal_tools() -> None:
         set_cron, stop_cron_job, setup_webhook, remove_webhook,
         list_automations, report_to_ceo,
         start_background_task, check_background_task, stop_background_task,
-        list_background_tasks,
+        list_background_tasks, request_api_key,
     ]
     for t in _base:
         tool_registry.register(t, ToolMeta(name=t.name, category="base"))

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -6311,11 +6311,12 @@ async def send_ceo_session_message(project_id: str, body: dict):
     if conv.phase == ConversationPhase.ARCHIVED.value:
         await service.reactivate(conv.id)
 
-    # Save CEO message
-    await service.send_message(conv.id, "ceo", "CEO", text, mentions=mentions)
-
-    # Try to resolve pending interaction
+    # Try to resolve pending interaction BEFORE persisting message
     result = await service.resolve_interaction(conv.id, text)
+
+    # Persist CEO message (masked for credential requests)
+    display_text = result.get("display_text", text)
+    await service.send_message(conv.id, "ceo", "CEO", display_text, mentions=mentions)
 
     if result["type"] == "followup":
         # Dispatch as a CEO_FOLLOWUP via the existing task_followup logic.
@@ -6653,10 +6654,11 @@ async def send_conversation_message(conv_id: str, body: dict) -> dict:
     # where timeout=0 fires on next event loop tick).
     result = await service.resolve_interaction(conv_id, text)
     if result["type"] == "resolved":
-        # Persist CEO message to conversation history after resolving
+        # For credential requests, persist masked text instead of the actual key
+        display_text = result.get("display_text", text)
         try:
             await service.send_message(
-                conv_id, sender="ceo", role="CEO", text=text,
+                conv_id, sender="ceo", role="CEO", text=display_text,
                 attachments=body.get("attachments"),
             )
         except ValueError:

--- a/src/onemancompany/core/conversation.py
+++ b/src/onemancompany/core/conversation.py
@@ -45,10 +45,11 @@ class Interaction:
     tree_path: str
     project_id: str
     source_employee: str
-    interaction_type: str      # ceo_request | project_confirm
+    interaction_type: str      # ceo_request | project_confirm | credential_request
     message: str
     future: asyncio.Future = field(repr=False)
     created_at: str = ""
+    credential_env_key: str = ""  # for credential_request: env var name to store the key
 
     def __post_init__(self) -> None:
         if not self.created_at:
@@ -355,7 +356,20 @@ class ConversationService:
             "[conversation] resolved interaction conv_id={} node_id={} type={}",
             conv_id, interaction.node_id, interaction.interaction_type,
         )
-        return {"type": "resolved", "node_id": interaction.node_id}
+
+        result: dict = {"type": "resolved", "node_id": interaction.node_id}
+
+        # Credential requests: store as env var and mask the reply text
+        if interaction.interaction_type == "credential_request" and interaction.credential_env_key:
+            from onemancompany.core.config import update_env_var
+            update_env_var(interaction.credential_env_key, ceo_text)
+            result["display_text"] = f"••• (saved as {interaction.credential_env_key})"
+            logger.info(
+                "[conversation] stored credential {} for node={}",
+                interaction.credential_env_key, interaction.node_id,
+            )
+
+        return result
 
     def get_pending_count(self, conv_id: str) -> int:
         """Return the number of unresolved pending interactions for a conversation."""

--- a/src/onemancompany/core/conversation.py
+++ b/src/onemancompany/core/conversation.py
@@ -361,13 +361,23 @@ class ConversationService:
 
         # Credential requests: store as env var and mask the reply text
         if interaction.interaction_type == "credential_request" and interaction.credential_env_key:
-            from onemancompany.core.config import update_env_var
-            update_env_var(interaction.credential_env_key, ceo_text)
-            result["display_text"] = f"••• (saved as {interaction.credential_env_key})"
-            logger.info(
-                "[conversation] stored credential {} for node={}",
-                interaction.credential_env_key, interaction.node_id,
-            )
+            import os
+            clean_value = ceo_text.strip()
+            if clean_value and '\n' not in clean_value and '\r' not in clean_value:
+                from onemancompany.core.config import update_env_var
+                update_env_var(interaction.credential_env_key, clean_value)
+                os.environ[interaction.credential_env_key] = clean_value
+                result["display_text"] = f"••• (saved as {interaction.credential_env_key})"
+                logger.info(
+                    "[conversation] stored credential {} for node={}",
+                    interaction.credential_env_key, interaction.node_id,
+                )
+            else:
+                result["display_text"] = "(empty or invalid key — not saved)"
+                logger.warning(
+                    "[conversation] empty/invalid credential for {} node={}",
+                    interaction.credential_env_key, interaction.node_id,
+                )
 
         return result
 
@@ -380,7 +390,10 @@ class ConversationService:
         """Start timer. If CEO doesn't respond within timeout, EA auto-replies.
 
         When CEO DND mode is on, auto-reply triggers immediately (0s timeout).
+        Credential requests never auto-reply — must wait for CEO.
         """
+        if interaction.interaction_type == "credential_request":
+            return
         from onemancompany.core.config import get_ceo_dnd
         timeout = 0 if get_ceo_dnd() else AUTO_REPLY_TIMEOUT
 

--- a/tests/unit/agents/test_request_api_key.py
+++ b/tests/unit/agents/test_request_api_key.py
@@ -135,3 +135,97 @@ class TestResolveCredentialInteraction:
         assert result["type"] == "resolved"
         assert "display_text" not in result
         mock_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_credential_resolve_rejects_empty_key(self):
+        """Empty or whitespace-only key should not be stored."""
+        import asyncio
+        from onemancompany.core.conversation import ConversationService, Interaction
+
+        service = ConversationService.__new__(ConversationService)
+        service._pending = {}
+        service._auto_reply_tasks = {}
+
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        interaction = Interaction(
+            node_id="node_abc",
+            tree_path="",
+            project_id="proj_1",
+            source_employee="00004",
+            interaction_type="credential_request",
+            message="Need key",
+            future=future,
+            credential_env_key="EMPTY_API_KEY",
+        )
+        from collections import deque
+        service._pending["conv_123"] = deque([interaction])
+
+        with patch("onemancompany.core.config.update_env_var") as mock_update:
+            result = await service.resolve_interaction("conv_123", "   ")
+
+        assert result["display_text"] == "(empty or invalid key — not saved)"
+        mock_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_credential_resolve_rejects_newlines(self):
+        """Keys with newlines should not be stored (would corrupt .env)."""
+        import asyncio
+        from onemancompany.core.conversation import ConversationService, Interaction
+
+        service = ConversationService.__new__(ConversationService)
+        service._pending = {}
+        service._auto_reply_tasks = {}
+
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        interaction = Interaction(
+            node_id="node_abc",
+            tree_path="",
+            project_id="proj_1",
+            source_employee="00004",
+            interaction_type="credential_request",
+            message="Need key",
+            future=future,
+            credential_env_key="BAD_API_KEY",
+        )
+        from collections import deque
+        service._pending["conv_123"] = deque([interaction])
+
+        with patch("onemancompany.core.config.update_env_var") as mock_update:
+            result = await service.resolve_interaction("conv_123", "sk-abc\ninjection")
+
+        mock_update.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_credential_no_auto_reply_timer(self):
+        """Credential requests must NOT start auto-reply timer."""
+        import asyncio
+        from onemancompany.core.conversation import ConversationService, Interaction
+        from collections import deque
+
+        service = ConversationService.__new__(ConversationService)
+        service._pending = {}
+        service._auto_reply_tasks = {}
+        service._conversations = {}
+        service.send_message = AsyncMock()
+
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        interaction = Interaction(
+            node_id="node_abc",
+            tree_path="",
+            project_id="proj_1",
+            source_employee="00004",
+            interaction_type="credential_request",
+            message="Need key",
+            future=future,
+            credential_env_key="TEST_API_KEY",
+        )
+
+        with patch("onemancompany.core.conversation.event_bus") as mock_bus:
+            mock_bus.publish = AsyncMock()
+            await service.enqueue_interaction("conv_123", interaction)
+
+        # No timer should have been started
+        assert len(service._auto_reply_tasks) == 0

--- a/tests/unit/agents/test_request_api_key.py
+++ b/tests/unit/agents/test_request_api_key.py
@@ -1,0 +1,137 @@
+"""Tests for request_api_key tool."""
+from __future__ import annotations
+
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import pytest
+
+
+class TestRequestApiKey:
+    """request_api_key tool — agent requests API key from CEO via chat."""
+
+    @pytest.mark.asyncio
+    async def test_dnd_mode_returns_error(self):
+        """When CEO DND is on, tool should refuse and tell agent to try alternatives."""
+        from onemancompany.agents.common_tools import request_api_key
+
+        with patch("onemancompany.core.config.get_ceo_dnd", return_value=True):
+            result = await request_api_key.ainvoke({
+                "service_name": "stripe",
+                "reason": "Need payment processing",
+                "employee_id": "00004",
+            })
+
+        assert result["status"] == "dnd_active"
+        assert "alternative" in result["message"].lower() or "not available" in result["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_enqueues_interaction_when_available(self):
+        """When CEO is available, should enqueue a credential interaction."""
+        from onemancompany.agents.common_tools import request_api_key
+        from onemancompany.core.conversation import Interaction
+
+        mock_service = MagicMock()
+        mock_conv = MagicMock()
+        mock_conv.id = "conv_123"
+        mock_service.get_or_create_oneonone = AsyncMock(return_value=mock_conv)
+
+        # Auto-resolve the future when enqueue_interaction is called
+        async def _auto_resolve(conv_id, interaction):
+            interaction.future.set_result("sk-test-key-123")
+        mock_service.enqueue_interaction = AsyncMock(side_effect=_auto_resolve)
+
+        with patch("onemancompany.core.config.get_ceo_dnd", return_value=False), \
+             patch("onemancompany.core.conversation.get_conversation_service", return_value=mock_service), \
+             patch("onemancompany.core.conversation.event_bus") as mock_bus:
+            mock_bus.publish = AsyncMock()
+            result = await request_api_key.ainvoke({
+                "service_name": "stripe",
+                "reason": "Need payment processing",
+                "employee_id": "00004",
+            })
+
+        assert result["status"] == "ok"
+        assert result["env_key"] == "STRIPE_API_KEY"
+        mock_service.enqueue_interaction.assert_awaited_once()
+        # Verify interaction type is credential_request
+        call_args = mock_service.enqueue_interaction.call_args
+        interaction = call_args[0][1]
+        assert interaction.interaction_type == "credential_request"
+        assert interaction.credential_env_key == "STRIPE_API_KEY"
+        assert "stripe" in interaction.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_env_var_key_name(self):
+        """Service name should be converted to env var format."""
+        from onemancompany.agents.common_tools import _credential_env_key
+        assert _credential_env_key("stripe") == "STRIPE_API_KEY"
+        assert _credential_env_key("my_service") == "MY_SERVICE_API_KEY"
+        assert _credential_env_key("OpenAI") == "OPENAI_API_KEY"
+
+
+class TestResolveCredentialInteraction:
+    """resolve_interaction with credential_request type — mask and store."""
+
+    @pytest.mark.asyncio
+    async def test_credential_resolve_stores_env_var(self):
+        """Resolving a credential interaction should store the key as env var."""
+        import asyncio
+        from onemancompany.core.conversation import ConversationService, Interaction
+
+        service = ConversationService.__new__(ConversationService)
+        service._pending = {}
+        service._auto_reply_tasks = {}
+
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        interaction = Interaction(
+            node_id="node_abc",
+            tree_path="",
+            project_id="proj_1",
+            source_employee="00004",
+            interaction_type="credential_request",
+            message="🔑 Need Stripe API key",
+            future=future,
+            credential_env_key="STRIPE_API_KEY",
+        )
+        from collections import deque
+        service._pending["conv_123"] = deque([interaction])
+
+        with patch("onemancompany.core.config.update_env_var") as mock_update:
+            result = await service.resolve_interaction("conv_123", "sk-live-abc123")
+
+        assert result["type"] == "resolved"
+        assert result.get("display_text") == "••• (saved as STRIPE_API_KEY)"
+        mock_update.assert_called_once_with("STRIPE_API_KEY", "sk-live-abc123")
+        assert future.result() == "sk-live-abc123"
+
+    @pytest.mark.asyncio
+    async def test_normal_resolve_no_masking(self):
+        """Non-credential interactions should not mask or store env vars."""
+        import asyncio
+        from onemancompany.core.conversation import ConversationService, Interaction
+
+        service = ConversationService.__new__(ConversationService)
+        service._pending = {}
+        service._auto_reply_tasks = {}
+
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        interaction = Interaction(
+            node_id="node_abc",
+            tree_path="",
+            project_id="proj_1",
+            source_employee="00004",
+            interaction_type="ceo_request",
+            message="Need approval",
+            future=future,
+        )
+        from collections import deque
+        service._pending["conv_123"] = deque([interaction])
+
+        with patch("onemancompany.core.config.update_env_var") as mock_update:
+            result = await service.resolve_interaction("conv_123", "approved")
+
+        assert result["type"] == "resolved"
+        assert "display_text" not in result
+        mock_update.assert_not_called()


### PR DESCRIPTION
## Summary
New `request_api_key` tool lets agents request API keys from CEO through the conversation channel, like CC-agent's inline interaction pattern.

**Flow:**
1. Agent calls `request_api_key(service_name="stripe", reason="Need payment processing")`
2. Chat message: "🔑 I need an API key for **stripe**. Reason: ..."
3. CEO types the key in the **same chat box**
4. System auto-stores as env var (`STRIPE_API_KEY`), masks in chat history (`••• (saved as STRIPE_API_KEY)`)
5. Agent gets the key and continues

**DND guard:** When CEO is in Do Not Disturb mode, the tool refuses immediately with a message telling the agent to try alternatives.

**Security:** API key never appears in conversation history or logs — only the masked placeholder is stored.

### Changes
- `src/onemancompany/agents/common_tools.py` — new `request_api_key` tool + `_credential_env_key` helper
- `src/onemancompany/core/conversation.py` — `Interaction.credential_env_key` field, `resolve_interaction` stores env var + returns `display_text` mask for credential requests
- `src/onemancompany/api/routes.py` — both message endpoints use masked `display_text` for credential replies; project session endpoint resolve-before-send fix
- `company/shared_prompts/tool_usage.md` — document new tool

## Test plan
- [x] `test_dnd_mode_returns_error` — DND active → tool refuses
- [x] `test_enqueues_interaction_when_available` — enqueues credential interaction, blocks on future
- [x] `test_env_var_key_name` — service name → env var conversion
- [x] `test_credential_resolve_stores_env_var` — resolve stores key + returns masked display_text
- [x] `test_normal_resolve_no_masking` — non-credential interactions unchanged
- [x] Full suite: 2333 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)