### PR TITLE
feat: lazy document tree — expand directories on click

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -4782,31 +4782,14 @@ class AppController {
           html += `<div style="font-size:6px;color:var(--pixel-white);background:var(--bg-dark);padding:6px;border:1px solid var(--border);">${doc.output}</div>`;
         }
 
-        // Documents
-        const files = doc.files || [];
-        if (files.length > 0) {
-          html += `<div style="font-size:7px;color:var(--pixel-cyan);margin:8px 0 4px;">Documents (${files.length}):</div>`;
-          for (const f of files) {
-            const url = `/api/projects/${encodeURIComponent(projectId)}/files/${encodeURIComponent(f)}`;
-            const safeUrl = this._escHtml(url);
-            const safeFile = this._escHtml(f);
-            const encodedUrl = encodeURIComponent(url);
-            const encodedFile = encodeURIComponent(f);
-            html += `<div style="font-size:6px;margin:2px 0;">`;
-            html += `<a href="${safeUrl}" class="project-doc-link" data-url="${encodedUrl}" data-file="${encodedFile}" style="color:var(--pixel-green);text-decoration:underline;cursor:pointer;">${safeFile}</a>`;
-            html += `</div>`;
-          }
-        }
+        // Documents — lazy tree (click to expand directories)
+        html += `<div style="font-size:7px;color:var(--pixel-cyan);margin:8px 0 4px;">Documents:</div>`;
+        html += `<div class="lazy-file-tree" data-project-id="${this._escHtml(projectId)}" data-path="" style="font-size:6px;">
+          <div style="color:var(--text-dim);">Click to load files...</div>
+        </div>`;
 
         contentEl.innerHTML = html;
