### PR TITLE
feat: product delete button — removes product, issues, versions, and linked projects

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -7610,6 +7610,26 @@ class AppController {
     });
     header.appendChild(exportBtn);
 
+    // Delete button
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'btn-small btn-danger';
+    deleteBtn.style.marginLeft = '4px';
+    deleteBtn.textContent = 'Delete';
+    deleteBtn.addEventListener('click', async () => {
+      if (!confirm(`Delete product "${product.name}" and ALL its data? This cannot be undone.`)) return;
+      try {
+        const res = await fetch(`/api/product/${encodeURIComponent(slug)}`, { method: 'DELETE' });
+        if (!res.ok) throw new Error(`Server error: ${res.status}`);
+        document.getElementById('product-modal').classList.add('hidden');
+        this.updateProjectsPanel();
+        this._refreshProductSelector();
+      } catch (err) {
+        console.error('Delete failed:', err);
+        alert('Delete failed: ' + err.message);
+      }
+    });
+    header.appendChild(deleteBtn);
+
     container.appendChild(header);
 
     // Objective

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -5782,6 +5782,17 @@ body.resize-dragging {
   color: var(--pixel-cyan);
 }
 
+.btn-danger {
+  color: #ff4444;
+  border-color: #500;
+}
+
+.btn-danger:hover {
+  background: #ff4444;
+  color: var(--bg-dark);
+  border-color: #ff4444;
+}
+
 .btn-primary {
   background: var(--pixel-cyan);
   color: var(--bg-dark);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.2"
+version = "0.7.3"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -7029,15 +7029,12 @@ async def api_delete_product(slug: str) -> dict:
     """Delete a product and all its data."""
     from onemancompany.core import product as prod
 
-    product = prod.load_product(slug)
-    if not product:
-        raise HTTPException(status_code=404, detail=f"Product '{slug}' not found")
+    try:
+        result = prod.delete_product(slug)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
 
-    success = prod.delete_product(slug)
-    if not success:
-        raise HTTPException(status_code=500, detail="Failed to delete product")
-
-    return {"status": "deleted", "slug": slug}
+    return {"status": "deleted", **result}
 
 
 @router.put("/api/product/{slug}")

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -7024,6 +7024,22 @@ async def api_get_product(slug: str) -> dict:
     return data
 
 
+@router.delete("/api/product/{slug}")
+async def api_delete_product(slug: str) -> dict:
+    """Delete a product and all its data."""
+    from onemancompany.core import product as prod
+
+    product = prod.load_product(slug)
+    if not product:
+        raise HTTPException(status_code=404, detail=f"Product '{slug}' not found")
+
+    success = prod.delete_product(slug)
+    if not success:
+        raise HTTPException(status_code=500, detail="Failed to delete product")
+
+    return {"status": "deleted", "slug": slug}
+
+
 @router.put("/api/product/{slug}")
 async def api_update_product(slug: str, request: Request) -> dict:
     """Update product fields."""

--- a/src/onemancompany/core/product.py
+++ b/src/onemancompany/core/product.py
@@ -616,6 +616,22 @@ def import_product(bundle: dict, owner_id: str = "", auto_activate: bool = True)
     }
 
 
+def delete_product(slug: str) -> bool:
+    """Delete a product and all its issues/versions. Returns True if deleted."""
+    product_dir = _product_dir(slug)
+    if not product_dir.exists():
+        logger.warning("delete_product: slug={} not found", slug)
+        return False
+
+    import shutil
+    with _get_slug_lock(slug):
+        shutil.rmtree(product_dir)
+
+    mark_dirty(DirtyCategory.PRODUCTS)
+    logger.info("[PRODUCT] Deleted product '{}'", slug)
+    return True
+
+
 def find_slug_by_product_id(product_id: str) -> str | None:
     """Find product slug by product ID."""
     for p in list_products():

--- a/src/onemancompany/core/product.py
+++ b/src/onemancompany/core/product.py
@@ -616,20 +616,57 @@ def import_product(bundle: dict, owner_id: str = "", auto_activate: bool = True)
     }
 
 
