### PR TITLE
fix: detect agent stall when promising actions without dispatching tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.6.1"
+version = "0.6.2"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1722,8 +1722,8 @@ class EmployeeManager:
                     )
                     self._push_to_conversation(
                         node,
-                        "⚠️ Agent声称将执行后续工作但未实际创建任务，可能已stall。"
-                        "请检查并手动重新下达指令。",
+                        "⚠️ Agent claimed it would execute follow-up work but did not "
+                        "create any tasks. It may have stalled. Please review and re-dispatch.",
                     )
 
                 save_tree_async(entry.tree_path)

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -125,6 +125,40 @@ def _save_project_tree(project_dir: str, tree):
         save_tree_async(path)
 
 
+# ---------------------------------------------------------------------------
+# Stall detection — detect unfulfilled action promises in agent output
+# ---------------------------------------------------------------------------
+
+import re as _re
+
+# Patterns that indicate the agent is promising future actions it hasn't taken.
+# These are checked ONLY when the task completes WITHOUT dispatching children.
+_PROMISE_PATTERNS = _re.compile(
+    r"(?:"
+    # Chinese future-action phrases
+    r"我将|接下来|下一步|现在开始|马上开始|即将开始|准备开始"
+    r"|我会(?:立即|马上|开始)"
+    r"|下面我(?:来|将|要)"
+    # English future-action phrases
+    r"|I will (?:now |start |begin )|I'll (?:now |start |begin )"
+    r"|Let me (?:start|begin|proceed)"
+    r"|Next,? I'?(?:ll| will)"
+    r"|I'?m going to (?:start|begin)"
+    r")",
+    _re.IGNORECASE,
+)
+
+
+def detect_unfulfilled_promises(output: str | None) -> bool:
+    """Check if agent output contains unfulfilled action promises.
+
+    Returns True if the output contains phrases indicating the agent
+    plans to take action (but hasn't, since this is checked at completion).
+    """
+    if not output:
+        return False
+    return bool(_PROMISE_PATTERNS.search(output))
+
 
 # ---------------------------------------------------------------------------
 # Dependency context builder
@@ -1676,6 +1710,22 @@ class EmployeeManager:
                     node.set_status(TaskPhase.FINISHED)
                     logger.debug("[TASK LIFECYCLE] employee={} node={} → auto FINISHED (system node)",
                                  employee_id, entry.node_id)
+
+                # Stall detection: agent said "I will do X" but dispatched no children
+                if (node.node_type not in SYSTEM_NODE_TYPES
+                        and not node.children_ids
+                        and detect_unfulfilled_promises(node.result)):
+                    logger.warning(
+                        "[STALL] employee={} node={}: output contains action promises "
+                        "but no subtasks were dispatched. Agent may have stalled.",
+                        employee_id, entry.node_id,
+                    )
+                    self._push_to_conversation(
+                        node,
+                        "⚠️ Agent声称将执行后续工作但未实际创建任务，可能已stall。"
+                        "请检查并手动重新下达指令。",
+                    )
+
                 save_tree_async(entry.tree_path)
 
         if node.status != TaskPhase.HOLDING.value:

--- a/tests/unit/test_stall_detection.py
+++ b/tests/unit/test_stall_detection.py
@@ -1,0 +1,55 @@
+"""Unit tests for agent stall detection."""
+
+import pytest
+
+from onemancompany.core.vessel import detect_unfulfilled_promises
+
+
+class TestDetectUnfulfilledPromises:
+    """Detect when an agent says it will do something but didn't use tools."""
+
+    def test_chinese_future_action(self):
+        assert detect_unfulfilled_promises("我将正式开始执行前端重构任务") is True
+
+    def test_chinese_next_step(self):
+        assert detect_unfulfilled_promises("接下来我会优化数据库查询") is True
+
+    def test_chinese_about_to(self):
+        assert detect_unfulfilled_promises("下一步，我将部署新版本") is True
+
+    def test_chinese_now_starting(self):
+        assert detect_unfulfilled_promises("现在开始处理这个需求") is True
+
+    def test_english_i_will(self):
+        assert detect_unfulfilled_promises("I will now start implementing the feature") is True
+
+    def test_english_let_me(self):
+        assert detect_unfulfilled_promises("Let me start working on the refactoring") is True
+
+    def test_english_next(self):
+        assert detect_unfulfilled_promises("Next, I'll dispatch a task to the engineer") is True
+
+    def test_completed_report_no_stall(self):
+        """Agent reporting what it DID is not a stall."""
+        assert detect_unfulfilled_promises("已完成OKR更新，所有指标已同步") is False
+
+    def test_short_ack_no_stall(self):
+        assert detect_unfulfilled_promises("收到，已更新") is False
+
+    def test_empty_string(self):
+        assert detect_unfulfilled_promises("") is False
+
+    def test_none_returns_false(self):
+        assert detect_unfulfilled_promises(None) is False
+
+    def test_past_tense_no_stall(self):
+        assert detect_unfulfilled_promises("I have completed the task and updated the OKR") is False
+
+    def test_mixed_completed_and_promise(self):
+        """If output has BOTH completed work AND future promises, it's a stall."""
+        text = "已完成OKR更新。接下来我将开始执行前端重构任务。"
+        assert detect_unfulfilled_promises(text) is True
+
+    def test_asking_question_no_stall(self):
+        """Agent asking a question should not be flagged."""
+        assert detect_unfulfilled_promises("需要确认一下，这个功能要支持哪些浏览器？") is False


### PR DESCRIPTION
## Summary

- **Root cause**: Agent LLM output says "I will start executing X" but doesn't call `dispatch_child()`. Task is marked COMPLETED, agent goes idle. Promised work never happens.
- **Fix**: `detect_unfulfilled_promises()` regex checks output for action-promising phrases (CN/EN). When detected at COMPLETED with no children dispatched, logs WARNING and pushes stall alert to CEO conversation.
- **Scope**: Detection only. Does not auto-retry or block completion. CEO sees a warning: "Agent claimed it would execute follow-up work but did not create any tasks. It may have stalled." and can re-dispatch manually.

## Test plan
- [x] 14 unit tests for `detect_unfulfilled_promises()` — CN/EN patterns, negatives, edge cases
- [x] 2522 passed (excluding pre-existing lifespan test error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)