### PR TITLE
feat: EA brainstorming skill — requirements discovery before dispatch

### DIFF
--- a/company/operations/sops/ea_dispatch_authority_sop.md
+++ b/company/operations/sops/ea_dispatch_authority_sop.md
@@ -22,17 +22,18 @@ Only escalate to CEO (via dispatch_child to CEO) when you judge there is risk.
 
 ## 2. Task Flow
 1. **Analyze** the CEO's task — identify ALL requirements (explicit and implicit).
-2. **Dispatch children** — use dispatch_child(target_employee_id, description, acceptance_criteria) for each subtask.
+2. **Brainstorm (for project-level tasks)** — load_skill("project-brainstorming") and follow its process: ask CEO clarifying questions, propose a plan with acceptance criteria, get CEO approval. Skip this for simple/urgent tasks.
+3. **Dispatch children** — use dispatch_child(target_employee_id, description, acceptance_criteria) for each subtask.
    - Each child MUST have measurable acceptance_criteria.
    - For multi-domain tasks, dispatch multiple children (they run in parallel).
    - For sequential work, dispatch the first step; after accepting it, dispatch the next.
    - **You may ONLY dispatch to O-level executives: HR, COO, CSO, or CEO.**
-3. **Wait for results** — the system will wake you when all children complete.
-4. **Review results** — for each child, call accept_child() or reject_child().
-5. **Iterate** — after accepting results, proactively dispatch the NEXT phase:
+4. **Wait for results** — the system will wake you when all children complete.
+5. **Review results** — for each child, call accept_child() or reject_child().
+6. **Iterate** — after accepting results, proactively dispatch the NEXT phase:
    - After acceptance, if there is follow-up work, **you MUST immediately dispatch_child to the corresponding O-level**.
    - **NEVER mark a task as complete when there is still follow-up work remaining.**
-6. **Complete** — ONLY when ALL phases of work are done and accepted.
+7. **Complete** — ONLY when ALL phases of work are done and accepted.
 
 ## 3. Routing Table (Strictly Enforced — Only dispatch to O-level)
 | Domain | Route to | Examples |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.5.7"
+version = "0.5.8"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/ea_agent.py
+++ b/src/onemancompany/agents/ea_agent.py
@@ -47,7 +47,8 @@ class EAAgent(BaseAgentRunner):
             {"messages": [
                 SystemMessage(content=self._build_full_prompt()),
                 HumanMessage(content=task),
-            ]}
+            ]},
+            config={"recursion_limit": 80},
         )
 
         self._extract_and_record_usage(result)

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -67,7 +67,7 @@ HEARTBEAT_SCRIPT = "heartbeat.sh"
 
 # Default skills injected for every new employee
 _DEFAULT_SKILLS_DIR = Path(__file__).resolve().parent.parent / "default_skills"
-_DEFAULT_SKILL_NAMES = ["task_lifecycle"]
+_DEFAULT_SKILL_NAMES = ["task_lifecycle", "project-brainstorming"]
 
 
 # ---------------------------------------------------------------------------

--- a/src/onemancompany/agents/onboarding.py
+++ b/src/onemancompany/agents/onboarding.py
@@ -67,7 +67,9 @@ HEARTBEAT_SCRIPT = "heartbeat.sh"
 
 # Default skills injected for every new employee
 _DEFAULT_SKILLS_DIR = Path(__file__).resolve().parent.parent / "default_skills"
-_DEFAULT_SKILL_NAMES = ["task_lifecycle", "project-brainstorming"]
+_DEFAULT_SKILL_NAMES = ["task_lifecycle"]
+# EA-only skills injected during founding team setup
+_EA_SKILL_NAMES = ["project-brainstorming"]
 
 
 # ---------------------------------------------------------------------------
@@ -622,14 +624,18 @@ async def clone_talent_repo(repo_url: str, talent_id: str) -> Path:
     return resolved if resolved.exists() else _TALENTS_CLONE_DIR
 
 
-def _inject_default_skills(skills_dir: Path) -> None:
+def _inject_default_skills(skills_dir: Path, employee_id: str = "") -> None:
     """Copy/update default skills into the employee's skills folder.
 
     Always overwrites SKILL.md from the source to pick up frontmatter
     changes (e.g. autoload flag). Preserves employee-specific files
     in the skill directory that don't exist in the source.
     """
