### PR TITLE
feat: one-click product import/export with auto-start

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7307,6 +7307,42 @@ class AppController {
     document.getElementById('submit-create-product')?.addEventListener('click', () => {
       this._submitCreateProduct();
     });
+
+    // Import product from JSON file
+    document.getElementById('import-product-btn')?.addEventListener('click', () => {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = '.json';
+      input.addEventListener('change', async (e) => {
+        const file = e.target.files[0];
+        if (!file) return;
+        try {
+          const text = await file.text();
+          const bundle = JSON.parse(text);
+          const ownerId = prompt('Enter owner employee ID (e.g. 00004):');
+          if (!ownerId) return;
+          bundle.owner_id = ownerId;
+          bundle.auto_activate = true;
+          const res = await fetch('/api/product/import', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(bundle),
+          });
+          const result = await res.json();
+          if (result.status === 'imported') {
+            this.updateProjectsPanel();
+            this._refreshProductSelector();
+            alert(`Imported "${bundle.product.name}" — ${result.issues_created} issues, ${result.krs_created} KRs. Auto-activated.`);
+          } else {
+            alert('Import failed: ' + (result.detail || 'Unknown error'));
+          }
+        } catch (err) {
+          console.error('Import failed:', err);
+          alert('Import failed: ' + err.message);
+        }
+      });
+      input.click();
+    });
   }
 
   _addKrRow() {
@@ -7555,6 +7591,24 @@ class AppController {
       });
       header.appendChild(activateBtn);
     }
