### PR TITLE
fix: route CEO followup to product owner + product selector feedback

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -795,6 +795,9 @@ class AppController {
     // Create Product modal
     this._initCreateProductModal();
 
+    // Product selector feedback
+    this._initProductSelector();
+
     hrBtn?.addEventListener('click', () => {
       hrBtn.disabled = true;
       this.logEntry('CEO', '🔄 Triggering quarterly review...', 'ceo');
@@ -7262,6 +7265,20 @@ class AppController {
   }
 
   // ===== Product Selector =====
+  _initProductSelector() {
+    const sel = document.getElementById('ceo-product-select');
+    if (!sel) return;
+    sel.addEventListener('change', () => {
+      if (sel.value) {
+        sel.style.borderColor = 'var(--pixel-cyan)';
+        sel.style.color = 'var(--pixel-white)';
+      } else {
+        sel.style.borderColor = '';
+        sel.style.color = '';
+      }
+    });
+  }
+
   async _refreshProductSelector() {
     try {
       const data = await fetch('/api/products').then(r => r.json());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.19"
+version = "0.7.20"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -655,7 +655,7 @@ async def ceo_submit_task(
 
 @router.post("/api/task/{project_id}/followup")
 async def task_followup(project_id: str, body: dict) -> dict:
-    """CEO adds follow-up instructions to an existing task, dispatched to EA with context."""
+    """CEO adds follow-up instructions to an existing task, dispatched to assignee (product owner or EA) with context."""
     from datetime import datetime as _dt
 
     from onemancompany.core.agent_loop import get_agent_loop
@@ -699,7 +699,23 @@ async def task_followup(project_id: str, body: dict) -> dict:
             for fname in deliverables:
                 work_summary_lines.append(f"  {fname}")
 
-    # Build follow-up task for EA
+    # Determine assignee: product owner if product-linked, else EA
+    assignee_id = EA_ID
+    product_id = doc.get("product_id", "")
+    if product_id:
+        from onemancompany.core.product import find_slug_by_product_id, load_product
+        product_slug = find_slug_by_product_id(product_id)
+        if product_slug:
+            product = load_product(product_slug)
+            if product and product.get("owner_id"):
+                assignee_id = product["owner_id"]
+                logger.debug("[FOLLOWUP] Product-linked project {}, routing to owner {}",
+                             project_id, assignee_id)
+        if assignee_id == EA_ID:
+            logger.debug("[FOLLOWUP] No product owner found for project {}, falling back to EA",
+                         project_id)
+
+    # Build follow-up task for assignee
     context_parts = [
         f"CEO has added follow-up instructions to a completed task:\n",
         f"Original task: {original_task}\n",
@@ -721,11 +737,11 @@ async def task_followup(project_id: str, body: dict) -> dict:
     else:
         tree = TaskTree(project_id=project_id)
 
-    ea_loop = get_agent_loop(EA_ID)
-    if not ea_loop:
-        raise HTTPException(status_code=503, detail="EA agent not available")
+    assignee_loop = get_agent_loop(assignee_id)
+    if not assignee_loop:
+        raise HTTPException(status_code=503, detail=f"Agent {assignee_id} not available")
 
-    schedule_node_id = ""  # will be set to the EA node to schedule
+    schedule_node_id = ""  # will be set to the assignee node to schedule
 
     if tree.root_id:
         # Add a new subtree from CEO root — old subtree stays intact
@@ -741,39 +757,39 @@ async def task_followup(project_id: str, body: dict) -> dict:
         followup_node.node_type = NodeType.CEO_FOLLOWUP
         followup_node.status = TaskPhase.ACCEPTED.value
 
-        # Create a new EA node under the followup node for execution
-        ea_child = tree.add_child(
+        # Create execution node under the followup node
+        exec_child = tree.add_child(
             parent_id=followup_node.id,
-            employee_id=EA_ID,
+            employee_id=assignee_id,
             description=followup_task,
             acceptance_criteria=[],
         )
-        schedule_node_id = ea_child.id
+        schedule_node_id = exec_child.id
 
         # Keep CEO root in PROCESSING while new subtree runs
         if root and root.node_type == NodeType.CEO_PROMPT:
             root.status = TaskPhase.PROCESSING.value
     else:
-        # No root yet — create CEO root + EA child
+        # No root yet — create CEO root + assignee child
         ceo_root = tree.create_root(employee_id=CEO_ID, description=instructions)
         ceo_root.node_type = NodeType.CEO_PROMPT
         ceo_root.set_status(TaskPhase.PROCESSING)
-        ea_child = tree.add_child(
+        exec_child = tree.add_child(
             parent_id=ceo_root.id,
-            employee_id=EA_ID,
+            employee_id=assignee_id,
             description=instructions,
             acceptance_criteria=[],
         )
-        schedule_node_id = ea_child.id
+        schedule_node_id = exec_child.id
 
     _save_project_tree(pdir, tree)
 
-    # Schedule the EA node for execution
+    # Schedule the assignee node for execution
     if schedule_node_id:
         tree_path = str(Path(pdir) / TASK_TREE_FILENAME)
         from onemancompany.core.agent_loop import employee_manager
-        employee_manager.schedule_node(EA_ID, schedule_node_id, tree_path)
-        employee_manager._schedule_next(EA_ID)
+        employee_manager.schedule_node(assignee_id, schedule_node_id, tree_path)
+        employee_manager._schedule_next(assignee_id)
 
     # Update project.yaml status back to in_progress
     doc["status"] = "in_progress"

--- a/tests/unit/api/test_product_followup.py
+++ b/tests/unit/api/test_product_followup.py
@@ -1,0 +1,228 @@
+"""Tests for product-owner routing in task_followup and product selector behavior.
+
+Bug 1: task_followup always routes to EA even for product-linked projects.
+        Should route to product owner instead.
+Bug 2: CEO console product selector gives no visual feedback on change.
+        (Frontend test — verified via app.js code inspection.)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from onemancompany.core.config import CEO_ID, EA_ID, TASK_TREE_FILENAME
+from onemancompany.core.task_lifecycle import NodeType, TaskPhase
+from onemancompany.core.task_tree import TaskTree
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+OWNER_ID = "00010"
+PRODUCT_ID = "prod_abc"
+PRODUCT_SLUG = "my-product"
+PROJECT_ID = "proj_001"
+
+
+def _make_project_doc(product_id: str = "") -> dict:
+    return {
+        "project_id": PROJECT_ID,
+        "task": "Build feature X",
+        "status": "completed",
+        "product_id": product_id,
+        "completed_at": "2026-01-01",
+    }
+
+
+def _make_tree_with_root(project_id: str = PROJECT_ID) -> TaskTree:
+    """Create a minimal tree with CEO root + completed EA child."""
+    tree = TaskTree(project_id=project_id)
+    root = tree.create_root(employee_id=CEO_ID, description="Build feature X")
+    root.node_type = NodeType.CEO_PROMPT
+    root.set_status(TaskPhase.PROCESSING)
+    ea_child = tree.add_child(
+        parent_id=root.id,
+        employee_id=EA_ID,
+        description="Execute feature X",
+        acceptance_criteria=[],
+    )
+    ea_child.set_status(TaskPhase.PROCESSING)
+    ea_child.set_status(TaskPhase.COMPLETED)
+    return tree
+
+
+def _mock_product(product_id: str = PRODUCT_ID, owner_id: str = OWNER_ID) -> dict:
+    return {
+        "id": product_id,
+        "slug": PRODUCT_SLUG,
+        "name": "My Product",
+        "owner_id": owner_id,
+        "status": "active",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: task_followup should route to product owner for product-linked projects
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_followup_routes_to_product_owner_when_product_linked(tmp_path):
+    """When a project is linked to a product with an owner, the followup
+    node should be assigned to the product owner, NOT the EA."""
+    from onemancompany.api.routes import task_followup
+
+    # Set up project dir with tree file present so tree_path.exists() is True
+    pdir = tmp_path / PROJECT_ID
+    pdir.mkdir()
+    tree = _make_tree_with_root()
+    tree_path = pdir / TASK_TREE_FILENAME
+    tree_path.write_text("{}")  # dummy content, get_tree is mocked
+
+    project_doc = _make_project_doc(product_id=PRODUCT_ID)
+
+    mock_em = MagicMock()
+    mock_em.schedule_node = MagicMock()
+    mock_em._schedule_next = MagicMock()
+
+    mock_agent_loop = MagicMock()
+
+    with patch("onemancompany.core.project_archive.get_project_dir", return_value=str(pdir)), \
+         patch("onemancompany.core.project_archive._resolve_and_load", return_value=("v1", project_doc, "key1")), \
+         patch("onemancompany.core.project_archive.append_action"), \
+         patch("onemancompany.core.task_tree.get_tree", return_value=tree), \
+         patch("onemancompany.core.vessel._save_project_tree"), \
+         patch("onemancompany.core.agent_loop.get_agent_loop", return_value=mock_agent_loop), \
+         patch("onemancompany.core.agent_loop.employee_manager", mock_em), \
+         patch("onemancompany.core.project_archive._save_resolved"), \
+         patch("onemancompany.api.routes.event_bus", AsyncMock()), \
+         patch("onemancompany.core.product.find_slug_by_product_id", return_value=PRODUCT_SLUG), \
+         patch("onemancompany.core.product.load_product", return_value=_mock_product()):
+
+        result = await task_followup(PROJECT_ID, {"instructions": "Update the KR progress"})
+
+    assert result["status"] == "ok"
+
+    # The key assertion: schedule_node should be called with the product OWNER,
+    # not the EA.
+    scheduled_employee_id = mock_em.schedule_node.call_args[0][0]
+    assert scheduled_employee_id == OWNER_ID, (
+        f"Expected followup to be routed to product owner {OWNER_ID}, "
+        f"but was routed to {scheduled_employee_id}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_task_followup_routes_to_ea_when_no_product(tmp_path):
+    """When a project is NOT linked to any product, followup should still
+    route to EA as before."""
+    from onemancompany.api.routes import task_followup
+
+    pdir = tmp_path / PROJECT_ID
+    pdir.mkdir()
+    tree = _make_tree_with_root()
+    tree_path = pdir / TASK_TREE_FILENAME
+    tree_path.write_text("{}")  # dummy, get_tree is mocked
+
+    project_doc = _make_project_doc(product_id="")  # no product
+
+    mock_em = MagicMock()
+    mock_em.schedule_node = MagicMock()
+    mock_em._schedule_next = MagicMock()
+
+    mock_agent_loop = MagicMock()
+
+    with patch("onemancompany.core.project_archive.get_project_dir", return_value=str(pdir)), \
+         patch("onemancompany.core.project_archive._resolve_and_load", return_value=("v1", project_doc, "key1")), \
+         patch("onemancompany.core.project_archive.append_action"), \
+         patch("onemancompany.core.task_tree.get_tree", return_value=tree), \
+         patch("onemancompany.core.vessel._save_project_tree"), \
+         patch("onemancompany.core.agent_loop.get_agent_loop", return_value=mock_agent_loop), \
+         patch("onemancompany.core.agent_loop.employee_manager", mock_em), \
+         patch("onemancompany.core.project_archive._save_resolved"), \
+         patch("onemancompany.api.routes.event_bus", AsyncMock()):
+
+        result = await task_followup(PROJECT_ID, {"instructions": "Check status"})
+
+    assert result["status"] == "ok"
+
+    # Should route to EA when no product
+    scheduled_employee_id = mock_em.schedule_node.call_args[0][0]
+    assert scheduled_employee_id == EA_ID, (
+        f"Expected followup to be routed to EA {EA_ID}, "
+        f"but was routed to {scheduled_employee_id}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_task_followup_falls_back_to_ea_when_product_has_no_owner(tmp_path):
+    """When project has product_id but product has no owner_id, fallback to EA."""
+    from onemancompany.api.routes import task_followup
+
+    pdir = tmp_path / PROJECT_ID
+    pdir.mkdir()
+    tree = _make_tree_with_root()
+    (pdir / TASK_TREE_FILENAME).write_text("{}")
+
+    no_owner_product = _mock_product()
+    no_owner_product["owner_id"] = ""
+
+    project_doc = _make_project_doc(product_id=PRODUCT_ID)
+
+    mock_em = MagicMock()
+    mock_em.schedule_node = MagicMock()
+    mock_em._schedule_next = MagicMock()
+
+    with patch("onemancompany.core.project_archive.get_project_dir", return_value=str(pdir)), \
+         patch("onemancompany.core.project_archive._resolve_and_load", return_value=("v1", project_doc, "key1")), \
+         patch("onemancompany.core.project_archive.append_action"), \
+         patch("onemancompany.core.task_tree.get_tree", return_value=tree), \
+         patch("onemancompany.core.vessel._save_project_tree"), \
+         patch("onemancompany.core.agent_loop.get_agent_loop", return_value=MagicMock()), \
+         patch("onemancompany.core.agent_loop.employee_manager", mock_em), \
+         patch("onemancompany.core.project_archive._save_resolved"), \
+         patch("onemancompany.api.routes.event_bus", AsyncMock()), \
+         patch("onemancompany.core.product.find_slug_by_product_id", return_value=PRODUCT_SLUG), \
+         patch("onemancompany.core.product.load_product", return_value=no_owner_product):
+
+        result = await task_followup(PROJECT_ID, {"instructions": "Review progress"})
+
+    assert result["status"] == "ok"
+    assert mock_em.schedule_node.call_args[0][0] == EA_ID
+
+
+@pytest.mark.asyncio
+async def test_task_followup_falls_back_to_ea_when_product_slug_not_found(tmp_path):
+    """When project has product_id but slug lookup returns None (deleted product), fallback to EA."""
+    from onemancompany.api.routes import task_followup
+
+    pdir = tmp_path / PROJECT_ID
+    pdir.mkdir()
+    tree = _make_tree_with_root()
+    (pdir / TASK_TREE_FILENAME).write_text("{}")
+
+    project_doc = _make_project_doc(product_id=PRODUCT_ID)
+
+    mock_em = MagicMock()
+    mock_em.schedule_node = MagicMock()
+    mock_em._schedule_next = MagicMock()
+
+    with patch("onemancompany.core.project_archive.get_project_dir", return_value=str(pdir)), \
+         patch("onemancompany.core.project_archive._resolve_and_load", return_value=("v1", project_doc, "key1")), \
+         patch("onemancompany.core.project_archive.append_action"), \
+         patch("onemancompany.core.task_tree.get_tree", return_value=tree), \
+         patch("onemancompany.core.vessel._save_project_tree"), \
+         patch("onemancompany.core.agent_loop.get_agent_loop", return_value=MagicMock()), \
+         patch("onemancompany.core.agent_loop.employee_manager", mock_em), \
+         patch("onemancompany.core.project_archive._save_resolved"), \
+         patch("onemancompany.api.routes.event_bus", AsyncMock()), \
+         patch("onemancompany.core.product.find_slug_by_product_id", return_value=None):
+
+        result = await task_followup(PROJECT_ID, {"instructions": "Check KRs"})
+
+    assert result["status"] == "ok"
+    assert mock_em.schedule_node.call_args[0][0] == EA_ID


### PR DESCRIPTION
## Summary
- **Bug 1:** `task_followup()` always routed CEO chat messages to EA, even for product-linked projects. Product owners never got notified to update KR/issue progress. Now detects `product_id` in project doc, looks up product owner, and routes followup to them.
- **Bug 2:** CEO console product selector had no change event handler — selecting a product gave zero visual feedback. Added `_initProductSelector()` with border highlight on selection.

## Changes
- `src/onemancompany/api/routes.py` — product owner lookup + routing in `task_followup()`
- `frontend/app.js` — `_initProductSelector()` change event listener
- `tests/unit/api/test_product_followup.py` — 4 tests: owner routing, EA fallback, no-owner fallback, deleted-product fallback

## Test plan
- [x] 4 new regression tests covering all routing paths
- [x] Full test suite: 3944 passed, 0 failures
- [ ] Manual: send CEO followup on a product-linked project, verify owner gets the task
- [ ] Manual: select product in CEO console, verify border highlights cyan

🤖 Generated with [Claude Code](https://claude.com/claude-code)