-def delete_product(slug: str) -> bool:
-    """Delete a product and all its issues/versions. Returns True if deleted."""
-    product_dir = _product_dir(slug)
-    if not product_dir.exists():
-        logger.warning("delete_product: slug={} not found", slug)
-        return False
+def delete_product(slug: str) -> dict:
+    """Delete a product, its issues/versions, and all linked projects.
 
+    Returns summary dict with counts of deleted items.
+    Raises ValueError if product not found.
+    """
+    product = load_product(slug)
+    if not product:
+        raise ValueError(f"Product '{slug}' not found")
+
+    product_id = product.get("id", "")
+
+    # Delete linked projects
+    deleted_projects = 0
+    if product_id:
+        from onemancompany.core.project_archive import list_projects
+        from onemancompany.core.config import PROJECTS_DIR
+        import shutil as _shutil
+
+        for proj in list_projects():
+            if proj.get("product_id") == product_id:
+                proj_dir = PROJECTS_DIR / proj["project_id"]
+                if proj_dir.exists():
+                    # Cancel running tasks for this project
+                    try:
+                        from onemancompany.core.agent_loop import employee_manager
+                        employee_manager.abort_project(proj["project_id"])
+                    except Exception as e:
+                        logger.debug("[PRODUCT] Could not abort project {}: {}", proj["project_id"], e)
+                    _shutil.rmtree(proj_dir)
+                    deleted_projects += 1
+                    logger.debug("[PRODUCT] Deleted linked project {}", proj["project_id"])
+
+    # Count issues before deletion
+    issues = list_issues(slug)
+    deleted_issues = len(issues)
+
+    # Delete product directory (product.yaml, issues/, versions/)
     import shutil
+    product_dir = _product_dir(slug)
     with _get_slug_lock(slug):
         shutil.rmtree(product_dir)
 
     mark_dirty(DirtyCategory.PRODUCTS)
-    logger.info("[PRODUCT] Deleted product '{}'", slug)
-    return True
+    logger.info("[PRODUCT] Deleted product '{}': {} issues, {} projects removed", slug, deleted_issues, deleted_projects)
+    return {
+        "deleted": True,
+        "slug": slug,
+        "issues_deleted": deleted_issues,
+        "projects_deleted": deleted_projects,
+    }
 
 
 def find_slug_by_product_id(product_id: str) -> str | None:

--- a/tests/unit/test_product.py
+++ b/tests/unit/test_product.py
@@ -814,10 +814,33 @@ class TestDeleteProduct:
         assert prod.load_product(p["slug"]) is not None
 
         result = prod.delete_product(p["slug"])
-        assert result is True
+        assert result["deleted"] is True
+        assert result["issues_deleted"] == 1
         assert prod.load_product(p["slug"]) is None
         assert prod.list_issues(p["slug"]) == []
 
     def test_delete_nonexistent(self):
-        result = prod.delete_product("nonexistent")
-        assert result is False
+        with pytest.raises(ValueError, match="not found"):
+            prod.delete_product("nonexistent")
+
+    def test_delete_cleans_linked_projects(self, tmp_path, monkeypatch):
+        """Deleting a product also removes linked projects."""
+        from unittest.mock import patch, MagicMock
+        p = prod.create_product(name="WithProjects", owner_id="00004")
+        product_id = p["id"]
+
+        # Create a fake project dir linked to this product
+        from onemancompany.core.config import PROJECTS_DIR
+        fake_proj_dir = PROJECTS_DIR / "fake-proj-123"
+        fake_proj_dir.mkdir(parents=True, exist_ok=True)
+        (fake_proj_dir / "project.yaml").write_text("test: true")
+
+        with patch("onemancompany.core.project_archive.list_projects", return_value=[
+            {"project_id": "fake-proj-123", "product_id": product_id, "status": "active"},
+        ]):
+            with patch("onemancompany.core.agent_loop.employee_manager") as mock_em:
+                mock_em.abort_project = MagicMock()
+                result = prod.delete_product(p["slug"])
+
+        assert result["projects_deleted"] == 1
+        assert not fake_proj_dir.exists()

--- a/tests/unit/test_product.py
+++ b/tests/unit/test_product.py
@@ -800,3 +800,24 @@ class TestBuildProductContextEdgeCases:
             prod.create_issue(slug=p["slug"], title=f"Issue {i}", created_by="ceo")
         ctx = prod.build_product_context(p["slug"])
         assert "and 2 more" in ctx
+
+
+# ---------------------------------------------------------------------------
+# Delete Product
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteProduct:
+    def test_delete_product(self):
+        p = prod.create_product(name="ToDelete", owner_id="00004")
+        prod.create_issue(slug=p["slug"], title="Issue1", created_by="ceo")
+        assert prod.load_product(p["slug"]) is not None
+
+        result = prod.delete_product(p["slug"])
+        assert result is True
+        assert prod.load_product(p["slug"]) is None
+        assert prod.list_issues(p["slug"]) == []
+
+    def test_delete_nonexistent(self):
+        result = prod.delete_product("nonexistent")
+        assert result is False


### PR DESCRIPTION
## Summary

- **Backend**: `delete_product(slug)` removes product directory + all linked projects (cancels running tasks first)
- **API**: `DELETE /api/product/{slug}` with 404 for not found
- **Frontend**: Delete button in product detail modal header with confirmation dialog
- **Cleanup**: Linked projects are found by `product_id`, their running tasks are aborted, then directories are removed

## Test plan
- [x] 3 tests: delete product, delete nonexistent, delete cleans linked projects
- [x] 3877 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)