### PR TITLE
fix: CEO console only shows active real projects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.4"
+version = "0.7.5"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -6255,12 +6255,26 @@ async def list_ceo_sessions():
     from onemancompany.core.conversation import get_conversation_service
     from onemancompany.core.models import ConversationType
 
+    from onemancompany.core.project_archive import load_named_project
+
     service = get_conversation_service()
     convs = service.list_by_phase(type=ConversationType.PROJECT.value)
     sessions = []
     for conv in convs:
+        pid = conv.project_id or ""
+        # Skip non-project conversations: default, empty, system projects
+        if not pid or pid == "default" or pid.startswith("_sys"):
+            continue
+        # Skip conversations for deleted/nonexistent projects
+        base_pid = pid.split("/")[0]
+        proj = load_named_project(base_pid)
+        if not proj:
+            continue
+        # Skip archived projects (they're done)
+        if proj.get("status") == "archived":
+            continue
         sessions.append({
-            "project_id": conv.project_id or conv.id,
+            "project_id": pid,
             "pending_count": service.get_pending_count(conv.id),
             "history_count": len(service.get_messages(conv.id)),
             "conv_id": conv.id,

--- a/src/onemancompany/core/project_archive.py
+++ b/src/onemancompany/core/project_archive.py
@@ -502,7 +502,7 @@ def list_named_projects() -> list[dict]:
 
 
 def archive_project(project_id: str) -> None:
-    """Mark a named project as archived."""
+    """Mark a named project as archived and close its conversation."""
     proj = load_named_project(project_id)
     if not proj:
         return
@@ -512,6 +512,24 @@ def archive_project(project_id: str) -> None:
     lock = _get_project_lock(project_id)
     with lock, open_utf(path, "w") as f:
         yaml.dump(proj, f, allow_unicode=True, default_flow_style=False)
+
+    # Close project conversation so it disappears from CEO console
+    try:
+        from onemancompany.core.conversation import get_conversation_service
+        from onemancompany.core.models import ConversationType
+        service = get_conversation_service()
+        for conv in service.list_by_phase(type=ConversationType.PROJECT.value):
+            conv_pid = (conv.project_id or "").split("/")[0]
+            if conv_pid == project_id:
+                import asyncio
+                try:
+                    loop = asyncio.get_running_loop()
+                    loop.create_task(service.close(conv.id))
+                except RuntimeError:
+                    logger.debug("[archive] No event loop for async close of conv {}", conv.id)
+                logger.debug("[archive] Closed conversation {} for project {}", conv.id, project_id)
+    except Exception as e:
+        logger.debug("[archive] Could not close conversation for {}: {}", project_id, e)
 
 
 def get_project_workspace(project_id: str) -> str:

--- a/tests/unit/api/test_ceo_sessions.py
+++ b/tests/unit/api/test_ceo_sessions.py
@@ -59,7 +59,9 @@ class TestListSessions:
             return [Message(sender="x", role="system", text="hi", timestamp="t")]
         svc.get_messages.side_effect = _messages
 
-        with patch("onemancompany.core.conversation.get_conversation_service", return_value=svc):
+        with patch("onemancompany.core.conversation.get_conversation_service", return_value=svc), \
+             patch("onemancompany.core.project_archive.load_named_project",
+                   side_effect=lambda pid: {"status": "active"} if pid in ("proj_a", "proj_b") else None):
             result = await list_ceo_sessions()
             assert len(result["sessions"]) == 2
             assert result["sessions"][0]["project_id"] == "proj_b"


### PR DESCRIPTION
## Summary

CEO console project list was cluttered with system projects, default conversations, and archived projects that never close.

**Filters added to `list_ceo_sessions`:**
- Skip `default` project_id
- Skip empty project_id
- Skip `_sys_` prefix projects
- Skip deleted projects (no project.yaml on disk)
- Skip archived projects

**Auto-close on archive:**
- `archive_project()` now closes the project's conversation so it disappears from CEO console

## Test plan
- [x] 3877 tests passing
- [x] Updated test_returns_sessions_sorted to mock load_named_project

🤖 Generated with [Claude Code](https://claude.com/claude-code)