-        contentEl.querySelectorAll('.project-doc-link').forEach((link) => {
-          link.addEventListener('click', (e) => {
-            e.preventDefault();
-            const rawUrl = decodeURIComponent(link.dataset.url || '');
-            const rawFile = decodeURIComponent(link.dataset.file || '');
-            window._ceoViewFile(rawUrl, rawFile);
-          });
-        });
+        this._initLazyFileTrees(contentEl);
       })
       .catch(err => {
         contentEl.innerHTML = `<div style="color:var(--pixel-red);">Load failed: ${this._escHtml(err.message)}</div>`;
@@ -7105,6 +7088,99 @@ class AppController {
     return renderNode(root, 0);
   }
 
+  /**
+   * Initialize lazy file trees — click to load top-level, click dirs to expand.
+   * Call after DOM insertion of elements with class="lazy-file-tree".
+   */
+  _initLazyFileTrees(container) {
+    const trees = container.querySelectorAll('.lazy-file-tree');
+    trees.forEach(tree => {
+      if (tree.dataset.initialized) return;
+      tree.dataset.initialized = '1';
+      tree.style.cursor = 'pointer';
+      tree.addEventListener('click', (e) => {
+        if (!tree.dataset.loaded) {
+          this._loadLazyDir(tree, tree.dataset.projectId, '');
+          tree.dataset.loaded = '1';
+        }
+      }, { once: true });
+    });
+  }
+
+  async _loadLazyDir(container, projectId, dirPath) {
+    container.innerHTML = '<div style="color:var(--text-dim);">Loading...</div>';
+    try {
+      const url = `/api/projects/${encodeURIComponent(projectId)}/ls?path=${encodeURIComponent(dirPath)}`;
+      const resp = await fetch(url);
+      if (!resp.ok) { container.innerHTML = '<div style="color:var(--pixel-red);">Failed to load</div>'; return; }
+      const data = await resp.json();
+      const entries = data.entries || [];
+      if (entries.length === 0) {
+        container.innerHTML = '<div style="color:var(--text-dim);">Empty</div>';
+        return;
+      }
+      let html = '';
+      const esc = s => this._escHtml(s);
+      const iconFor = ext => ({png:'\uD83D\uDDBC',jpg:'\uD83D\uDDBC',jpeg:'\uD83D\uDDBC',gif:'\uD83D\uDDBC',svg:'\uD83D\uDDBC',pdf:'\uD83D\uDCC3'})[ext] || '\uD83D\uDCC4';
+      for (const entry of entries) {
+        const childPath = dirPath ? `${dirPath}/${entry.name}` : entry.name;
+        if (entry.type === 'dir') {
+          html += `<div class="lazy-dir-entry" style="padding:2px 0;cursor:pointer;color:var(--pixel-yellow);" data-dir-path="${esc(childPath)}" data-project-id="${esc(projectId)}">`;
+          html += `<span class="lazy-dir-arrow">\u25B6</span> ${esc(entry.name)}/`;
+          html += `</div>`;
+          html += `<div class="lazy-dir-children hidden" style="padding-left:12px;"></div>`;
+        } else {
+          const ext = entry.name.split('.').pop().toLowerCase();
+          const fileUrl = `/api/projects/${encodeURIComponent(projectId)}/files/${encodeURIComponent(childPath)}`;
+          html += `<div class="project-file-item" data-file="${esc(childPath)}" data-url="${esc(fileUrl)}" data-ext="${ext}" style="padding:2px 0;color:var(--pixel-green);cursor:pointer;">`;
+          html += `${iconFor(ext)} ${esc(entry.name)}`;
+          html += `</div>`;
+        }
+      }
+      container.innerHTML = html;
+      // Wire directory click handlers
+      container.querySelectorAll('.lazy-dir-entry').forEach(dir => {
+        dir.addEventListener('click', () => {
+          const childrenEl = dir.nextElementSibling;
+          if (childrenEl.dataset.loaded) {
+            childrenEl.classList.toggle('hidden');
+            dir.querySelector('.lazy-dir-arrow').textContent = childrenEl.classList.contains('hidden') ? '\u25B6' : '\u25BE';
+          } else {
+            childrenEl.dataset.loaded = '1';
+            childrenEl.classList.remove('hidden');
+            dir.querySelector('.lazy-dir-arrow').textContent = '\u25BE';
+            this._loadLazyDir(childrenEl, dir.dataset.projectId, dir.dataset.dirPath);
+          }
+        });
+      });
+      // Wire file click handlers
+      this._wireFileItemClicks(container, projectId);
+    } catch (err) {
+      container.innerHTML = `<div style="color:var(--pixel-red);">Error: ${this._escHtml(err.message)}</div>`;
+    }
+  }
+
+  _wireFileItemClicks(container, projectId) {
+    container.querySelectorAll('.project-file-item').forEach(item => {
+      item.addEventListener('click', () => {
+        const fileUrl = item.dataset.url;
+        const ext = item.dataset.ext;
+        const file = item.dataset.file;
+        if (['png','jpg','jpeg','gif','svg','webp'].includes(ext)) {
+          window.open(fileUrl, '_blank');
+        } else {
+          fetch(fileUrl).then(r => r.text()).then(text => {
+            const pre = document.createElement('pre');
+            pre.style.cssText = 'font-size:5px;background:var(--bg-dark);padding:6px;border:1px solid var(--border);max-height:200px;overflow:auto;white-space:pre-wrap;color:var(--pixel-white);';
+            pre.textContent = text.substring(0, 10000);
+            item.parentElement.insertBefore(pre, item.nextSibling);
+            item.style.pointerEvents = 'none';
+          }).catch(() => {});
+        }
+      });
+    });
+  }
+
   _renderMarkdown(md) {
     if (!md) return '';
     let html = this._escapeHtml(md);
@@ -7552,18 +7628,14 @@ class AppController {
           </div>
         </div>`;
 
-        const files = doc.files || [];
-        const fileBaseUrl = `/api/projects/${qualifiedPath}/files/`;
         const downloadUrl = `/api/projects/${qualifiedPath}/download`;
         detailHtml += `<div style="font-size:7px;color:var(--pixel-cyan);margin:6px 0 3px;display:flex;justify-content:space-between;align-items:center;">
-          <span>Documents (${files.length})</span>
-          ${files.length > 0 ? `<a href="${downloadUrl}" style="font-size:5px;color:var(--pixel-green);text-decoration:none;border:1px solid var(--border);padding:1px 6px;cursor:pointer;">Download ZIP</a>` : ''}
+          <span>Documents</span>
+          <a href="${downloadUrl}" style="font-size:5px;color:var(--pixel-green);text-decoration:none;border:1px solid var(--border);padding:1px 6px;cursor:pointer;">Download ZIP</a>
         </div>`;
-        if (files.length > 0) {
-          detailHtml += this._renderFileTree(files, fileBaseUrl);
-        } else {
-          detailHtml += `<div style="font-size:5px;color:var(--text-dim);">No output documents yet</div>`;
-        }
+        detailHtml += `<div class="lazy-file-tree" data-project-id="${this._escHtml(qualifiedPath)}" data-path="" style="font-size:6px;">
+          <div style="color:var(--text-dim);">Click to load files...</div>
+        </div>`;
 
         // CEO Report (stored when project completion report is submitted)
         if (doc.ceo_report) {
@@ -7690,12 +7762,8 @@ class AppController {
           });
         });
 
-        // Bind file click handlers
-        panel.querySelectorAll('.project-file-item').forEach(item => {
-          item.addEventListener('click', () => {
-            this._openProjectFile(item.dataset.file, item.dataset.url, item.dataset.ext);
-          });
-        });
+        // Initialize lazy file trees (click to expand)
+        this._initLazyFileTrees(panel);
 
         // Bind team member click → open employee detail
         panel.querySelectorAll('.project-team-member').forEach(el => {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7045,49 +7045,6 @@ class AppController {
    * Lightweight Markdown → HTML renderer.
    * Handles: headers, bold, italic, inline code, code blocks, lists, links, newlines.
    */
-  _renderFileTree(files, baseUrl) {
-    // Build tree structure from flat file paths
-    const root = {};
-    for (const f of files) {
-      const parts = f.split('/');
-      let node = root;
-      for (let i = 0; i < parts.length - 1; i++) {
-        if (!node[parts[i]]) node[parts[i]] = {};
-        node = node[parts[i]];
-      }
-      node[parts[parts.length - 1]] = f; // leaf = full path string
-    }
-
-    const esc = s => this._escHtml(s);
-    const iconFor = ext => ({png:'\uD83D\uDDBC',jpg:'\uD83D\uDDBC',jpeg:'\uD83D\uDDBC',gif:'\uD83D\uDDBC',svg:'\uD83D\uDDBC',pdf:'\uD83D\uDCC3'})[ext] || '\uD83D\uDCC4';
-
-    const renderNode = (obj, depth) => {
-      let html = '';
-      const entries = Object.entries(obj).sort(([a, av], [b, bv]) => {
-        const aDir = typeof av === 'object', bDir = typeof bv === 'object';
-        if (aDir !== bDir) return aDir ? -1 : 1; // dirs first
-        return a.localeCompare(b);
-      });
-      for (const [name, val] of entries) {
-        if (typeof val === 'object') {
-          // Directory — collapsible
-          const pad = depth * 10;
-          html += `<div class="file-tree-dir" style="padding-left:${pad}px;font-size:6px;color:var(--pixel-yellow);padding-top:2px;padding-bottom:2px;cursor:pointer;" onclick="this.classList.toggle('collapsed');this.nextElementSibling.classList.toggle('hidden');">\u25BE ${esc(name)}/</div>`;
-          html += `<div class="file-tree-children">${renderNode(val, depth + 1)}</div>`;
-        } else {
-          // File — clickable
-          const fullPath = val;
-          const ext = name.split('.').pop().toLowerCase();
-          const pad = depth * 10;
-          html += `<div class="project-file-item" data-file="${esc(fullPath)}" data-url="${baseUrl}${encodeURIComponent(fullPath)}" data-ext="${ext}" style="font-size:6px;color:var(--pixel-green);padding:2px 2px 2px ${pad}px;border-bottom:1px solid var(--border);cursor:pointer;">${iconFor(ext)} ${esc(name)}</div>`;
-        }
-      }
-      return html;
-    };
-
-    return renderNode(root, 0);
-  }
-
   /**
    * Initialize lazy file trees — click to load top-level, click dirs to expand.
    * Call after DOM insertion of elements with class="lazy-file-tree".
@@ -7163,20 +7120,7 @@ class AppController {
   _wireFileItemClicks(container, projectId) {
     container.querySelectorAll('.project-file-item').forEach(item => {
       item.addEventListener('click', () => {
-        const fileUrl = item.dataset.url;
-        const ext = item.dataset.ext;
-        const file = item.dataset.file;
-        if (['png','jpg','jpeg','gif','svg','webp'].includes(ext)) {
-          window.open(fileUrl, '_blank');
-        } else {
-          fetch(fileUrl).then(r => r.text()).then(text => {
-            const pre = document.createElement('pre');
-            pre.style.cssText = 'font-size:5px;background:var(--bg-dark);padding:6px;border:1px solid var(--border);max-height:200px;overflow:auto;white-space:pre-wrap;color:var(--pixel-white);';
-            pre.textContent = text.substring(0, 10000);
-            item.parentElement.insertBefore(pre, item.nextSibling);
-            item.style.pointerEvents = 'none';
-          }).catch(() => {});
-        }
+        this._openProjectFile(item.dataset.file, item.dataset.url, item.dataset.ext);
       });
     });
   }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1673,6 +1673,7 @@ body.resize-dragging {
 }
 .file-tree-dir:hover { background: rgba(255, 255, 0, 0.06); }
 .file-tree-children.hidden { display: none; }
+.lazy-dir-children.hidden { display: none; }
 
 /* ===== Candidate Selection Modal (Boss Online) ===== */
 .candidate-modal-content {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.5.3"
+version = "0.5.4"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -3678,6 +3678,44 @@ async def get_iteration_file(project_id: str, iteration_id: str, file_path: str)
     return await get_project_file(f"{project_id}/{iteration_id}", file_path)
 
 
+@router.get("/api/projects/{project_id}/ls")
+async def list_project_dir(project_id: str, path: str = "") -> dict:
+    """List immediate children of a directory in a project workspace.
+
+    Returns files and subdirectories (one level only) for lazy tree rendering.
+    """
+    from onemancompany.core.project_archive import get_project_dir
+
+    project_dir = get_project_dir(project_id)
+    if not project_dir or not Path(project_dir).exists():
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    target = Path(project_dir) / path if path else Path(project_dir)
+    # Security: prevent path traversal
+    try:
+        target.resolve().relative_to(Path(project_dir).resolve())
+    except ValueError:
+        raise HTTPException(status_code=403, detail="Path traversal denied")
+
+    if not target.is_dir():
+        raise HTTPException(status_code=404, detail="Not a directory")
+
+    from onemancompany.core.project_archive import _INTERNAL_DIR_NAMES, _SKIP_DIR_NAMES, _is_internal_file
+    skip = _INTERNAL_DIR_NAMES | _SKIP_DIR_NAMES
+    entries = []
+    for item in sorted(target.iterdir()):
+        name = item.name
+        if name.startswith(".") and name != ".gitignore":
+            continue
+        if _is_internal_file(name) or name in skip:
+            continue
+        entries.append({
+            "name": name,
+            "type": "dir" if item.is_dir() else "file",
+        })
+    return {"path": path, "entries": entries}
+
+
 @router.get("/api/projects/{project_id}/files/{file_path:path}")
 async def get_project_file(project_id: str, file_path: str):
     """Read a file from a project workspace."""


### PR DESCRIPTION
## Summary
Documents section was loading ALL files recursively upfront, causing CPU hang and slow rendering for projects with thousands of files.

**Backend:**
- New `GET /api/projects/{id}/ls?path=` endpoint — returns immediate children (files + dirs) of a directory, one level only
- Path traversal protection via `resolve().relative_to()` check
- Reuses `_SKIP_DIR_NAMES` to exclude node_modules etc.

**Frontend:**
- Documents section shows "Click to load files..." placeholder
- Click → fetches top-level entries via `/ls`
- Directories render with ▶ arrow, click to expand (fetches next level)
- Files render with icons, click to view content inline
- Both employee detail and project detail use the same lazy tree

## Test plan
- [x] Full suite: 2338 passed
- [ ] Click Documents in employee detail → loads top-level
- [ ] Click folder → expands children lazily
- [ ] Click file → shows content inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)