### PR TITLE
feat: Product creation — agent tool + frontend modal

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -787,6 +787,9 @@ class AppController {
     // DND toggle button
     this._initDndToggle();
 
+    // Create Product modal
+    this._initCreateProductModal();
+
     hrBtn?.addEventListener('click', () => {
       hrBtn.disabled = true;
       this.logEntry('CEO', '🔄 Triggering quarterly review...', 'ceo');
@@ -7226,6 +7229,125 @@ class AppController {
       sel.value = current;  // preserve selection
     } catch (e) {
       console.debug('[_refreshProductSelector] failed:', e);
+    }
+  }
+
+  // ===== Create Product Modal =====
+  _initCreateProductModal() {
+    const btn = document.getElementById('create-product-btn');
+    const modal = document.getElementById('create-product-modal');
+    if (!btn || !modal) return;
+
+    // Open modal
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      modal.classList.remove('hidden');
+      this._populateProductOwnerDropdown();
+      // Reset form
+      document.getElementById('create-product-name').value = '';
+      document.getElementById('create-product-desc').value = '';
+      document.getElementById('kr-list').innerHTML = '';
+    });
+
+    // Close modal
+    modal.querySelector('.modal-close')?.addEventListener('click', () => {
+      modal.classList.add('hidden');
+    });
+    modal.addEventListener('click', (e) => {
+      if (e.target === modal) modal.classList.add('hidden');
+    });
+
+    // Add KR button
+    document.getElementById('add-kr-btn')?.addEventListener('click', () => {
+      this._addKrRow();
+    });
+
+    // Submit
+    document.getElementById('submit-create-product')?.addEventListener('click', () => {
+      this._submitCreateProduct();
+    });
+  }
+
+  _addKrRow() {
+    const list = document.getElementById('kr-list');
+    if (!list) return;
+    const row = document.createElement('div');
+    row.className = 'kr-form-row';
+    row.innerHTML = `
+      <input type="text" class="kr-title-input form-input" placeholder="KR title" />
+      <input type="number" class="kr-target-input form-input" placeholder="Target" style="width:70px" />
+      <input type="text" class="kr-unit-input form-input" placeholder="Unit" style="width:60px" />
+      <button class="kr-remove-btn" title="Remove">&times;</button>
+    `;
+    row.querySelector('.kr-remove-btn').addEventListener('click', () => row.remove());
+    list.appendChild(row);
+  }
+
+  async _populateProductOwnerDropdown() {
+    try {
+      const data = await fetch('/api/bootstrap').then(r => r.json());
+      const sel = document.getElementById('create-product-owner');
+      if (!sel) return;
+      sel.innerHTML = '<option value="">Select owner...</option>';
+      for (const emp of (data.employees || [])) {
+        const opt = document.createElement('option');
+        opt.value = emp.id;
+        opt.textContent = `${emp.name || emp.id} (${emp.role || ''})`;
+        sel.appendChild(opt);
+      }
+    } catch (e) {
+      console.debug('Failed to populate owner dropdown:', e);
+    }
+  }
+
+  async _submitCreateProduct() {
+    const name = document.getElementById('create-product-name')?.value?.trim();
+    const desc = document.getElementById('create-product-desc')?.value?.trim();
+    const ownerId = document.getElementById('create-product-owner')?.value || '';
+
+    if (!name) {
+      alert('Product name is required');
+      return;
+    }
+
+    // Collect KRs
+    const krRows = document.querySelectorAll('#kr-list .kr-form-row');
+    const krs = [];
+    for (const row of krRows) {
+      const title = row.querySelector('.kr-title-input')?.value?.trim();
+      const target = parseFloat(row.querySelector('.kr-target-input')?.value) || 0;
+      const unit = row.querySelector('.kr-unit-input')?.value?.trim() || '';
+      if (title && target > 0) {
+        krs.push({ title, target, unit });
+      }
+    }
+
+    try {
+      // Create product
+      const res = await fetch('/api/product', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, description: desc, owner_id: ownerId }),
+      });
+      const product = await res.json();
+      const slug = product.slug;
+
+      // Add KRs
+      for (const kr of krs) {
+        await fetch(`/api/product/${slug}/kr`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(kr),
+        });
+      }
+
+      // Close modal and refresh
+      document.getElementById('create-product-modal')?.classList.add('hidden');
+      this.updateProjectsPanel();
+      this._refreshProductSelector();
+    } catch (e) {
+      console.error('Failed to create product:', e);
+      alert('Failed to create product');
     }
   }
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,6 +17,7 @@
       <div class="collapsible-header" data-target="projects-panel-body">
         <span class="collapse-arrow">&#9660;</span>
         <h3 class="pixel-title">PRODUCTS</h3>
