### PR TITLE
feat: Product planning conversation — CEO + Agent define OKR before execution

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6904,6 +6904,37 @@ class AppController {
     await this._refreshOneononeList();
   }
 
+  async _openProductPlanningConversation(slug, convId) {
+    // Reuse the 1-on-1 terminal pattern for product planning conversations
+    this._currentCeoProject = null;
+    this._currentConvId = convId;
+    this._currentConvType = 'product';
+    this._currentConvEmployeeId = null;
+
+    // Clear active states
+    document.querySelectorAll('.ceo-proj-item').forEach(el => el.classList.remove('active'));
+    document.querySelectorAll('.ceo-oneonone-item').forEach(el => el.classList.remove('active'));
+
+    // Load existing messages
+    let messages = [];
+    try {
+      const resp = await fetch(`/api/conversation/${encodeURIComponent(convId)}/messages`);
+      const data = await resp.json();
+      messages = data.messages || [];
+    } catch (e) {
+      console.error('[_openProductPlanningConversation]', e);
+    }
+
+    // Convert to terminal format
+    const history = messages.map(m => ({
+      role: m.sender === 'ceo' ? 'ceo' : 'system',
+      text: m.text || '',
+      source: m.sender === 'ceo' ? undefined : 'EA',
+    }));
+
+    this._ceoTerm?.showChat(`plan:${slug}`, history);
+  }
+
   async _sendConversationMessage(convId, text, attachments) {
     if (!this._chatPanel) return;
     this._chatPanel.showTyping(true);
@@ -7490,6 +7521,41 @@ class AppController {
     });
     meta.appendChild(statusSel);
     header.appendChild(meta);
