### PR TITLE
fix: EA stops over-creating projects for follow-up messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.5.8"
+version = "0.5.9"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/conversation_adapters.py
+++ b/src/onemancompany/core/conversation_adapters.py
@@ -125,12 +125,17 @@ def _build_conversation_prompt(
         lines.append(
             "This is a direct chat with the CEO. You are their EA (Executive Assistant).\n"
             "- Answer questions directly and concisely.\n"
-            "- If the CEO gives a task that requires team execution (build something, research, "
-            "hiring, design, etc.), you MUST call create_project(task=<full CEO request>) to create "
-            "a project. The system will set up the task tree and schedule you to analyze and dispatch.\n"
-            "- For simple questions (weather, info, advice, status checks), just answer — do NOT create a project.\n"
-            "- When in doubt about whether to create a project, create one. It's better to organize "
-            "work properly than to try doing it yourself in this chat."
+            "- ONLY call create_project() when the CEO gives a BRAND NEW task that requires "
+            "team execution (build something new, start a new research, new hiring request).\n"
+            "- Do NOT create a project for:\n"
+            "  * Follow-up messages about existing projects (check conversation history!)\n"
+            "  * Simple questions, status checks, advice requests\n"
+            "  * Feedback or adjustments to ongoing work\n"
+            "  * Anything that references work already in progress\n"
+            "- If the conversation history shows prior messages about the same topic, "
+            "this is a FOLLOW-UP, not a new project. Respond directly or use report_to_ceo.\n"
+            "- When in doubt, ASK the CEO: 'Should I create a new project for this, "
+            "or is this related to an existing one?'"
         )
 
     if messages:

--- a/src/onemancompany/core/conversation_adapters.py
+++ b/src/onemancompany/core/conversation_adapters.py
@@ -125,17 +125,16 @@ def _build_conversation_prompt(
         lines.append(
             "This is a direct chat with the CEO. You are their EA (Executive Assistant).\n"
             "- Answer questions directly and concisely.\n"
-            "- ONLY call create_project() when the CEO gives a BRAND NEW task that requires "
-            "team execution (build something new, start a new research, new hiring request).\n"
+            "- For BRAND NEW tasks requiring team execution (build something, research, hiring), "
+            "call create_project(task=<full CEO request>). Do this without asking.\n"
             "- Do NOT create a project for:\n"
-            "  * Follow-up messages about existing projects (check conversation history!)\n"
+            "  * Follow-up messages continuing the same conversation topic (check history!)\n"
             "  * Simple questions, status checks, advice requests\n"
-            "  * Feedback or adjustments to ongoing work\n"
-            "  * Anything that references work already in progress\n"
-            "- If the conversation history shows prior messages about the same topic, "
-            "this is a FOLLOW-UP, not a new project. Respond directly or use report_to_ceo.\n"
-            "- When in doubt, ASK the CEO: 'Should I create a new project for this, "
-            "or is this related to an existing one?'"
+            "  * Feedback or adjustments CEO gives about ongoing work\n"
+            "- If the conversation history shows this topic was already discussed, respond "
+            "directly — do NOT create a new project.\n"
+            "- When genuinely unsure (CEO mentions an existing project but adds a big new "
+            "requirement), ask: 'Should I create a new project or add to the existing one?'"
         )
 
     if messages:

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -300,6 +300,12 @@ def _build_tree_context(tree, node, project_dir: str) -> str:
     if children:
         parts.append("=== Child Tasks ===")
         for child in children:
+            # Include CEO_REQUEST results (CEO replies) — critical for multi-turn context
+            if child.is_ceo_node and child.is_done_executing:
+                child.load_content(project_dir)
+                if child.result:
+                    parts.append(f"  [CEO REPLY] {child.id}: {child.result}")
+                continue
             if child.is_ceo_node:
                 continue
             if child.status == TaskPhase.ACCEPTED:

--- a/src/onemancompany/default_skills/project-brainstorming/SKILL.md
+++ b/src/onemancompany/default_skills/project-brainstorming/SKILL.md
@@ -1,7 +1,7 @@
 # Project Brainstorming — Requirements Discovery Before Execution
 
-Turn vague ideas into clear specs with acceptance criteria through ONE structured
-interaction with the CEO. Understand what to build before building it.
+Turn vague ideas into clear specs with acceptance criteria through collaborative
+dialogue with the CEO. Understand what to build before building it.
 
 <HARD-GATE>
 Do NOT dispatch any project work to the team until the CEO has approved your
@@ -24,73 +24,107 @@ proposed plan. This applies to EVERY project regardless of perceived simplicity.
 
 ---
 
-## The Process (Single CEO Interaction)
-
-IMPORTANT: The entire brainstorming happens in ONE dispatch_child to CEO.
-Do NOT send multiple separate questions as separate dispatch_child calls.
-Each dispatch_child creates a new task cycle — keep it to ONE round.
-
-### Step 1: Analyze Silently (no CEO interaction)
+## Phase 1: Understand Context (no CEO interaction)
 
 Before asking the CEO anything:
 1. Read existing project files if this is a follow-up
 2. Check what team members are available (use list_colleagues)
 3. Form your own understanding of the task
 
-### Step 2: Send ONE Structured Proposal to CEO
+---
 
-Combine your questions AND a draft plan into a SINGLE dispatch_child:
+## Phase 2: Ask Clarifying Questions (ONE AT A TIME)
+
+Ask the CEO questions via `dispatch_child(target_employee_id="00001", ...)`.
+The system preserves your conversation history — when CEO replies, you will
+see ALL prior CEO replies in your task context under [CEO REPLY] sections.
+
+### Rules:
+- **One question per dispatch.** Do NOT bundle multiple questions.
+- **Prefer multiple choice** when possible — easier for CEO to answer.
+- **Max 3-4 questions** — respect CEO's time. Stop when you have enough context.
+- **Check your [CEO REPLY] sections** — do NOT re-ask questions CEO already answered.
+
+### What to ask about:
+1. **Purpose & Users**: Who is this for? What problem does it solve?
+2. **Scope**: What's the minimum viable version? What can wait for later?
+3. **Constraints**: Tech stack, timeline, budget, hosting preferences?
+4. **Success criteria**: How will the CEO know this is done and successful?
+5. **Priority**: Speed vs. quality? MVP vs. polished?
+
+### Good question examples:
+- "What's the primary goal? (A) Generate revenue (B) Attract users (C) Internal tool (D) Research/learning"
+- "Who is the target user? (A) End consumers (B) Businesses (C) Internal team (D) Developers"
+- "What's the priority? (A) Ship fast with basic quality (B) Take time for polish"
+
+---
+
+## Phase 3: Challenge Premises
+
+Before proposing solutions, question your own assumptions:
+
+- **Is the stated problem the real problem?**
+- **Does this need to be built at all?** Is there a simpler approach?
+- **Is the scope right?** If too large, propose breaking into phases.
+
+If you identify a premise worth challenging, raise it with the CEO via
+dispatch_child(target_employee_id="00001").
+
+---
+
+## Phase 4: Propose 2-3 Approaches (MANDATORY)
+
+You MUST present at least 2 approaches with trade-offs:
 
 ```
 dispatch_child(
     target_employee_id="00001",
     description="""
-I've analyzed your request. Before I dispatch the team, I'd like to confirm a few things:
+Based on our discussion, here are the approaches I see:
 
-**My understanding**: [1-2 sentences of what you think CEO wants]
+## Approach A: [Name] (Recommended)
+**What**: [2-3 sentences]
+**Pros**: [bullet points]
+**Cons**: [bullet points]
+**Team**: [who does what]
 
-**Quick questions** (answer inline or skip any that are obvious):
-1. [Most important clarification — prefer A/B/C multiple choice]
-2. [Second question if needed]
-3. [Third question if needed — max 3]
+## Approach B: [Name]
+**What**: [2-3 sentences]
+**Pros**: [bullet points]
+**Cons**: [bullet points]
+**Team**: [who does what]
 
-**My proposed plan**:
+**My recommendation**: Approach [X] because [one-line reason].
 
-Approach A (Recommended): [2-3 sentences]
-- Team: [who does what]
-- Pros: [why this is better]
+**Proposed Acceptance Criteria**:
+1. [measurable, verifiable criterion]
+2. [measurable, verifiable criterion]
+3. [measurable, verifiable criterion]
 
-Approach B: [2-3 sentences]
-- Team: [who does what]
-- Pros: [alternative advantage]
-
-**Proposed acceptance criteria**:
-1. [measurable criterion]
-2. [measurable criterion]
-3. [measurable criterion]
-
-Please confirm the approach and criteria, adjust anything, or just say "go" to proceed with my recommendation.
+Please choose an approach and confirm/adjust the acceptance criteria.
 """,
-    acceptance_criteria=["CEO confirms or adjusts the project plan"]
+    acceptance_criteria=["CEO selects approach and approves acceptance criteria"]
 )
 ```
 
-### Step 3: Execute After CEO Confirms
+---
 
-After CEO responds:
+## Phase 5: Execute After CEO Confirms
+
+After CEO approves:
 1. Call `set_project_name()` with a concise 2-6 word name
-2. Incorporate any CEO feedback into the final plan
+2. Incorporate CEO feedback into the final plan
 3. Dispatch to O-level executives with the confirmed acceptance criteria
-4. Save a brief `design.md` to the project workspace if the project is medium/large scope
+4. Save a brief `design.md` to the project workspace for medium/large projects
 
 ---
 
 ## Key Principles
 
-- **ONE interaction with CEO, not a multi-round Q&A.** Combine questions + proposal into a single message. CEO responds once, you execute.
+- **CEO's time is the scarcest resource.** Keep questions focused and minimal.
 - **Never assume scope.** "Build a website" could mean a landing page or a full platform.
-- **Always present 2+ approaches** with trade-offs, even if one is clearly better.
+- **Always present 2+ approaches** with trade-offs.
 - **Acceptance criteria are a contract.** Once CEO confirms, deliver against them.
-- **Challenge premises when warranted.** "Is X the real goal?" can save weeks of wasted work.
-- **If CEO says "just do it"** — respect that and dispatch immediately with your best judgment.
-- **Scope decomposition.** If a project is too large, propose breaking it into phases.
+- **Check [CEO REPLY] sections** before each turn — don't lose context or re-ask.
+- **If CEO says "just do it"** — respect that and dispatch immediately.
+- **Scope decomposition.** If too large, propose phases. Each phase gets its own cycle.

--- a/src/onemancompany/default_skills/project-brainstorming/SKILL.md
+++ b/src/onemancompany/default_skills/project-brainstorming/SKILL.md
@@ -6,6 +6,9 @@ dialogue with the CEO. Understand what to build before building it.
 <HARD-GATE>
 Do NOT dispatch any project work to the team until the CEO has approved your
 proposed plan. This applies to EVERY project regardless of perceived simplicity.
+"Simple" projects are where unexamined assumptions cause the most wasted work.
+The design can be SHORT (a few sentences for truly simple projects), but you
+MUST present it and get CEO approval before dispatching.
 </HARD-GATE>
 
 ## When to Use This Skill

--- a/src/onemancompany/default_skills/project-brainstorming/SKILL.md
+++ b/src/onemancompany/default_skills/project-brainstorming/SKILL.md
@@ -1,19 +1,12 @@
 # Project Brainstorming — Requirements Discovery Before Execution
 
-Turn vague ideas into clear specs with acceptance criteria through collaborative
-dialogue with the CEO. Understand what to build before building it.
+Turn vague ideas into clear specs with acceptance criteria through ONE structured
+interaction with the CEO. Understand what to build before building it.
 
 <HARD-GATE>
 Do NOT dispatch any project work to the team until the CEO has approved your
 proposed plan. This applies to EVERY project regardless of perceived simplicity.
-"Simple" projects are where unexamined assumptions cause the most wasted work.
 </HARD-GATE>
-
-## Anti-Pattern: "This Is Too Simple To Need A Design"
-
-Every project goes through this process. A landing page, a single API, a config
-change — all of them. The design can be SHORT (a few sentences for truly simple
-projects), but you MUST present it and get CEO approval before dispatching.
 
 ## When to Use This Skill
 
@@ -21,183 +14,83 @@ projects), but you MUST present it and get CEO approval before dispatching.
 - New product/feature requests ("build X", "create Y", "design Z")
 - Multi-step projects that involve multiple team members
 - Ambiguous tasks where CEO intent needs clarification
-- Tasks with unclear success criteria
 
 **SKIP brainstorming for:**
 - Simple operational tasks ("check status", "send email", "look up info")
 - Urgent fixes ("the site is down", "fix this bug now")
+- Tasks where CEO gave explicit, detailed instructions with clear criteria
 - Follow-up tasks on existing projects where scope is already defined
-- Tasks where CEO says "just do it" or "skip the questions"
+- CEO explicitly says "just do it" or "skip the questions"
 
 ---
 
-## Phase 1: Understand Context
+## The Process (Single CEO Interaction)
 
-Before asking any questions:
+IMPORTANT: The entire brainstorming happens in ONE dispatch_child to CEO.
+Do NOT send multiple separate questions as separate dispatch_child calls.
+Each dispatch_child creates a new task cycle — keep it to ONE round.
+
+### Step 1: Analyze Silently (no CEO interaction)
+
+Before asking the CEO anything:
 1. Read existing project files if this is a follow-up
-2. Check what team members are currently working on (use list_colleagues)
-3. Understand the company's current state and capabilities
+2. Check what team members are available (use list_colleagues)
+3. Form your own understanding of the task
 
-Output to yourself (do not send to CEO): "Here is what I understand about the
-context: [summary]. Here is what I still need to know: [gaps]."
+### Step 2: Send ONE Structured Proposal to CEO
 
----
-
-## Phase 2: Ask Clarifying Questions (ONE AT A TIME)
-
-Ask the CEO questions via `dispatch_child(target_employee_id="00001", ...)`.
-
-### Rules:
-- **One question per dispatch.** Do NOT bundle multiple questions.
-- **Prefer multiple choice** when possible — easier for CEO to answer.
-- **Max 3-5 questions** — respect CEO's time. Stop when you have enough context.
-- **Each question should unlock a decision.** Don't ask just to ask.
-
-### What to ask about:
-1. **Purpose & Users**: Who is this for? What problem does it solve?
-2. **Scope**: What's the minimum viable version? What can wait for later?
-3. **Constraints**: Tech stack, timeline, budget, hosting preferences?
-4. **Success criteria**: How will the CEO know this is done and successful?
-5. **Priority**: Speed vs. quality? MVP vs. polished?
-
-### Good question examples:
-- "What's the primary goal? (A) Generate revenue (B) Attract users (C) Internal tool (D) Research/learning"
-- "Who is the target user? (A) End consumers (B) Businesses (C) Internal team (D) Developers"
-- "What's the priority? (A) Ship fast with basic quality (B) Take time for polish (C) Somewhere in between"
-- "Any technical constraints? (A) Use specific tech stack [which?] (B) Must deploy to [where?] (C) No constraints, you decide"
-
-### Bad questions (never ask these):
-- Questions you could answer by reading existing context
-- Overly technical questions the CEO shouldn't need to answer
-- Multiple questions bundled in one message
-- Questions with obvious answers ("should this work correctly?")
-
----
-
-## Phase 3: Challenge Premises
-
-Before proposing solutions, question your own assumptions:
-
-- **Is the stated problem the real problem?** Sometimes "build a website" really
-  means "get more customers." The solution might not be a website.
-- **Does this need to be built at all?** Is there an existing tool, service, or
-  simpler approach that achieves the same goal?
-- **Is the scope right?** If the project touches multiple independent systems,
-  flag it: "This looks like 2-3 separate projects. Should we tackle them one at
-  a time?"
-
-If you identify a premise worth challenging, raise it with the CEO:
-```
-dispatch_child(
-    target_employee_id="00001",
-    description="Before I plan execution, I want to check one assumption: [premise]. Is that correct, or should we think about this differently?",
-    acceptance_criteria=["CEO confirms or adjusts the premise"]
-)
-```
-
----
-
-## Phase 4: Propose 2-3 Approaches (MANDATORY)
-
-You MUST present at least 2 approaches, each with trade-offs. Do NOT present a
-single "recommended plan" without alternatives.
+Combine your questions AND a draft plan into a SINGLE dispatch_child:
 
 ```
 dispatch_child(
     target_employee_id="00001",
     description="""
-Based on our discussion, here are the approaches I see:
+I've analyzed your request. Before I dispatch the team, I'd like to confirm a few things:
 
-## Approach A: [Name] (Recommended)
-**What**: [2-3 sentences]
-**Pros**: [bullet points]
-**Cons**: [bullet points]
-**Scope**: [small/medium/large]
-**Team**: [who does what]
+**My understanding**: [1-2 sentences of what you think CEO wants]
 
-## Approach B: [Name]
-**What**: [2-3 sentences]
-**Pros**: [bullet points]
-**Cons**: [bullet points]
-**Scope**: [small/medium/large]
-**Team**: [who does what]
+**Quick questions** (answer inline or skip any that are obvious):
+1. [Most important clarification — prefer A/B/C multiple choice]
+2. [Second question if needed]
+3. [Third question if needed — max 3]
 
-## (Optional) Approach C: [Name]
-[same format]
+**My proposed plan**:
 
----
+Approach A (Recommended): [2-3 sentences]
+- Team: [who does what]
+- Pros: [why this is better]
 
-**My recommendation**: Approach [X] because [one-line reason].
+Approach B: [2-3 sentences]
+- Team: [who does what]
+- Pros: [alternative advantage]
 
-**Proposed Acceptance Criteria** (how we know it's done):
-1. [measurable, verifiable criterion]
-2. [measurable, verifiable criterion]
-3. [measurable, verifiable criterion]
-4. [measurable, verifiable criterion]
+**Proposed acceptance criteria**:
+1. [measurable criterion]
+2. [measurable criterion]
+3. [measurable criterion]
 
-Please choose an approach (or mix elements), and confirm/adjust the acceptance criteria.
+Please confirm the approach and criteria, adjust anything, or just say "go" to proceed with my recommendation.
 """,
-    acceptance_criteria=["CEO selects approach and approves acceptance criteria"]
+    acceptance_criteria=["CEO confirms or adjusts the project plan"]
 )
 ```
 
-### Acceptance Criteria Rules:
-- Every CEO requirement must map to at least one criterion
-- Criteria must be **verifiable** — pass/fail against actual deliverables
-- Include both functional criteria ("feature X works") and quality criteria ("deployed and accessible")
-- If CEO asked to review something, include "CEO approves [what]" as a criterion
+### Step 3: Execute After CEO Confirms
 
----
-
-## Phase 5: Write Design Summary
-
-After CEO approves, save a brief design doc to the project workspace.
-Use `ls` to find your project workspace path first (check task context for
-`[Project workspace: ...]`), then write the design doc there:
-
-```
-write(file_path="<your project workspace path>/design.md", content="""
-# [Project Name] — Design Summary
-
-## Problem
-[What we're solving and why]
-
-## Approach
-[Selected approach from Phase 4]
-
-## Acceptance Criteria
-1. [criterion 1]
-2. [criterion 2]
-3. [criterion 3]
-
-## Team Plan
-- [who does what]
-
-## Constraints & Decisions
-- [key decisions made during brainstorming]
-
-## Out of Scope (deferred)
-- [what we explicitly decided NOT to do now]
-""")
-```
-
----
-
-## Phase 6: Execute
-
-Only after CEO confirms the plan:
+After CEO responds:
 1. Call `set_project_name()` with a concise 2-6 word name
-2. Dispatch to O-level executives using the confirmed approach and acceptance criteria
-3. The acceptance criteria from Phase 4 become the real criteria for the dispatched tasks
+2. Incorporate any CEO feedback into the final plan
+3. Dispatch to O-level executives with the confirmed acceptance criteria
+4. Save a brief `design.md` to the project workspace if the project is medium/large scope
 
 ---
 
 ## Key Principles
 
-- **CEO's time is the scarcest resource.** Keep questions focused and minimal.
+- **ONE interaction with CEO, not a multi-round Q&A.** Combine questions + proposal into a single message. CEO responds once, you execute.
 - **Never assume scope.** "Build a website" could mean a landing page or a full platform.
-- **Always present alternatives.** Even if one approach is obviously better, show why by contrasting.
-- **Acceptance criteria are a contract.** Once CEO confirms, that's what you deliver against.
-- **Challenge premises respectfully.** "Is X the real goal?" is valuable; "X is wrong" is not.
-- **If CEO says "just do it"** — respect that and dispatch immediately with your best judgment. Not every task needs 5 phases.
-- **Scope decomposition.** If a project is too large for one team to deliver in a reasonable time, propose breaking it into phases. Each phase gets its own brainstorming cycle.
+- **Always present 2+ approaches** with trade-offs, even if one is clearly better.
+- **Acceptance criteria are a contract.** Once CEO confirms, deliver against them.
+- **Challenge premises when warranted.** "Is X the real goal?" can save weeks of wasted work.
+- **If CEO says "just do it"** — respect that and dispatch immediately with your best judgment.
+- **Scope decomposition.** If a project is too large, propose breaking it into phases.


### PR DESCRIPTION
## Summary
EA was creating a new project for every CEO message, including follow-ups on existing projects. 

**Root cause**: EA chat prompt said "MUST call create_project" and "when in doubt, create one" — too aggressive.

**Fix**: Rewrote EA chat prompt to:
- ONLY create_project for **brand new** tasks requiring team execution
- Check conversation history — same topic = follow-up, not new project
- Explicit list of what NOT to create projects for (follow-ups, status checks, feedback)
- When in doubt: ask CEO, don't auto-create

## Test plan
- [ ] Send follow-up message about existing project → EA responds directly, no new project
- [ ] Send brand new task → EA creates project correctly
- [ ] Send simple question → EA answers, no project

🤖 Generated with [Claude Code](https://claude.com/claude-code)