+        <button id="create-product-btn" class="panel-add-btn" title="New Product">+</button>
       </div>
       <div id="projects-panel-body" class="collapsible-body">
         <div id="projects-panel-list"></div>
@@ -651,6 +652,40 @@
         <div id="bg-tasks-list" class="bg-tasks-list"></div>
         <div id="bg-tasks-detail" class="bg-tasks-detail">
           <div class="bg-tasks-detail-empty">Select a task</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Create Product Modal -->
+  <div id="create-product-modal" class="modal-overlay hidden">
+    <div class="modal-content" style="max-width: 420px;">
+      <div class="modal-header">
+        <h3 class="pixel-title">NEW PRODUCT</h3>
+        <button class="modal-close" data-modal="create-product-modal">&times;</button>
+      </div>
+      <div class="modal-body" style="flex-direction:column;padding:12px;">
+        <div class="form-group">
+          <label class="form-label">Name</label>
+          <input type="text" id="create-product-name" class="form-input" placeholder="e.g. OneManCompany官网" />
+        </div>
+        <div class="form-group">
+          <label class="form-label">Objective</label>
+          <textarea id="create-product-desc" class="form-input" rows="2" placeholder="Product goal / objective"></textarea>
+        </div>
+        <div class="form-group">
+          <label class="form-label">Owner</label>
+          <select id="create-product-owner" class="form-input">
+            <option value="">Select owner...</option>
+          </select>
+        </div>
+        <div id="create-product-krs">
+          <label class="form-label">Key Results</label>
+          <div id="kr-list"></div>
+          <button id="add-kr-btn" class="btn-small">+ Add KR</button>
+        </div>
+        <div class="form-actions">
+          <button id="submit-create-product" class="btn-primary">Create</button>
         </div>
       </div>
     </div>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5720,3 +5720,113 @@ body.resize-dragging {
   color: var(--pixel-white);
   outline: none;
 }