+
+    // Planning/Activate/Archive buttons based on status
+    if (product.status === 'planning') {
+      const planBtn = document.createElement('button');
+      planBtn.className = 'btn-primary';
+      planBtn.style.width = 'auto';
+      planBtn.style.marginLeft = '8px';
+      planBtn.textContent = 'Start Planning';
+      planBtn.addEventListener('click', async () => {
+        const res = await fetch(`/api/product/${encodeURIComponent(slug)}/planning`, { method: 'POST' });
+        const data = await res.json();
+        if (data.conversation_id) {
+          // Close product modal and open planning conversation
+          document.getElementById('product-modal')?.classList.add('hidden');
+          this._openProductPlanningConversation(slug, data.conversation_id);
+        }
+      });
+      header.appendChild(planBtn);
+
+      const activateBtn = document.createElement('button');
+      activateBtn.className = 'btn-small';
+      activateBtn.style.marginLeft = '4px';
+      activateBtn.textContent = 'Activate Product';
+      activateBtn.addEventListener('click', async () => {
+        await fetch(`/api/product/${encodeURIComponent(slug)}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'active' }),
+        });
+        this._openProductDetail(slug);
+        this.updateProjectsPanel();
+      });
+      header.appendChild(activateBtn);
+    }
+
     container.appendChild(header);
 
     // Objective
@@ -8113,10 +8179,12 @@ class AppController {
           header.className = 'product-group-header';
           const version = prod.current_version ? ` (v${this._escHtml(prod.current_version)})` : '';
           const statusBadge = prod.status === 'active' ? '\u25CF' : prod.status === 'planning' ? '\u25CB' : '\u25C6';
+          const planningIndicator = prod.status === 'planning' ? '<span class="product-planning-indicator">PLANNING</span>' : '';
           header.innerHTML = `
             <span class="product-expand-arrow">${state.main ? '\u25BE' : '\u25B8'}</span>
             <span class="product-status-dot status-${this._escHtml(prod.status || 'active')}">${statusBadge}</span>
             <span class="product-group-name">${this._escHtml(prod.name)}${version}</span>
+            ${planningIndicator}
           `;
           const detailBtn = document.createElement('button');
           detailBtn.className = 'product-detail-btn';

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8186,6 +8186,13 @@ class AppController {
             <span class="product-group-name">${this._escHtml(prod.name)}${version}</span>
             ${planningIndicator}
           `;
+          if (prod.status === 'active' && prod.owner_id) {
+            const ownerEl = document.createElement('span');
+            ownerEl.className = 'product-owner-indicator';
+            ownerEl.textContent = `\u2192 ${prod.owner_id}`;
+            ownerEl.title = 'Product owner';
+            header.appendChild(ownerEl);
+          }
           const detailBtn = document.createElement('button');
           detailBtn.className = 'product-detail-btn';
           detailBtn.textContent = '\u22EF';

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -6205,3 +6205,15 @@ body.resize-dragging {
   padding: 0 4px;
   border-radius: 2px;
 }
+
+.product-planning-indicator {
+  color: var(--pixel-yellow);
+  font-size: calc(5px + var(--font-boost));
+  margin-left: 6px;
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5877,6 +5877,12 @@ body.resize-dragging {
 .product-status-badge.status-planning { background: rgba(255,255,0,0.1); color: var(--pixel-yellow); }
 .product-status-badge.status-archived { background: rgba(128,128,128,0.15); color: var(--text-dim); }
 
+.product-owner-indicator {
+  color: var(--text-dim);
+  font-size: calc(5px + var(--font-boost));
+  margin-left: 4px;
+}
+
 .product-section-label {
   font-size: calc(6px + var(--font-boost));
   color: var(--pixel-cyan);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.6.4"
+version = "0.6.5"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.6.3"
+version = "0.6.4"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/common_tools.py
+++ b/src/onemancompany/agents/common_tools.py
@@ -795,6 +795,11 @@ async def pull_meeting(
             break
 
     if not room:
+        await _publish("meeting_denied", {
+            "initiator_id": initiator_id,
+            "topic": topic,
+            "reason": "No meeting rooms available",
+        })
         return {
             "status": "denied",
             "message": "No meeting rooms available. Please try again later or work on other tasks.",

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -7271,3 +7271,34 @@ async def api_product_detail(slug: str) -> dict:
         "versions": versions,
         "projects": linked_projects,
     }
+
+
+@router.post("/api/product/{slug}/planning")
+async def api_start_product_planning(slug: str) -> dict:
+    """Start or resume a planning conversation for a product."""
+    from onemancompany.core import product as prod
+    from onemancompany.core.conversation import get_conversation_service
+    from onemancompany.core.models import ConversationType
+    from onemancompany.core.config import EA_ID
+
+    product = prod.load_product(slug)
+    if not product:
+        raise HTTPException(status_code=404, detail=f"Product '{slug}' not found")
+
+    conversation_service = get_conversation_service()
+
+    # Check for existing active planning conversation
+    active_convs = conversation_service.list_active(type=ConversationType.PRODUCT)
+    for conv in active_convs:
+        if conv.metadata.get("product_slug") == slug:
+            return {"conversation_id": conv.id, "existing": True}
+
+    # Create new planning conversation with EA as the counterpart
+    conv = await conversation_service.create(
+        type=ConversationType.PRODUCT,
+        employee_id=EA_ID,
+        tools_enabled=True,
+        product_slug=slug,
+        product_id=product["id"],
+    )
+    return {"conversation_id": conv.id, "existing": False}

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -7038,6 +7038,16 @@ async def api_update_product(slug: str, request: Request) -> dict:
     result = prod.update_product(slug, **filtered)
     if not result:
         raise HTTPException(status_code=404, detail=f"Product '{slug}' not found")
+
+    # If status just changed to active, dispatch initial product review
+    if "status" in filtered:
+        new_status = filtered["status"]
+        if hasattr(new_status, "value"):
+            new_status = new_status.value
+        if new_status == "active":
+            from onemancompany.core.product_triggers import dispatch_product_review
+            await dispatch_product_review(slug)
+
     return result
 
 

--- a/src/onemancompany/core/conversation.py
+++ b/src/onemancompany/core/conversation.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import yaml
 from loguru import logger
 
-from onemancompany.core.config import CONVERSATIONS_DIR_NAME, PROJECTS_DIR, EMPLOYEES_DIR, open_utf
+from onemancompany.core.config import CONVERSATIONS_DIR_NAME, PROJECTS_DIR, PRODUCTS_DIR, EMPLOYEES_DIR, open_utf
 from onemancompany.core.events import event_bus, CompanyEvent
 from onemancompany.core.models import ConversationType, ConversationPhase, EventType
 
@@ -118,6 +118,11 @@ def resolve_conv_dir(conv: Conversation) -> Path:
     if conv.type == ConversationType.CEO_INBOX:
         project_dir = conv.metadata.get("project_dir", "")
         return Path(project_dir) / CONVERSATIONS_DIR_NAME / conv.id
+    elif conv.type == ConversationType.PRODUCT.value or conv.type == ConversationType.PRODUCT:
+        product_slug = conv.metadata.get("product_slug", "")
+        if product_slug:
+            return PRODUCTS_DIR / product_slug / CONVERSATIONS_DIR_NAME / conv.id
+        return EMPLOYEES_DIR / conv.employee_id / CONVERSATIONS_DIR_NAME / conv.id
     else:  # oneonone
         return EMPLOYEES_DIR / conv.employee_id / CONVERSATIONS_DIR_NAME / conv.id
 
@@ -582,6 +587,14 @@ class ConversationService:
         if PROJECTS_DIR.exists():
             for proj_dir in PROJECTS_DIR.iterdir():
                 conv_base = proj_dir / CONVERSATIONS_DIR_NAME
+                if conv_base.exists():
+                    for conv_dir in conv_base.iterdir():
+                        meta = conv_dir / CONVERSATION_META_FILENAME
+                        if meta.exists():
+                            self._index[conv_dir.name] = conv_dir
+        if PRODUCTS_DIR.exists():
+            for prod_dir in PRODUCTS_DIR.iterdir():
+                conv_base = prod_dir / CONVERSATIONS_DIR_NAME
                 if conv_base.exists():
                     for conv_dir in conv_base.iterdir():
                         meta = conv_dir / CONVERSATION_META_FILENAME

--- a/src/onemancompany/core/product_triggers.py
+++ b/src/onemancompany/core/product_triggers.py
@@ -265,22 +265,32 @@ You are the owner of this product. Review its current state and take action to a
 - Completed projects: {len(completed_projects)}
 - Issues: {len(backlog)} backlog, {len(in_progress)} in progress, {len(done)} done
 
-### Your Responsibilities
-1. **Review OKR progress** — Are KRs on track? If behind, what needs to change?
-2. **Review issue backlog** — Are priorities correct? Any missing issues? Any blocked?
-3. **Review active projects** — Are they progressing? Any need intervention?
-4. **Take action** — Create new issues, adjust priorities, update KR progress based on completed work
-5. **Plan next steps** — What should be worked on next? Create issues for upcoming work.
+### Review Checklist (follow in order)
 
-### Available Tools
-- `create_product_issue` — Create new issues
-- `update_product_issue` — Update issue priority, status, assignee
-- `close_product_issue` — Close completed issues
-- `update_kr_progress_tool` — Update KR metrics
-- `get_product_context_tool` — Refresh product context
-- `list_product_issues_tool` — List/filter issues
+**Step 1: Check existing Issues**
+- Are there open issues? Who is assigned? Are they being worked on (linked projects active)?
+- If an issue has no assignee or no active project → assign someone and dispatch work.
 
-Act like a product manager. Be proactive. Don't just report — take action.
+**Step 2: Check KR progress**
+- For each KR: is progress on track? Is anyone currently working toward this KR?
+- If a KR has no associated issues → create issues to advance it.
+- If a KR has issues but nobody is working on them → assign and dispatch.
+
+**Step 3: Fill gaps**
+- Are there KRs with no path to completion? Create the missing issues.
+- Are there stalled projects? Check what's blocking and take action.
+
+**Step 4: Dispatch work**
+- For unassigned high-priority issues, find the right employee (use `list_colleagues`) and assign them.
+- Use `create_product_issue` to create new issues when needed.
+- Use `update_product_issue` to assign and reprioritize.
+- Use `update_kr_progress_tool` to update KR metrics based on completed work.
+
+### Key Principles
+- **Skip if already handled** — If an issue already has an assignee AND an active project, do nothing for that issue. Avoid duplicate work.
+- **Only act on gaps** — Only create issues or dispatch work for things nobody is currently handling.
+- **Take action, don't just report** — If something needs doing and nobody is on it, assign it. You are the product owner — own it.
+- **Be concise** — Brief summary of what you checked and what action you took (or why no action needed).
 """
 
     # Submit as a CEO task linked to this product

--- a/src/onemancompany/core/product_triggers.py
+++ b/src/onemancompany/core/product_triggers.py
@@ -38,6 +38,12 @@ async def handle_issue_created(event: CompanyEvent) -> None:
         logger.warning("[PRODUCT_TRIGGER] issue {} not found in {}", issue_id, slug)
         return
 
+    # Gate: skip auto-project during planning phase
+    product = prod.load_product(slug)
+    if product and product.get("status") == "planning":
+        logger.debug("[PRODUCT_TRIGGER] Product '{}' is in planning — skipping auto-project", slug)
+        return
+
     priority = issue.get("priority", "")
     # Normalise — could be an enum value or a raw string
     if hasattr(priority, "value"):
@@ -228,6 +234,12 @@ async def handle_issue_assigned(event: CompanyEvent) -> None:
     issue = prod.load_issue(slug, issue_id)
     if not issue:
         logger.warning("[PRODUCT_TRIGGER] handle_issue_assigned: issue {} not found", issue_id)
+        return
+
+    # Gate: skip auto-project during planning phase
+    product = prod.load_product(slug)
+    if product and product.get("status") == "planning":
+        logger.debug("[PRODUCT_TRIGGER] Product '{}' is in planning — skipping auto-project on assign", slug)
         return
 
     # Only act on open/in_progress issues

--- a/src/onemancompany/core/product_triggers.py
+++ b/src/onemancompany/core/product_triggers.py
@@ -298,7 +298,7 @@ Act like a product manager. Be proactive. Don't just report — take action.
         return None
 
 
-@system_cron("product_health_check", interval="4h", description="Periodic product review + health check")
+@system_cron("product_health_check", interval="10m", description="Periodic product review + health check")
 async def product_health_check() -> list | None:
     """Check all products for stale issues, lagging KRs, and dispatch owner reviews."""
     products = prod.list_products()

--- a/src/onemancompany/core/product_triggers.py
+++ b/src/onemancompany/core/product_triggers.py
@@ -136,6 +136,9 @@ async def handle_project_complete(event: CompanyEvent) -> None:
         )
     )
 
+    # After version release, schedule a product review so owner can plan next steps
+    await dispatch_product_review(slug)
+
 
 def sync_issue_statuses(product_slug: str) -> list[dict]:
     """Sync all issue statuses by deriving from linked TaskNode states.
@@ -205,9 +208,99 @@ async def check_kr_progress(product_slug: str) -> list[dict]:
     return created_issues
 
 
-@system_cron("product_health_check", interval="30m", description="Periodic product issue/KR health check")
+async def dispatch_product_review(product_slug: str) -> str | None:
+    """Dispatch a product review task to the product owner.
+
+    The owner reviews OKR progress, issue backlog, active projects,
+    and takes autonomous action to advance the product.
+
+    Returns the project_id if a task was dispatched, None otherwise.
+    """
+    product = prod.load_product(product_slug)
+    if not product:
+        logger.warning("[PRODUCT_TRIGGER] dispatch_product_review: product '{}' not found", product_slug)
+        return None
+
+    if product.get("status") != "active":
+        logger.debug("[PRODUCT_TRIGGER] Product '{}' not active, skip review", product_slug)
+        return None
+
+    owner_id = product.get("owner_id", "")
+    if not owner_id:
+        logger.warning("[PRODUCT_TRIGGER] Product '{}' has no owner", product_slug)
+        return None
+
+    # Check if owner already has too many active projects for this product (avoid stacking)
+    from onemancompany.core.project_archive import list_projects
+    existing = [p for p in list_projects()
+                if p.get("product_id") == product["id"]
+                and p.get("status") == "active"]
+    if len(existing) >= 3:
+        logger.debug("[PRODUCT_TRIGGER] Product '{}' already has {} active projects, skip review dispatch",
+                     product_slug, len(existing))
+        return None
+
+    # Build the review task description
+    context = prod.build_product_context(product_slug)
+
+    # Gather current project status
+    linked_projects = [p for p in list_projects() if p.get("product_id") == product["id"]]
+    active_projects = [p for p in linked_projects if p.get("status") == "active"]
+    completed_projects = [p for p in linked_projects if p.get("status") == "archived"]
+
+    # Gather issue stats
+    all_issues = prod.list_issues(product_slug)
+    backlog = [i for i in all_issues if i.get("status") == IssueStatus.BACKLOG.value]
+    in_progress = [i for i in all_issues if i.get("status") == IssueStatus.IN_PROGRESS.value]
+    done = [i for i in all_issues if i.get("status") == IssueStatus.DONE.value]
+
+    task_description = f"""## Product Review — {product['name']}
+
+You are the owner of this product. Review its current state and take action to advance it toward its objectives.
+
+{context}
+
+### Current Status
+- Active projects: {len(active_projects)}
+- Completed projects: {len(completed_projects)}
+- Issues: {len(backlog)} backlog, {len(in_progress)} in progress, {len(done)} done
+
+### Your Responsibilities
+1. **Review OKR progress** — Are KRs on track? If behind, what needs to change?
+2. **Review issue backlog** — Are priorities correct? Any missing issues? Any blocked?
+3. **Review active projects** — Are they progressing? Any need intervention?
+4. **Take action** — Create new issues, adjust priorities, update KR progress based on completed work
+5. **Plan next steps** — What should be worked on next? Create issues for upcoming work.
+
+### Available Tools
+- `create_product_issue` — Create new issues
+- `update_product_issue` — Update issue priority, status, assignee
+- `close_product_issue` — Close completed issues
+- `update_kr_progress_tool` — Update KR metrics
+- `get_product_context_tool` — Refresh product context
+- `list_product_issues_tool` — List/filter issues
+
+Act like a product manager. Be proactive. Don't just report — take action.
+"""
+
+    # Submit as a CEO task linked to this product
+    from onemancompany.core.project_archive import async_create_project_from_task
+    try:
+        project_id, _iter_id = await async_create_project_from_task(
+            task_description,
+            product_id=product["id"],
+        )
+        logger.info("[PRODUCT_TRIGGER] Dispatched product review for '{}' → project {}",
+                    product_slug, project_id)
+        return project_id
+    except Exception:
+        logger.exception("[PRODUCT_TRIGGER] Failed to dispatch product review for '{}'", product_slug)
+        return None
+
+
+@system_cron("product_health_check", interval="4h", description="Periodic product review + health check")
 async def product_health_check() -> list | None:
-    """Check all products for stale issues and lagging KRs."""
+    """Check all products for stale issues, lagging KRs, and dispatch owner reviews."""
     products = prod.list_products()
     events = []
     for p in products:
@@ -217,10 +310,12 @@ async def product_health_check() -> list | None:
         # Sync issue statuses from linked TaskNode states
         status_changes = sync_issue_statuses(slug)
         kr_issues = await check_kr_progress(slug)
-        if status_changes or kr_issues:
+        # Dispatch product review to owner (only for active products)
+        review_project = await dispatch_product_review(slug)
+        if status_changes or kr_issues or review_project:
             events.append(CompanyEvent(
                 type=EventType.ACTIVITY,
-                payload={"message": f"Product '{p['name']}': {len(status_changes)} status changes, {len(kr_issues)} KR alerts"},
+                payload={"message": f"Product '{p['name']}': {len(status_changes)} status changes, {len(kr_issues)} KR alerts" + (f", review dispatched" if review_project else "")},
             ))
     return events if events else None
 

--- a/src/onemancompany/core/product_triggers.py
+++ b/src/onemancompany/core/product_triggers.py
@@ -232,7 +232,8 @@ async def dispatch_product_review(product_slug: str) -> str | None:
 
     # Check if owner already has too many active projects for this product (avoid stacking)
     from onemancompany.core.project_archive import list_projects
-    existing = [p for p in list_projects()
+    all_projects = list_projects()
+    existing = [p for p in all_projects
                 if p.get("product_id") == product["id"]
                 and p.get("status") == "active"]
     if len(existing) >= 3:
@@ -243,8 +244,8 @@ async def dispatch_product_review(product_slug: str) -> str | None:
     # Build the review task description
     context = prod.build_product_context(product_slug)
 
-    # Gather current project status
-    linked_projects = [p for p in list_projects() if p.get("product_id") == product["id"]]
+    # Gather current project status (reuse cached list)
+    linked_projects = [p for p in all_projects if p.get("product_id") == product["id"]]
     active_projects = [p for p in linked_projects if p.get("status") == "active"]
     completed_projects = [p for p in linked_projects if p.get("status") == "archived"]
 
@@ -293,11 +294,12 @@ You are the owner of this product. Review its current state and take action to a
 - **Be concise** — Brief summary of what you checked and what action you took (or why no action needed).
 """
 
-    # Submit as a CEO task linked to this product
+    # Dispatch directly to product owner (not CEO/EA pipeline)
     from onemancompany.core.project_archive import async_create_project_from_task
     try:
         project_id, _iter_id = await async_create_project_from_task(
             task_description,
+            routed_to=owner_id,
             product_id=product["id"],
         )
         logger.info("[PRODUCT_TRIGGER] Dispatched product review for '{}' → project {}",

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1443,8 +1443,8 @@ class EmployeeManager:
 
                 # Product context — inject if project is linked to a product
                 if project_id:
-                    from onemancompany.core.project_archive import load_project as _load_proj
-                    _proj_doc = _load_proj(project_id)
+                    from onemancompany.core.project_archive import load_named_project as _load_named_proj
+                    _proj_doc = _load_named_proj(project_id)
                     _product_id = _proj_doc.get("product_id", "") if _proj_doc else ""
                     if _product_id:
                         from onemancompany.core.product import build_product_context, find_slug_by_product_id
@@ -3116,10 +3116,36 @@ class EmployeeManager:
         summary = (node.result or node.description or "Task completed")[:MAX_SUMMARY_LEN]
         if agent_error:
             summary = f"(with errors) {summary}"
+
+        # Resolve product_slug + resolved_issue_ids for product trigger pipeline
+        _product_slug = ""
+        _resolved_issue_ids: list[str] = []
+        if project_id:
+            from onemancompany.core.project_archive import load_project as _lp
+            _proj = _lp(project_id)
+            _pid = _proj.get("product_id", "") if _proj else ""
+            if _pid:
+                from onemancompany.core.product import find_slug_by_product_id
+                _product_slug = find_slug_by_product_id(_pid) or ""
+            if _product_slug:
+                from onemancompany.core import product as _prod
+                _all_issues = _prod.list_issues(_product_slug)
+                _resolved_issue_ids = [
+                    i["id"] for i in _all_issues
+                    if project_id in i.get("linked_task_ids", [])
+                ]
+
         await event_bus.publish(
             CompanyEvent(
                 type=EventType.AGENT_DONE,
-                payload={"role": role, "summary": summary, "employee_id": employee_id, "project_id": project_id},
+                payload={
+                    "role": role,
+                    "summary": summary,
+                    "employee_id": employee_id,
+                    "project_id": project_id,
+                    "product_slug": _product_slug,
+                    "resolved_issue_ids": _resolved_issue_ids,
+                },
                 agent=role,
             )
         )

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1129,9 +1129,11 @@ class EmployeeManager:
                 self._deferred_schedule.discard(employee_id)
             logger.debug("[SCHEDULE] employee={} no pending tasks → IDLE", employee_id)
             self._set_employee_status(employee_id, STATUS_IDLE)
+            self._publish_dispatch_status(employee_id, status="idle")
             return
         try:
             logger.debug("[SCHEDULE] employee={} starting node={}", employee_id, entry.node_id)
+            self._publish_dispatch_status(employee_id, status="dispatched", entry=entry)
             loop = asyncio.get_running_loop()
             self._running_tasks[employee_id] = loop.create_task(
                 self._run_task(employee_id, entry)
@@ -3366,6 +3368,26 @@ class EmployeeManager:
             spawn_background(_store.save_employee_runtime(employee_id, status=status))
         except RuntimeError:
             logger.warning("No event loop for runtime persist of {}", employee_id)
+
+    def _publish_dispatch_status(
+        self, employee_id: str, *, status: str, entry: ScheduleEntry | None = None
+    ) -> None:
+        """Fire-and-forget publish of DISPATCH_STATUS_CHANGE event."""
+        payload: dict = {"employee_id": employee_id, "status": status}
+        if entry is not None:
+            payload["node_id"] = entry.node_id
+            # Resolve project_id from the task tree
+            from onemancompany.core.task_tree import get_tree
+            tree = get_tree(entry.tree_path)
+            node = tree.get_node(entry.node_id) if tree else None
+            payload["project_id"] = (node.project_id if node else "") or ""
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(event_bus.publish(
+                CompanyEvent(type=EventType.DISPATCH_STATUS_CHANGE, payload=payload)
+            ))
+        except RuntimeError:
+            logger.debug("No event loop for dispatch_status_change of {}", employee_id)
 
     def _log_node(self, employee_id: str, node_id: str, log_type: str, content: str | dict) -> None:
         """Log an event for a node.

--- a/tests/unit/test_product_triggers.py
+++ b/tests/unit/test_product_triggers.py
@@ -16,7 +16,7 @@ class TestIssueCreatedTrigger:
     async def test_p0_triggers_project(self, tmp_path):
         from onemancompany.core.product_triggers import handle_issue_created
 
-        p = prod.create_product(name="TriggerTest", owner_id="00004", description="obj")
+        p = prod.create_product(name="TriggerTest", owner_id="00004", description="obj", status=prod.ProductStatus.ACTIVE)
         issue = prod.create_issue(
             slug=p["slug"], title="Critical", description="desc",
             priority=IssuePriority.P0, created_by="ceo",


### PR DESCRIPTION
## Summary

- **Planning gate**: Products in `planning` status don't trigger auto-execution (P0/P1 issues won't auto-create projects)
- **Planning conversation**: `POST /api/product/{slug}/planning` creates a PRODUCT conversation with EA, reuses existing if active
- **Conversation routing**: `resolve_conv_dir()` routes PRODUCT conversations to `products/{slug}/conversations/{conv_id}/`
- **Frontend**: "Start Planning" button opens conversation in CEO terminal; "Activate Product" button switches to `active`; pulsing "PLANNING" indicator in sidebar
- **Flow**: CEO creates product (planning) → starts conversation with EA → discusses objectives/KR/issues → agent modifies product via tools → CEO activates → execution begins

## Test plan
- [x] 2532 unit tests passing
- [x] Planning gate test updated
- [x] Python compilation verified
- [x] PRODUCT conversation dir routing added

🤖 Generated with [Claude Code](https://claude.com/claude-code)