### PR TITLE
fix: prevent infinite retry loop + truncate oversized context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.6"
+version = "0.7.7"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -529,6 +529,15 @@ def reject_child(node_id: str, reason: str, retry: bool = True) -> dict:
 
         node.acceptance_result = {"passed": False, "notes": reason}
 
+        # --- Max retry guard: prevent infinite reject→retry loops ---
+        MAX_REJECT_RETRIES = 3
+        if retry and node.retry_count >= MAX_REJECT_RETRIES:
+            logger.warning(
+                "Node {} has been retried {} times (max {}), forcing abandon",
+                node_id, node.retry_count, MAX_REJECT_RETRIES,
+            )
+            retry = False
+
         if retry:
             from onemancompany.core.vessel import employee_manager as em
             if node.employee_id not in em.executors:
@@ -537,6 +546,7 @@ def reject_child(node_id: str, reason: str, retry: bool = True) -> dict:
             # Reset to pending and re-schedule — keep original description, add rejection as directive
             node.load_content(project_dir)
             node.set_status(TaskPhase.PENDING)
+            node.retry_count += 1
             node.result = ""
             from datetime import datetime
             new_directives = list(node.directives)

--- a/src/onemancompany/core/task_tree.py
+++ b/src/onemancompany/core/task_tree.py
@@ -87,6 +87,10 @@ class TaskNode:
     # Used by the global HOLDING timeout to auto-fail stale tasks.
     hold_started_at: str = ""
 
+    # How many times this node has been rejected and retried by the parent.
+    # Used to cap infinite retry loops (e.g. EA keeps retrying a failing child).
+    retry_count: int = 0
+
     # --- Content externalization tracking (not part of equality/repr) ---
     _content_dirty: bool = field(default=False, init=False, repr=False, compare=False)
     _content_loaded: bool = field(default=False, init=False, repr=False, compare=False)
@@ -205,6 +209,7 @@ class TaskNode:
             "depends_on": list(self.depends_on),
             "hold_reason": self.hold_reason,
             "hold_started_at": self.hold_started_at,
+            "retry_count": self.retry_count,
             "directives_count": len(self.directives),
         }
 

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -1532,6 +1532,18 @@ class EmployeeManager:
             except Exception:
                 logger.warning("Task start hooks failed for {}", employee_id)
 
+            # --- Truncate oversized prompts to avoid context-limit errors ---
+            MAX_PROMPT_CHARS = 100_000  # ~25K tokens, safe for most models
+            if len(task_with_ctx) > MAX_PROMPT_CHARS:
+                logger.warning(
+                    "[TASK] Truncating oversized prompt for employee={} node={}: {} → {} chars",
+                    employee_id, entry.node_id, len(task_with_ctx), MAX_PROMPT_CHARS,
+                )
+                # Keep the beginning (company context + product context) and end (task description)
+                # Truncate from the middle (progress log, workflow context — least critical)
+                half = MAX_PROMPT_CHARS // 2
+                task_with_ctx = task_with_ctx[:half] + "\n\n[... context truncated ...]\n\n" + task_with_ctx[-half:]
+
             # Universal timeout — asyncio.wait_for wraps ALL executor types.
             task_timeout = node.timeout_seconds or 3600
             # For SubprocessExecutor: set its internal timeout slightly longer


### PR DESCRIPTION
## Summary

**Fix 1: Retry limit for child task failures**
- Added `retry_count` field to TaskNode
- `reject_child(retry=True)` increments retry_count, forces `retry=False` after 3 attempts
- Prevents infinite loop: child fails → EA retries → child fails → EA retries → ...

**Fix 2: Context truncation before executor**
- Added 100K char limit on task prompt before sending to executor
- Middle-out truncation: keeps beginning (company/product context) + end (task description)
- Prevents `claude-daemon error: chunk is longer than limit`

## Test plan
- [x] 3877 tests passing
- [x] Import verification OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)