### PR TITLE
fix: cron start() runs immediately when enabled via settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.3"
+version = "0.7.4"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -6431,7 +6431,7 @@ async def list_system_crons() -> list[dict]:
 @router.post("/api/system/crons/{name}/start")
 async def start_system_cron(name: str) -> dict:
     from onemancompany.core.system_cron import system_cron_manager
-    return system_cron_manager.start(name)
+    return system_cron_manager.start(name, run_immediately=True)
 
 
 @router.post("/api/system/crons/{name}/stop")

--- a/src/onemancompany/core/system_cron.py
+++ b/src/onemancompany/core/system_cron.py
@@ -184,15 +184,21 @@ class SystemCronManager:
         self._tasks.clear()
         logger.info("All system crons stopped")
 
-    def start(self, name: str) -> dict:
-        """Start a single system cron by name. Removes from disabled set."""
+    def start(self, name: str, run_immediately: bool = False) -> dict:
+        """Start a single system cron by name. Removes from disabled set.
+
+        If run_immediately=True, triggers one execution before entering the loop.
+        """
         defn = self._registry.get(name)
         if not defn:
             return {"status": "error", "message": f"Unknown system cron: {name}"}
         existing = self._tasks.get(name)
         if existing and not existing.done():
             existing.cancel()
-        task = asyncio.create_task(self._loop(defn), name=f"system_cron:{name}")
+        task = asyncio.create_task(
+            self._loop(defn, run_first=run_immediately),
+            name=f"system_cron:{name}",
+        )
         self._tasks[name] = task
         if name in self._disabled:
             self._disabled.discard(name)
@@ -244,14 +250,19 @@ class SystemCronManager:
             })
         return result
 
-    async def _loop(self, cron_def: SystemCronDef) -> None:
+    async def _loop(self, cron_def: SystemCronDef, run_first: bool = False) -> None:
         """Main loop for a single system cron."""
         from onemancompany.core.events import event_bus
 
         logger.info("[system_cron] Started '{}' every {}", cron_def.name, cron_def.current_interval)
         try:
+            first_iteration = True
             while True:
-                await asyncio.sleep(cron_def.current_interval_seconds)
+                if first_iteration and run_first:
+                    first_iteration = False
+                    # Skip initial sleep — run immediately
+                else:
+                    await asyncio.sleep(cron_def.current_interval_seconds)
                 try:
                     events = await cron_def.handler()
                     cron_def.last_run = datetime.now()


### PR DESCRIPTION
## Summary

- `system_cron_manager.start(name, run_immediately=True)` — triggers first execution without waiting the full interval
- API endpoint `POST /api/system/crons/{name}/start` now passes `run_immediately=True`
- `_loop()` accepts `run_first` param to skip initial sleep on first iteration

## Context

In omc-test-3, `product_health_check` was in the disabled cron list. When re-enabled via settings, it would wait 10 minutes before first run. Now it runs immediately.

## Test plan
- [x] 3877 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)