### PR TITLE
fix: activity log right-edge text truncation

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -574,7 +574,7 @@ body.resize-dragging {
   border: 2px solid var(--border);
   border-top: none;
   border-radius: 0 0 2px 2px;
-  padding: 4px 4px 4px 4px;
+  padding: 0;        /* xterm.js FitAddon needs zero padding to calculate columns correctly */
   flex: 1;
   overflow: hidden;  /* xterm.js handles its own scrolling */
   min-height: 0;

--- a/frontend/xterm-log.js
+++ b/frontend/xterm-log.js
@@ -90,7 +90,14 @@ class XTermLog {
 
   _fit() {
     if (this._fitAddon) {
-      try { this._fitAddon.fit(); } catch (e) { console.warn('[XTermLog] fit failed:', e); }
+      try {
+        this._fitAddon.fit();
+        // Reduce columns by 1 to prevent right-edge clipping (border pixels)
+        const dims = this._fitAddon.proposeDimensions();
+        if (dims && dims.cols > 2) {
+          this._term.resize(dims.cols - 1, dims.rows);
+        }
+      } catch (e) { console.warn('[XTermLog] fit failed:', e); }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.5.0"
+version = "0.5.1"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- xterm.js FitAddon overcounts columns by ~1 due to container border pixels, causing rightmost characters to be clipped
- Set `#activity-log` padding to 0 (xterm controls its own spacing)
- After `fit()`, resize to `cols - 1` as safety margin

## Test plan
- [ ] Verify Chinese text in Activity Log is no longer truncated at right edge
- [ ] Verify scrollbar still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)