-    for name in _DEFAULT_SKILL_NAMES:
+    from onemancompany.core.config import EA_ID
+    names = list(_DEFAULT_SKILL_NAMES)
+    if employee_id == EA_ID:
+        names.extend(_EA_SKILL_NAMES)
+    for name in names:
         src = _DEFAULT_SKILLS_DIR / name
         if not src.exists():
             continue
@@ -1034,8 +1040,8 @@ async def execute_hire(
                 f"---\nname: {skill_name}\ndescription: \"{name}'s {skill_name} skill.\"\n---\n\n"
                 f"# {skill_name}\n\n(Auto-created by HR during hiring.)\n")
 
-    # Inject default skills (task_lifecycle)
-    _inject_default_skills(skills_dir)
+    # Inject default skills (task_lifecycle; EA also gets project-brainstorming)
+    _inject_default_skills(skills_dir, employee_id=emp_num)
 
     # Create initial SOUL.md in workspace
     workspace_dir = emp_dir / WORKSPACE_DIR_NAME

--- a/src/onemancompany/default_skills/project-brainstorming/SKILL.md
+++ b/src/onemancompany/default_skills/project-brainstorming/SKILL.md
@@ -1,0 +1,96 @@
+# Project Brainstorming — Requirements Discovery Before Execution
+
+Before dispatching any project-level task to the team, you MUST go through this
+brainstorming process with the CEO. The goal: understand what to build before
+building it. Turn vague ideas into clear specs with acceptance criteria.
+
+## When to Use This Skill
+
+**USE brainstorming for:**
+- New product/feature requests ("build X", "create Y", "design Z")
+- Multi-step projects that involve multiple team members
+- Ambiguous tasks where CEO intent needs clarification
+- Tasks with unclear success criteria
+
+**SKIP brainstorming for:**
+- Simple operational tasks ("check status", "send email", "look up info")
+- Urgent fixes ("the site is down", "fix this bug now")
+- Tasks where CEO gave explicit, detailed instructions with clear criteria
+- Follow-up tasks on existing projects where scope is already defined
+
+## The Process
+
+### Phase 1: Understand Context
+
+Before asking any questions:
+1. Read existing project files if this is a follow-up
+2. Check what team members are currently working on (use list_colleagues)
+3. Understand the company's current state
+
+### Phase 2: Ask Clarifying Questions (ONE AT A TIME)
+
+Ask the CEO questions via `dispatch_child(target_employee_id="00001", ...)` to
+understand requirements. Rules:
+
+- **One question per dispatch.** Do NOT bundle multiple questions.
+- **Prefer multiple choice** when possible — easier for CEO to answer.
+- **Focus on**: purpose, target users, constraints, timeline, success criteria.
+- **Max 3-4 questions** — respect CEO's time. Stop if you have enough context.
+
+Good questions:
+- "What's the primary goal? (A) Generate revenue (B) Attract users (C) Internal tool (D) Other"
+- "Who is the target user for this?"
+- "What does success look like? How will you know this is done?"
+- "Any technical constraints or preferences? (specific tech stack, hosting, etc.)"
+- "What's the priority: speed of delivery vs. polish/quality?"
+
+Bad questions:
+- Overly technical questions the CEO shouldn't need to answer
+- Questions you could answer yourself by reading existing context
+- Multiple questions in one message
+
+### Phase 3: Propose Approach
+
+After gathering answers, present a plan to the CEO:
+
+```
+dispatch_child(
+    target_employee_id="00001",
+    description="""
+Based on your answers, here is my proposed plan:
+
+**Goal**: [one sentence]
+
+**Approach**: [2-3 sentences describing how the team will execute]
+
+**Team assignments**:
+- COO → [what COO's team will do]
+- HR → [hiring needs, if any]
+- CSO → [sales/marketing, if any]
+
+**Acceptance Criteria** (how we know it's done):
+1. [measurable criterion]
+2. [measurable criterion]
+3. [measurable criterion]
+
+**Estimated scope**: [small/medium/large]
+
+Please confirm this plan, or tell me what to adjust.
+""",
+    acceptance_criteria=["CEO approves the project plan"]
+)
+```
+
+### Phase 4: Execute
+
+Only after CEO confirms the plan:
+1. Call `set_project_name()` with a concise 2-6 word name
+2. Dispatch to O-level executives using the confirmed plan and acceptance criteria
+3. The acceptance criteria from Phase 3 become the real criteria for the dispatched tasks
+
+## Key Principles
+
+- **The CEO's time is the scarcest resource.** Keep questions focused and minimal.
+- **Never assume scope.** A CEO saying "build a website" could mean a landing page or a full platform. Ask.
+- **Acceptance criteria are a contract.** Once CEO confirms, that's what you deliver against.
+- **If CEO says "just do it" or "skip the questions"** — respect that and dispatch immediately with your best judgment on criteria.