+
+/* Panel Add Button */
+.panel-add-btn {
+  margin-left: auto;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--pixel-cyan);
+  font-size: calc(10px + var(--font-boost));
+  cursor: pointer;
+  padding: 0 6px;
+  line-height: 1.2;
+  border-radius: 2px;
+  font-family: var(--font-pixel);
+}
+
+.panel-add-btn:hover {
+  background: var(--pixel-cyan);
+  color: var(--bg-dark);
+}
+
+/* KR Form Rows */
+.kr-form-row {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 4px;
+  align-items: center;
+}
+
+.kr-form-row .form-input {
+  flex: 1;
+}
+
+.kr-remove-btn {
+  background: transparent;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  font-size: calc(10px + var(--font-boost));
+  padding: 0 4px;
+}
+
+.kr-remove-btn:hover {
+  color: #ff4444;
+}
+
+.btn-small {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-family: var(--font-pixel);
+  font-size: calc(5.5px + var(--font-boost));
+  padding: 3px 8px;
+  cursor: pointer;
+  border-radius: 2px;
+  margin-top: 4px;
+}
+
+.btn-small:hover {
+  border-color: var(--pixel-cyan);
+  color: var(--pixel-cyan);
+}
+
+.btn-primary {
+  background: var(--pixel-cyan);
+  color: var(--bg-dark);
+  border: none;
+  font-family: var(--font-pixel);
+  font-size: calc(6px + var(--font-boost));
+  padding: 6px 16px;
+  cursor: pointer;
+  border-radius: 2px;
+  margin-top: 8px;
+  width: 100%;
+}
+
+.btn-primary:hover {
+  opacity: 0.9;
+}
+
+.form-group {
+  margin-bottom: 8px;
+}
+
+.form-label {
+  display: block;
+  color: var(--text-dim);
+  font-size: calc(5.5px + var(--font-boost));
+  margin-bottom: 3px;
+}
+
+.form-input {
+  width: 100%;
+  background: var(--bg-dark);
+  color: var(--pixel-white);
+  border: 1px solid var(--border);
+  font-family: var(--font-pixel);
+  font-size: calc(6px + var(--font-boost));
+  padding: 4px 8px;
+  border-radius: 2px;
+  box-sizing: border-box;
+}
+
+.form-input:focus {
+  border-color: var(--pixel-cyan);
+  outline: none;
+}
+
+.form-actions {
+  margin-top: 12px;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.6.0"
+version = "0.6.1"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/product_tools.py
+++ b/src/onemancompany/agents/product_tools.py
@@ -40,6 +40,52 @@ def _resolve_caller_id() -> str:
 
 
 @tool
+async def create_product_tool(
+    name: str,
+    description: str,
+    key_results: str = "",
+    owner_id: str = "",
+) -> str:
+    """Create a new product with optional key results.
+
+    Args:
+        name: Product name (e.g. "OneManCompany官网")
+        description: Product objective/description
+        key_results: Semicolon-separated KRs, each as "title|target|unit" (e.g. "DAU达到1000|1000|users;页面加载<2s|2.0|seconds")
+        owner_id: Employee ID of the product owner (optional, defaults to caller)
+    """
+    caller = _resolve_caller_id()
+    oid = owner_id or caller
+
+    try:
+        product = prod.create_product(name=name, owner_id=oid, description=description)
+        slug = product["slug"]
+
+        # Parse and add key results
+        kr_count = 0
+        if key_results:
+            for kr_str in key_results.split(";"):
+                parts = kr_str.strip().split("|")
+                if len(parts) >= 2:
+                    title = parts[0].strip()
+                    try:
+                        target = float(parts[1].strip())
+                    except ValueError:
+                        logger.debug("Skipping KR with non-numeric target: {}", parts[1])
+                        continue
+                    unit = parts[2].strip() if len(parts) >= 3 else ""
+                    prod.add_key_result(slug, title=title, target=target, unit=unit)
+                    kr_count += 1
+
+        result = f"Created product '{name}' (slug: {slug})"
+        if kr_count:
+            result += f" with {kr_count} key results"
+        return result
+    except (ValueError, FileNotFoundError) as e:
+        return f"Error: {e}"
+
+
+@tool
 async def create_product_issue(
     product_slug: str,
     title: str,
@@ -257,6 +303,7 @@ async def update_kr_progress_tool(
 # ---------------------------------------------------------------------------
 
 PRODUCT_TOOLS = [
+    create_product_tool,
     create_product_issue,
     update_product_issue,
     close_product_issue,

--- a/tests/unit/test_product_tools.py
+++ b/tests/unit/test_product_tools.py
@@ -205,8 +205,9 @@ class TestProductTools:
     async def test_product_tools_list(self):
         from onemancompany.agents.product_tools import PRODUCT_TOOLS
 
-        assert len(PRODUCT_TOOLS) == 6
+        assert len(PRODUCT_TOOLS) == 7
         names = {t.name for t in PRODUCT_TOOLS}
+        assert "create_product_tool" in names
         assert "create_product_issue" in names
         assert "update_product_issue" in names
         assert "close_product_issue" in names


### PR DESCRIPTION
## Summary

- **Agent tool**: `create_product_tool` — agents can create products with OKR in one call (semicolon-separated KRs)
- **Frontend modal**: "+" button in Products panel header opens a form with name, objective, owner dropdown, and dynamic KR rows
- **Flow**: CEO describes idea → agent creates product with OKR → CEO reviews in panel

## Test plan
- [x] Python compilation verified
- [x] 2338 unit tests passing
- [x] `create_product_tool` added to PRODUCT_TOOLS registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)