### PR TITLE
fix: CEO console shows full task description, not 200-char preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.5.2"
+version = "0.5.3"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1349,9 +1349,9 @@ class EmployeeManager:
         if node.project_id:
             from onemancompany.core.system_cron import clear_watchdog_nudge
             clear_watchdog_nudge(node.project_id)
-        self._log_node(employee_id, entry.node_id, "start", f"Starting task: {node.description_preview}")
+        self._log_node(employee_id, entry.node_id, "start", f"Starting task: {node.description}")
         self._publish_node_update(employee_id, node)
-        self._push_to_conversation(node, f"▶ {node.title or node.description_preview}")
+        self._push_to_conversation(node, f"▶ {node.title or node.description}")
 
         await _store.save_employee_runtime(employee_id, current_task_summary=node.description_preview[:100])
 

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1349,9 +1349,10 @@ class EmployeeManager:
         if node.project_id:
             from onemancompany.core.system_cron import clear_watchdog_nudge
             clear_watchdog_nudge(node.project_id)
-        self._log_node(employee_id, entry.node_id, "start", f"Starting task: {node.description}")
+        desc = node.description or node.description_preview
+        self._log_node(employee_id, entry.node_id, "start", f"Starting task: {desc}")
         self._publish_node_update(employee_id, node)
-        self._push_to_conversation(node, f"▶ {node.title or node.description}")
+        self._push_to_conversation(node, f"▶ {node.title or desc}")
 
         await _store.save_employee_runtime(employee_id, current_task_summary=node.description_preview[:100])
 


### PR DESCRIPTION
## Summary
- **Root cause**: `_push_to_conversation` and `_log_node` used `node.description_preview` (truncated at 200 chars). Cron task descriptions exceeding 200 chars were cut off mid-word ("dispat" instead of "dispatch").
- **Fix**: Use `node.description` (full text) for CEO-facing conversation messages and task start logs.

## Test plan
- [x] Full suite: 2338 passed
- [ ] Verify cron task descriptions display fully in CEO console

🤖 Generated with [Claude Code](https://claude.com/claude-code)