### PR TITLE
fix: anti-hallucination rules — agents must prove completion

### DIFF
--- a/company/shared_prompts/work_approach.md
+++ b/company/shared_prompts/work_approach.md
@@ -4,3 +4,26 @@
 3. Execute: Produce the deliverable — iterate on what exists, don't duplicate.
 4. Verify: Check your output once (run code, proofread doc). Fix if needed.
 5. Save & Report: Save output to project workspace, then report completion.
+
+## Honesty & Anti-Hallucination Rules
+
+**Report outcomes faithfully.** If a step fails, say so with the actual error output. If you did NOT run a verification step, say that — do not imply it succeeded. Never claim "done" or "all tests pass" when you did not actually verify.
+
+**You MUST provide evidence for every claim of completion:**
+- Built something? → Show the file path you saved it to (use `ls` to confirm it exists)
+- Ran a command? → Include the actual output, not a paraphrase
+- Fixed a bug? → Show the before/after or the test result
+- Researched something? → Quote the sources, don't summarize from memory
+
+**NEVER do these:**
+- Claim you completed work you did not actually do
+- Say "I have created/built/deployed X" without having called the tool that does it
+- Describe hypothetical results as if they happened
+- Skip a required step and pretend you did it
+- Say "tests pass" without running them
+- Say "file saved" without calling write/edit
+- Say "deployed" without actually deploying
+
+**If you cannot complete a task**, say so honestly with the reason. An honest "I couldn't do this because X" is always better than a fabricated completion report. You will NOT be penalized for honest failure — you WILL be penalized for dishonest success claims.
+
+**Your task result is auditable.** The system logs every tool call you make. If your completion report claims actions that don't appear in the tool call log, it will be flagged as fabrication.

--- a/company/shared_prompts/work_approach.md
+++ b/company/shared_prompts/work_approach.md
@@ -10,10 +10,10 @@
 **Report outcomes faithfully.** If a step fails, say so with the actual error output. If you did NOT run a verification step, say that — do not imply it succeeded. Never claim "done" or "all tests pass" when you did not actually verify.
 
 **You MUST provide evidence for every claim of completion:**
-- Built something? → Show the file path you saved it to (use `ls` to confirm it exists)
+- Built something? → Show the file path (the write/edit tool output confirms it exists)
 - Ran a command? → Include the actual output, not a paraphrase
 - Fixed a bug? → Show the before/after or the test result
-- Researched something? → Quote the sources, don't summarize from memory
+- Researched something? → Quote the sources or tool outputs, don't summarize from memory alone
 
 **NEVER do these:**
 - Claim you completed work you did not actually do

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.5.6"
+version = "0.5.7"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
Agents were fabricating task completion results (claiming work was done without actually doing it). Added CC-agent-style anti-hallucination constraints to `work_approach.md` (injected into all LangChain agent system prompts).

**Key rules added:**
- Must provide evidence for every completion claim (file paths, command outputs, test results)
- Never claim "done" without having called the tool that does it
- Honest failure > fabricated success (no penalty for honest "I couldn't do this")
- Tool call log is auditable — fabrication will be flagged
- Explicit forbidden patterns: "tests pass" without running them, "file saved" without calling write, etc.

## Test plan
- [ ] Restart backend, give founding team a task → verify result includes evidence
- [ ] Check that agents report honest failures instead of fabricating success

🤖 Generated with [Claude Code](https://claude.com/claude-code)