+
+    // Export button (always visible)
+    const exportBtn = document.createElement('button');
+    exportBtn.className = 'btn-small';
+    exportBtn.style.marginLeft = '4px';
+    exportBtn.textContent = 'Export';
+    exportBtn.addEventListener('click', async () => {
+      const res = await fetch(`/api/product/${encodeURIComponent(slug)}/export`);
+      const data = await res.json();
+      const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${slug}-export.json`;
+      a.click();
+      URL.revokeObjectURL(url);
+    });
+    header.appendChild(exportBtn);
 
     container.appendChild(header);
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -18,6 +18,7 @@
         <span class="collapse-arrow">&#9660;</span>
         <h3 class="pixel-title">PRODUCTS</h3>
         <button id="create-product-btn" class="panel-add-btn" title="New Product">+</button>
+        <button id="import-product-btn" class="panel-add-btn" title="Import Product">&#8593;</button>
       </div>
       <div id="projects-panel-body" class="collapsible-body">
         <div id="projects-panel-list"></div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.0"
+version = "0.7.1"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -7296,6 +7296,53 @@ async def api_product_detail(slug: str) -> dict:
     }
 
 
+@router.get("/api/product/{slug}/export")
+async def api_export_product(slug: str) -> dict:
+    """Export a product with all its OKR and issues as a portable JSON bundle."""
+    from onemancompany.core import product as prod
+
+    bundle = prod.export_product(slug)
+    if not bundle:
+        raise HTTPException(status_code=404, detail=f"Product '{slug}' not found")
+    return bundle
+
+
+@router.post("/api/product/import")
+async def api_import_product(request: Request) -> dict:
+    """Import a product from a JSON bundle. Creates product, KRs, issues, then auto-starts."""
+    from onemancompany.core import product as prod
+    from onemancompany.core.models import ProductStatus
+    from onemancompany.core.product_triggers import run_product_check
+
+    body = await request.json()
+
+    owner_id = body.get("owner_id", "")
+    auto_activate = body.get("auto_activate", True)
+
+    try:
+        result = prod.import_product(body, owner_id=owner_id, auto_activate=auto_activate)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    # Auto-activate: run product check to dispatch work
+    if result["auto_activated"]:
+        await run_product_check(result["slug"])
+
+    # Publish event
+    await event_bus.publish(
+        CompanyEvent(
+            type=EventType.PRODUCT_CREATED,
+            payload={"product_slug": result["slug"]},
+            agent=SYSTEM_AGENT,
+        )
+    )
+
+    return {
+        "status": "imported",
+        **result,
+    }
+
+
 @router.post("/api/product/{slug}/planning")
 async def api_start_product_planning(slug: str) -> dict:
     """Start or resume a planning conversation for a product."""

--- a/src/onemancompany/core/product.py
+++ b/src/onemancompany/core/product.py
@@ -536,6 +536,86 @@ def build_product_context(product_slug: str) -> str:
     return "\n".join(parts)
 
 
+def export_product(slug: str) -> dict | None:
+    """Export product as a portable bundle."""
+    product = load_product(slug)
+    if not product:
+        return None
+    issues = list_issues(slug)
+    return {
+        "format": "omc-product-v1",
+        "product": {
+            "name": product.get("name", ""),
+            "description": product.get("description", ""),
+            "key_results": [
+                {"title": kr["title"], "target": kr["target"], "current": kr.get("current", 0), "unit": kr.get("unit", "")}
+                for kr in product.get("key_results", [])
+            ],
+        },
+        "issues": [
+            {
+                "title": issue["title"],
+                "description": issue.get("description", ""),
+                "priority": issue.get("priority", "P2"),
+                "labels": issue.get("labels", []),
+                "story_points": issue.get("story_points"),
+                "sprint": issue.get("sprint"),
+                "status": issue.get("status", "backlog"),
+            }
+            for issue in issues
+        ],
+    }
+
+
+def import_product(bundle: dict, owner_id: str = "", auto_activate: bool = True) -> dict:
+    """Import product from a portable bundle. Returns result dict."""
+    if bundle.get("format") != "omc-product-v1":
+        raise ValueError("Invalid format. Expected 'omc-product-v1'")
+
+    product_data = bundle.get("product", {})
+    name = product_data.get("name")
+    if not name:
+        raise ValueError("Product name is required")
+
+    status = ProductStatus.ACTIVE if auto_activate and owner_id else ProductStatus.PLANNING
+    product = create_product(
+        name=name,
+        owner_id=owner_id,
+        description=product_data.get("description", ""),
+        status=status,
+    )
+    slug = product["slug"]
+
+    for kr_data in product_data.get("key_results", []):
+        add_key_result(slug, title=kr_data["title"], target=kr_data.get("target", 1), unit=kr_data.get("unit", ""))
+
+    issue_ids = []
+    for issue_data in bundle.get("issues", []):
+        try:
+            priority = IssuePriority(issue_data.get("priority", "P2"))
+        except ValueError:
+            priority = IssuePriority.P2
+        issue = create_issue(
+            slug=slug,
+            title=issue_data["title"],
+            description=issue_data.get("description", ""),
+            priority=priority,
+            labels=issue_data.get("labels", []),
+            story_points=issue_data.get("story_points"),
+            sprint=issue_data.get("sprint"),
+            created_by="import",
+        )
+        issue_ids.append(issue["id"])
+
+    return {
+        "slug": slug,
+        "product_id": product["id"],
+        "issues_created": len(issue_ids),
+        "krs_created": len(product_data.get("key_results", [])),
+        "auto_activated": status == ProductStatus.ACTIVE,
+    }
+
+
 def find_slug_by_product_id(product_id: str) -> str | None:
     """Find product slug by product ID."""
     for p in list_products():

--- a/tests/unit/test_product.py
+++ b/tests/unit/test_product.py
@@ -505,6 +505,112 @@ class TestResolveTaskStatus:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Export / Import
+# ---------------------------------------------------------------------------
+
+
+class TestProductExportImport:
+    def test_export_product(self):
+        """Export returns portable bundle with product, KRs, issues."""
+        p = prod.create_product(name="ExportTest", owner_id="00004", description="test desc")
+        prod.add_key_result(p["slug"], title="KR1", target=100, unit="users")
+        prod.create_issue(slug=p["slug"], title="Issue1", created_by="ceo", priority=IssuePriority.P1)
+
+        bundle = prod.export_product(p["slug"])
+        assert bundle is not None
+        assert bundle["format"] == "omc-product-v1"
+        assert bundle["product"]["name"] == "ExportTest"
+        assert bundle["product"]["description"] == "test desc"
+        assert len(bundle["product"]["key_results"]) == 1
+        assert bundle["product"]["key_results"][0]["title"] == "KR1"
+        assert bundle["product"]["key_results"][0]["target"] == 100
+        assert bundle["product"]["key_results"][0]["unit"] == "users"
+        assert len(bundle["issues"]) == 1
+        assert bundle["issues"][0]["title"] == "Issue1"
+
+    def test_export_missing_product(self):
+        assert prod.export_product("nonexistent") is None
+
+    def test_import_product(self):
+        bundle = {
+            "format": "omc-product-v1",
+            "product": {
+                "name": "Imported Product",
+                "description": "imported desc",
+                "key_results": [
+                    {"title": "KR1", "target": 100, "unit": "users"},
+                    {"title": "KR2", "target": 50},
+                ],
+            },
+            "issues": [
+                {"title": "Issue A", "priority": "P0", "labels": ["urgent"]},
+                {"title": "Issue B", "description": "desc B"},
+            ],
+        }
+        result = prod.import_product(bundle, owner_id="00004", auto_activate=True)
+        assert result["issues_created"] == 2
+        assert result["krs_created"] == 2
+        assert result["auto_activated"] is True
+
+        # Verify created
+        product = prod.load_product(result["slug"])
+        assert product["name"] == "Imported Product"
+        assert product["status"] == ProductStatus.ACTIVE
+        assert len(product["key_results"]) == 2
+        issues = prod.list_issues(result["slug"])
+        assert len(issues) == 2
+
+    def test_import_invalid_format(self):
+        with pytest.raises(ValueError, match="Invalid format"):
+            prod.import_product({"format": "wrong"})
+
+    def test_import_no_name(self):
+        with pytest.raises(ValueError, match="name"):
+            prod.import_product({"format": "omc-product-v1", "product": {}})
+
+    def test_import_planning_when_no_owner(self):
+        bundle = {
+            "format": "omc-product-v1",
+            "product": {"name": "No Owner Product", "key_results": []},
+            "issues": [],
+        }
+        result = prod.import_product(bundle, owner_id="", auto_activate=True)
+        assert result["auto_activated"] is False
+        product = prod.load_product(result["slug"])
+        assert product["status"] == ProductStatus.PLANNING
+
+    def test_roundtrip_export_import(self):
+        """Export a product, then import it — the imported copy should match."""
+        p = prod.create_product(name="RoundTrip", owner_id="00004", description="round trip test")
+        prod.add_key_result(p["slug"], title="Users", target=500, unit="DAU")
+        prod.create_issue(slug=p["slug"], title="Bug X", created_by="ceo", priority=IssuePriority.P1, labels=["bug"])
+        prod.create_issue(slug=p["slug"], title="Feat Y", created_by="ceo", priority=IssuePriority.P2, story_points=3)
+
+        bundle = prod.export_product(p["slug"])
+        result = prod.import_product(bundle, owner_id="00010", auto_activate=False)
+        assert result["issues_created"] == 2
+        assert result["krs_created"] == 1
+
+        imported = prod.load_product(result["slug"])
+        assert imported["name"] == "RoundTrip"
+        assert imported["description"] == "round trip test"
+        assert len(imported["key_results"]) == 1
+        assert imported["key_results"][0]["title"] == "Users"
+
+    def test_import_invalid_priority_falls_back(self):
+        """Invalid priority string falls back to P2."""
+        bundle = {
+            "format": "omc-product-v1",
+            "product": {"name": "BadPrio", "key_results": []},
+            "issues": [{"title": "Oops", "priority": "INVALID"}],
+        }
+        result = prod.import_product(bundle, owner_id="00004")
+        issues = prod.list_issues(result["slug"])
+        assert len(issues) == 1
+        assert issues[0]["priority"] == IssuePriority.P2
+
+
 class TestSlugifyEdgeCases:
     def test_long_name_truncated(self):
         """Line 59: slug longer than max_len gets truncated."""


### PR DESCRIPTION
## Summary

- **Export**: `GET /api/product/{slug}/export` → portable JSON bundle (`omc-product-v1` format) with product, KRs, issues
- **Import**: `POST /api/product/import` → creates product + KRs + issues from bundle, assigns owner, auto-activates and runs `run_product_check` to dispatch work
- **Frontend**: Export button in product detail header (downloads .json), Import button (↑) in panel header (file picker → prompt owner ID → auto-start)
- **Core functions**: `export_product()` and `import_product()` in product.py for testability

## Test plan
- [x] 8 new tests: export, import, roundtrip, invalid format, no name, no owner, missing product, invalid priority
- [x] 3874 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)