--- a/src/onemancompany/default_skills/project-brainstorming/SKILL.md
+++ b/src/onemancompany/default_skills/project-brainstorming/SKILL.md
@@ -151,10 +151,12 @@ Please choose an approach (or mix elements), and confirm/adjust the acceptance c
 
 ## Phase 5: Write Design Summary
 
-After CEO approves, save a brief design doc to the project workspace:
+After CEO approves, save a brief design doc to the project workspace.
+Use `ls` to find your project workspace path first (check task context for
+`[Project workspace: ...]`), then write the design doc there:
 
 ```
-write(file_path="[project_workspace]/design.md", content="""
+write(file_path="<your project workspace path>/design.md", content="""
 # [Project Name] — Design Summary
 
 ## Problem

--- a/src/onemancompany/default_skills/project-brainstorming/SKILL.md
+++ b/src/onemancompany/default_skills/project-brainstorming/SKILL.md
@@ -1,8 +1,19 @@
 # Project Brainstorming — Requirements Discovery Before Execution
 
-Before dispatching any project-level task to the team, you MUST go through this
-brainstorming process with the CEO. The goal: understand what to build before
-building it. Turn vague ideas into clear specs with acceptance criteria.
+Turn vague ideas into clear specs with acceptance criteria through collaborative
+dialogue with the CEO. Understand what to build before building it.
+
+<HARD-GATE>
+Do NOT dispatch any project work to the team until the CEO has approved your
+proposed plan. This applies to EVERY project regardless of perceived simplicity.
+"Simple" projects are where unexamined assumptions cause the most wasted work.
+</HARD-GATE>
+
+## Anti-Pattern: "This Is Too Simple To Need A Design"
+
+Every project goes through this process. A landing page, a single API, a config
+change — all of them. The design can be SHORT (a few sentences for truly simple
+projects), but you MUST present it and get CEO approval before dispatching.
 
 ## When to Use This Skill
 
@@ -15,82 +26,176 @@ building it. Turn vague ideas into clear specs with acceptance criteria.
 **SKIP brainstorming for:**
 - Simple operational tasks ("check status", "send email", "look up info")
 - Urgent fixes ("the site is down", "fix this bug now")
-- Tasks where CEO gave explicit, detailed instructions with clear criteria
 - Follow-up tasks on existing projects where scope is already defined
+- Tasks where CEO says "just do it" or "skip the questions"
 
-## The Process
+---
 
-### Phase 1: Understand Context
+## Phase 1: Understand Context
 
 Before asking any questions:
 1. Read existing project files if this is a follow-up
 2. Check what team members are currently working on (use list_colleagues)
-3. Understand the company's current state
+3. Understand the company's current state and capabilities
 
-### Phase 2: Ask Clarifying Questions (ONE AT A TIME)
+Output to yourself (do not send to CEO): "Here is what I understand about the
+context: [summary]. Here is what I still need to know: [gaps]."
 
-Ask the CEO questions via `dispatch_child(target_employee_id="00001", ...)` to
-understand requirements. Rules:
+---
 
+## Phase 2: Ask Clarifying Questions (ONE AT A TIME)
+
+Ask the CEO questions via `dispatch_child(target_employee_id="00001", ...)`.
+
+### Rules:
 - **One question per dispatch.** Do NOT bundle multiple questions.
 - **Prefer multiple choice** when possible — easier for CEO to answer.
-- **Focus on**: purpose, target users, constraints, timeline, success criteria.
-- **Max 3-4 questions** — respect CEO's time. Stop if you have enough context.
+- **Max 3-5 questions** — respect CEO's time. Stop when you have enough context.
+- **Each question should unlock a decision.** Don't ask just to ask.
 
-Good questions:
-- "What's the primary goal? (A) Generate revenue (B) Attract users (C) Internal tool (D) Other"
-- "Who is the target user for this?"
-- "What does success look like? How will you know this is done?"
-- "Any technical constraints or preferences? (specific tech stack, hosting, etc.)"
-- "What's the priority: speed of delivery vs. polish/quality?"
+### What to ask about:
+1. **Purpose & Users**: Who is this for? What problem does it solve?
+2. **Scope**: What's the minimum viable version? What can wait for later?
+3. **Constraints**: Tech stack, timeline, budget, hosting preferences?
+4. **Success criteria**: How will the CEO know this is done and successful?
+5. **Priority**: Speed vs. quality? MVP vs. polished?
 
-Bad questions:
+### Good question examples:
+- "What's the primary goal? (A) Generate revenue (B) Attract users (C) Internal tool (D) Research/learning"
+- "Who is the target user? (A) End consumers (B) Businesses (C) Internal team (D) Developers"
+- "What's the priority? (A) Ship fast with basic quality (B) Take time for polish (C) Somewhere in between"
+- "Any technical constraints? (A) Use specific tech stack [which?] (B) Must deploy to [where?] (C) No constraints, you decide"
+
+### Bad questions (never ask these):
+- Questions you could answer by reading existing context
 - Overly technical questions the CEO shouldn't need to answer
-- Questions you could answer yourself by reading existing context
-- Multiple questions in one message
+- Multiple questions bundled in one message
+- Questions with obvious answers ("should this work correctly?")
 
-### Phase 3: Propose Approach
+---
 
-After gathering answers, present a plan to the CEO:
+## Phase 3: Challenge Premises
+
+Before proposing solutions, question your own assumptions:
+
+- **Is the stated problem the real problem?** Sometimes "build a website" really
+  means "get more customers." The solution might not be a website.
+- **Does this need to be built at all?** Is there an existing tool, service, or
+  simpler approach that achieves the same goal?
+- **Is the scope right?** If the project touches multiple independent systems,
+  flag it: "This looks like 2-3 separate projects. Should we tackle them one at
+  a time?"
+
+If you identify a premise worth challenging, raise it with the CEO:
+```
+dispatch_child(
+    target_employee_id="00001",
+    description="Before I plan execution, I want to check one assumption: [premise]. Is that correct, or should we think about this differently?",
+    acceptance_criteria=["CEO confirms or adjusts the premise"]
+)
+```
+
+---
+
+## Phase 4: Propose 2-3 Approaches (MANDATORY)
+
+You MUST present at least 2 approaches, each with trade-offs. Do NOT present a
+single "recommended plan" without alternatives.
 
 ```
 dispatch_child(
     target_employee_id="00001",
     description="""
-Based on your answers, here is my proposed plan:
+Based on our discussion, here are the approaches I see:
 
-**Goal**: [one sentence]
+## Approach A: [Name] (Recommended)
+**What**: [2-3 sentences]
+**Pros**: [bullet points]
+**Cons**: [bullet points]
+**Scope**: [small/medium/large]
+**Team**: [who does what]
 
-**Approach**: [2-3 sentences describing how the team will execute]
+## Approach B: [Name]
+**What**: [2-3 sentences]
+**Pros**: [bullet points]
+**Cons**: [bullet points]
+**Scope**: [small/medium/large]
+**Team**: [who does what]
 
-**Team assignments**:
-- COO → [what COO's team will do]
-- HR → [hiring needs, if any]
-- CSO → [sales/marketing, if any]
+## (Optional) Approach C: [Name]
+[same format]
 
-**Acceptance Criteria** (how we know it's done):
-1. [measurable criterion]
-2. [measurable criterion]
-3. [measurable criterion]
+---
 
-**Estimated scope**: [small/medium/large]
+**My recommendation**: Approach [X] because [one-line reason].
 
-Please confirm this plan, or tell me what to adjust.
+**Proposed Acceptance Criteria** (how we know it's done):
+1. [measurable, verifiable criterion]
+2. [measurable, verifiable criterion]
+3. [measurable, verifiable criterion]
+4. [measurable, verifiable criterion]
+
+Please choose an approach (or mix elements), and confirm/adjust the acceptance criteria.
 """,
-    acceptance_criteria=["CEO approves the project plan"]
+    acceptance_criteria=["CEO selects approach and approves acceptance criteria"]
 )
 ```
 
-### Phase 4: Execute
+### Acceptance Criteria Rules:
+- Every CEO requirement must map to at least one criterion
+- Criteria must be **verifiable** — pass/fail against actual deliverables
+- Include both functional criteria ("feature X works") and quality criteria ("deployed and accessible")
+- If CEO asked to review something, include "CEO approves [what]" as a criterion
+
+---
+
+## Phase 5: Write Design Summary
+
+After CEO approves, save a brief design doc to the project workspace:
+
+```
+write(file_path="[project_workspace]/design.md", content="""
+# [Project Name] — Design Summary
+
+## Problem
+[What we're solving and why]
+
+## Approach
+[Selected approach from Phase 4]
+
+## Acceptance Criteria
+1. [criterion 1]
+2. [criterion 2]
+3. [criterion 3]
+
+## Team Plan
+- [who does what]
+
+## Constraints & Decisions
+- [key decisions made during brainstorming]
+
+## Out of Scope (deferred)
+- [what we explicitly decided NOT to do now]
+""")
+```
+
+---
+
+## Phase 6: Execute
 
 Only after CEO confirms the plan:
 1. Call `set_project_name()` with a concise 2-6 word name
-2. Dispatch to O-level executives using the confirmed plan and acceptance criteria
-3. The acceptance criteria from Phase 3 become the real criteria for the dispatched tasks
+2. Dispatch to O-level executives using the confirmed approach and acceptance criteria
+3. The acceptance criteria from Phase 4 become the real criteria for the dispatched tasks
+
+---
 
 ## Key Principles
 
-- **The CEO's time is the scarcest resource.** Keep questions focused and minimal.
-- **Never assume scope.** A CEO saying "build a website" could mean a landing page or a full platform. Ask.
+- **CEO's time is the scarcest resource.** Keep questions focused and minimal.
+- **Never assume scope.** "Build a website" could mean a landing page or a full platform.
+- **Always present alternatives.** Even if one approach is obviously better, show why by contrasting.
 - **Acceptance criteria are a contract.** Once CEO confirms, that's what you deliver against.
-- **If CEO says "just do it" or "skip the questions"** — respect that and dispatch immediately with your best judgment on criteria.
+- **Challenge premises respectfully.** "Is X the real goal?" is valuable; "X is wrong" is not.
+- **If CEO says "just do it"** — respect that and dispatch immediately with your best judgment. Not every task needs 5 phases.
+- **Scope decomposition.** If a project is too large for one team to deliver in a reasonable time, propose breaking it into phases. Each phase gets its own brainstorming cycle.

--- a/tests/unit/agents/test_ea_agent.py
+++ b/tests/unit/agents/test_ea_agent.py
@@ -222,7 +222,7 @@ class TestEAAgentRun:
 
         agent_invoked = False
 
-        async def spy_ainvoke(messages):
+        async def spy_ainvoke(messages, **kwargs):
             nonlocal agent_invoked
             agent_invoked = True
             return {"messages": [MagicMock(content="done")]}


### PR DESCRIPTION
## Summary
EA now has a brainstorming phase before dispatching project-level tasks, inspired by superpowers brainstorming + gstack office-hours.

**Flow:**
1. CEO gives task → EA analyzes complexity
2. If project-level: `load_skill("project-brainstorming")` → ask CEO 2-4 clarifying questions (one at a time via dispatch_child to CEO)
3. Propose plan with acceptance criteria → CEO confirms
4. THEN dispatch to team with confirmed criteria
5. If simple/urgent: skip brainstorming, dispatch immediately

**Changes:**
- `src/onemancompany/default_skills/project-brainstorming/SKILL.md` — new skill
- `company/operations/sops/ea_dispatch_authority_sop.md` — added brainstorming step to task flow
- `src/onemancompany/agents/ea_agent.py` — recursion_limit 25→80 for multi-turn flows
- `src/onemancompany/agents/onboarding.py` — skill added to defaults

## Test plan
- [ ] Give EA a vague project task → should ask clarifying questions before dispatching
- [ ] Give EA a simple task → should skip brainstorming and act immediately
- [ ] Verify EA can do 10+ tool calls in one execution (recursion limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)