### PR TITLE
fix: critical validation for product issue system

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.27",
+  "version": "0.7.29",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.29",
+  "version": "0.7.30",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.29"
+version = "0.7.30"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.27"
+version = "0.7.29"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -7197,8 +7197,11 @@ async def api_list_issues(slug: str, status: str = "", priority: str = "") -> li
     from onemancompany.core import product as prod
     from onemancompany.core.models import IssuePriority, IssueStatus
 
-    status_filter = IssueStatus(status) if status else None
-    priority_filter = IssuePriority(priority) if priority else None
+    try:
+        status_filter = IssueStatus(status) if status else None
+        priority_filter = IssuePriority(priority) if priority else None
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
     return prod.list_issues(slug, status=status_filter, priority=priority_filter)
 
 
@@ -7223,13 +7226,17 @@ async def api_update_issue(slug: str, issue_id: str, request: Request) -> dict:
     ISSUE_MUTABLE_FIELDS = {"title", "status", "priority", "assignee_id", "labels", "milestone_version", "description", "story_points", "sprint"}
     body = await request.json()
     filtered = {k: v for k, v in body.items() if k in ISSUE_MUTABLE_FIELDS}
-    if "status" in filtered:
-        filtered["status"] = _IS(filtered["status"]).value
-    if "priority" in filtered:
-        filtered["priority"] = _IP2(filtered["priority"]).value
-    result = prod.update_issue(slug, issue_id, **filtered)
-    if not result:
-        raise HTTPException(status_code=404, detail=f"Issue '{issue_id}' not found")
+    try:
+        if "status" in filtered:
+            filtered["status"] = _IS(filtered["status"]).value
+        if "priority" in filtered:
+            filtered["priority"] = _IP2(filtered["priority"]).value
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    try:
+        result = prod.update_issue(slug, issue_id, **filtered)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
 
     # Publish ISSUE_ASSIGNED event when assignee changes
     if "assignee_id" in filtered and filtered["assignee_id"]:
@@ -7257,9 +7264,14 @@ async def api_close_issue(slug: str, issue_id: str, request: Request) -> dict:
 
     body = await request.json() if request.headers.get("content-length", "0") != "0" else {}
     resolution_str = body.get("resolution", "fixed")
-    result = prod.close_issue(slug, issue_id, resolution=IssueResolution(resolution_str))
-    if not result:
-        raise HTTPException(status_code=404, detail=f"Issue '{issue_id}' not found")
+    try:
+        resolution = IssueResolution(resolution_str)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    try:
+        result = prod.close_issue(slug, issue_id, resolution=resolution)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     await event_bus.publish(
         CompanyEvent(
             type=EventType.ISSUE_CLOSED,
@@ -7275,9 +7287,10 @@ async def api_reopen_issue(slug: str, issue_id: str) -> dict:
     """Reopen a closed issue."""
     from onemancompany.core import product as prod
 
-    result = prod.reopen_issue(slug, issue_id)
-    if not result:
-        raise HTTPException(status_code=404, detail=f"Issue '{issue_id}' not found")
+    try:
+        result = prod.reopen_issue(slug, issue_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
     return result
 
 

--- a/src/onemancompany/core/product.py
+++ b/src/onemancompany/core/product.py
@@ -287,9 +287,11 @@ def create_issue(
     sprint: str | None = None,
 ) -> dict:
     """Create an issue for a product. Returns the issue dict."""
-    issue_id = _gen_id("issue_")
     product = load_product(slug)
-    product_id = product["id"] if product else ""
+    if not product:
+        raise ValueError(f"Product '{slug}' not found")
+    issue_id = _gen_id("issue_")
+    product_id = product["id"]
     now = datetime.now().isoformat()
 
     data = {
@@ -380,14 +382,13 @@ def list_issues(
     return results
 
 
-def update_issue(slug: str, issue_id: str, **fields) -> dict | None:
-    """Update issue fields. Returns updated dict or None if not found."""
+def update_issue(slug: str, issue_id: str, **fields) -> dict:
+    """Update issue fields. Returns updated dict. Raises ValueError if not found."""
     with _get_slug_lock(slug):
         path = _issues_dir(slug) / f"{issue_id}.yaml"
         data = _read_yaml(path)
         if not data:
-            logger.warning("update_issue: issue {} not found in {}", issue_id, slug)
-            return None
+            raise ValueError(f"Issue '{issue_id}' not found in product '{slug}'")
         for key, value in fields.items():
             if value is not None:
                 old_value = data.get(key)
@@ -404,14 +405,13 @@ def close_issue(
     issue_id: str,
     *,
     resolution: IssueResolution = IssueResolution.FIXED,
-) -> dict | None:
-    """Close an issue with a resolution. Returns updated dict or None."""
+) -> dict:
+    """Close an issue with a resolution. Returns updated dict. Raises ValueError if not found."""
     with _get_slug_lock(slug):
         path = _issues_dir(slug) / f"{issue_id}.yaml"
         data = _read_yaml(path)
         if not data:
-            logger.warning("close_issue: issue {} not found in {}", issue_id, slug)
-            return None
+            raise ValueError(f"Issue '{issue_id}' not found in product '{slug}'")
         old_status = data.get("status")
         _append_history(data, "status", old_status, IssueStatus.DONE.value, changed_by="system")
         data["status"] = IssueStatus.DONE.value
@@ -423,14 +423,13 @@ def close_issue(
     return data
 
 
-def reopen_issue(slug: str, issue_id: str) -> dict | None:
-    """Reopen a closed issue. Increments reopened_count. Returns updated dict or None."""
+def reopen_issue(slug: str, issue_id: str) -> dict:
+    """Reopen a closed issue. Increments reopened_count. Returns updated dict. Raises ValueError if not found."""
     with _get_slug_lock(slug):
         path = _issues_dir(slug) / f"{issue_id}.yaml"
         data = _read_yaml(path)
         if not data:
-            logger.warning("reopen_issue: issue {} not found in {}", issue_id, slug)
-            return None
+            raise ValueError(f"Issue '{issue_id}' not found in product '{slug}'")
         old_status = data.get("status")
         _append_history(data, "status", old_status, IssueStatus.BACKLOG.value, changed_by="system")
         data["status"] = IssueStatus.BACKLOG.value
@@ -478,6 +477,13 @@ def add_issue_link(
     rel_value = relation.value if hasattr(relation, "value") else relation
     reverse_rel = _REVERSE_RELATION[rel_value]
 
+    # Circular dependency check for blocking relations
+    if rel_value == IssueRelation.BLOCKS.value:
+        _check_block_cycle(slug, issue_id, target_id)
+    elif rel_value == IssueRelation.BLOCKED_BY.value:
+        # blocked_by is the reverse: target blocks issue
+        _check_block_cycle(slug, target_id, issue_id)
+
     # Add forward link (idempotent)
     _add_link_entry(slug, issue_id, target_id, rel_value)
     # Add reverse link
@@ -485,6 +491,34 @@ def add_issue_link(
 
     mark_dirty(DirtyCategory.PRODUCTS)
     logger.debug("Linked {} —{}→ {}", issue_id, rel_value, target_id)
+
+
+def _check_block_cycle(slug: str, blocker_id: str, blocked_id: str) -> None:
+    """Raise ValueError if adding 'blocker_id blocks blocked_id' would create a cycle.
+
+    Walks the existing 'blocks' graph starting from blocked_id to see if
+    blocker_id is reachable (meaning blocked_id already transitively blocks blocker_id).
+    """
+    visited: set[str] = set()
+    queue = [blocked_id]
+    while queue:
+        current = queue.pop()
+        if current in visited:
+            continue
+        visited.add(current)
+        issue = load_issue(slug, current)
+        if not issue:
+            continue
+        for link in issue.get("issue_links", []):
+            if link["relation"] != IssueRelation.BLOCKS.value:
+                continue
+            downstream = link["issue_id"]
+            if downstream == blocker_id:
+                raise ValueError(
+                    f"Circular dependency: {blocked_id} already transitively "
+                    f"blocks {blocker_id}"
+                )
+            queue.append(downstream)
 
 
 def _add_link_entry(slug: str, issue_id: str, target_id: str, relation: str) -> None:

--- a/tests/unit/agents/test_common_tools.py
+++ b/tests/unit/agents/test_common_tools.py
@@ -2193,3 +2193,23 @@ class TestRunDiscussionRound:
         # round 2 no willing + no CEO → break
         assert rounds == 2
         assert entries == []
+
+
+class TestLimitResult:
+    """Cover _limit_result branches (lines 68, 74)."""
+
+    def test_str_result_passes_through(self):
+        from onemancompany.agents.common_tools import _limit_result
+        assert _limit_result("hello", "test") == "hello"
+
+    def test_non_str_non_dict_returns_unchanged(self):
+        from onemancompany.agents.common_tools import _limit_result
+        assert _limit_result(42, "test") == 42
+        assert _limit_result(["a", "b"], "test") == ["a", "b"]
+
+    def test_dict_result_limits_content_key(self):
+        from onemancompany.agents.common_tools import _limit_result
+        d = {"content": "short text", "other": 123}
+        result = _limit_result(d, "test")
+        assert result["content"] == "short text"
+        assert result["other"] == 123

--- a/tests/unit/agents/test_ea_agent.py
+++ b/tests/unit/agents/test_ea_agent.py
@@ -156,6 +156,30 @@ class TestEARoleIdentity:
         assert result == ""
 
 
+    def test_get_role_identity_section_with_guide(self, tmp_path, monkeypatch):
+        """Line 36: returns guide content when role_guide.md exists."""
+        from onemancompany.agents import ea_agent as ea_mod
+        from onemancompany.agents import base as base_mod
+        from onemancompany.core import config as config_mod
+
+        monkeypatch.setattr(base_mod, "make_llm", lambda eid: MagicMock())
+        monkeypatch.setattr(ea_mod, "create_react_agent", lambda model, tools: MagicMock())
+
+        # First create the agent with a nonexistent dir (same as no_guide test)
+        monkeypatch.setattr(config_mod, "EMPLOYEES_DIR", Path("/nonexistent"))
+        from onemancompany.agents.ea_agent import EAAgent
+        agent = EAAgent()
+
+        # Now switch EMPLOYEES_DIR to tmp_path with the guide file present
+        monkeypatch.setattr(config_mod, "EMPLOYEES_DIR", tmp_path)
+        ea_dir = tmp_path / agent.employee_id
+        ea_dir.mkdir(parents=True)
+        (ea_dir / "role_guide.md").write_text("# EA Guide\nBe helpful.")
+
+        result = agent._get_role_identity_section()
+        assert "EA Guide" in result
+
+
 class TestEAPromptContents:
     def test_ea_role_guide_references_sop(self):
         """EA role_guide.md references SOP for progressive disclosure."""

--- a/tests/unit/core/test_task_persistence.py
+++ b/tests/unit/core/test_task_persistence.py
@@ -245,3 +245,19 @@ class TestRecoverScheduleFromTrees:
 
         loaded = SystemTaskTree.load(sys_path, "emp1")
         assert len(loaded.get_all_nodes()) == 1, "Finished nodes must be preserved on save"
+
+
+class TestRecoverCorruptSystemTree:
+    """Cover exception branch when system_tasks.yaml is corrupt (lines 140-142)."""
+
+    def test_corrupt_system_tasks_skipped(self, tmp_path):
+        from unittest.mock import MagicMock
+        from onemancompany.core.task_persistence import recover_schedule_from_trees
+
+        emp_dir = tmp_path / "employees" / "00099"
+        emp_dir.mkdir(parents=True)
+        (emp_dir / "system_tasks.yaml").write_text("{{{{not: valid: yaml: [}")
+
+        mock_em = MagicMock()
+        # projects_dir empty, employees_dir has corrupt file
+        recover_schedule_from_trees(mock_em, tmp_path / "projects", tmp_path / "employees")

--- a/tests/unit/test_product.py
+++ b/tests/unit/test_product.py
@@ -1184,9 +1184,18 @@ class TestAddIssueLink:
         with pytest.raises(ValueError, match="self"):
             prod.add_issue_link(slug, i1["id"], i1["id"], IssueRelation.BLOCKS)
 
-    def test_add_link_issue_not_found(self):
-        """Linking to a nonexistent issue raises."""
+    def test_add_link_source_not_found(self):
+        """Linking from a nonexistent source issue raises."""
         p = prod.create_product(name="MissLink", owner_id="00010")
+        slug = p["slug"]
+        i1 = prod.create_issue(slug=slug, title="A", created_by="ceo")
+
+        with pytest.raises(ValueError, match="not found"):
+            prod.add_issue_link(slug, "issue_nonexist", i1["id"], IssueRelation.BLOCKS)
+
+    def test_add_link_target_not_found(self):
+        """Linking to a nonexistent target issue raises."""
+        p = prod.create_product(name="MissLink2", owner_id="00010")
         slug = p["slug"]
         i1 = prod.create_issue(slug=slug, title="A", created_by="ceo")
 
@@ -1218,6 +1227,25 @@ class TestRemoveIssueLink:
         # Should not raise
         prod.remove_issue_link(slug, i1["id"], i2["id"])
         assert prod.get_issue_links(slug, i1["id"]) == []
+
+    def test_remove_link_missing_issue_file(self):
+        """Removing a link when issue file is missing doesn't crash."""
+        p = prod.create_product(name="RmMiss", owner_id="00010")
+        slug = p["slug"]
+        # Remove link on nonexistent issue IDs — should silently skip
+        prod.remove_issue_link(slug, "issue_ghost1", "issue_ghost2")
+
+    def test_get_issue_links_missing_issue(self):
+        """get_issue_links returns [] for nonexistent issue."""
+        p = prod.create_product(name="LinkMiss", owner_id="00010")
+        assert prod.get_issue_links(p["slug"], "issue_nope") == []
+
+    def test_add_link_entry_missing_issue_file(self):
+        """_add_link_entry silently skips when issue yaml doesn't exist."""
+        p = prod.create_product(name="AddMiss", owner_id="00010")
+        slug = p["slug"]
+        # Calling internal _add_link_entry on nonexistent issue — should not crash
+        prod._add_link_entry(slug, "issue_ghost", "issue_target", IssueRelation.BLOCKS.value)
 
 
 class TestIsBlocked:
@@ -1636,6 +1664,46 @@ class TestCircularDependencyDetection:
         # A blocked_by B → target(B) blocks issue(A) → B blocks A → circular with existing A blocks B
         with pytest.raises(ValueError, match="[Cc]ircular"):
             prod.add_issue_link(slug, a_id, b_id, IssueRelation.BLOCKED_BY)
+
+    def test_cycle_check_skips_missing_issues(self):
+        """Cycle check handles links pointing to deleted/missing issues gracefully."""
+        slug, issues = self._make_issues("cycle", 4)
+        a, b, c, d = [i["id"] for i in issues]
+        # A blocks B, B blocks C, C blocks D
+        prod.add_issue_link(slug, a, b, IssueRelation.BLOCKS)
+        prod.add_issue_link(slug, b, c, IssueRelation.BLOCKS)
+        prod.add_issue_link(slug, c, d, IssueRelation.BLOCKS)
+        # Delete C's yaml so the cycle checker encounters a missing issue mid-walk
+        import os
+        c_path = prod._issues_dir(slug) / f"{c}.yaml"
+        os.remove(c_path)
+        # D blocks A would be circular IF C existed. But C is gone, so walk stops.
+        # Still, add_issue_link validates both issues exist, so call _check_block_cycle directly.
+        prod._check_block_cycle(slug, a, b)  # walks B→C(missing)→stops, no cycle found
+
+    def test_cycle_check_handles_diamond_graph(self):
+        """Diamond: A→B, A→C, B→D, C→D. Adding D→A is circular."""
+        slug, issues = self._make_issues("cycle", 4)
+        a, b, c, d = [i["id"] for i in issues]
+        prod.add_issue_link(slug, a, b, IssueRelation.BLOCKS)
+        prod.add_issue_link(slug, a, c, IssueRelation.BLOCKS)
+        prod.add_issue_link(slug, b, d, IssueRelation.BLOCKS)
+        prod.add_issue_link(slug, c, d, IssueRelation.BLOCKS)
+        with pytest.raises(ValueError, match="[Cc]ircular"):
+            prod.add_issue_link(slug, d, a, IssueRelation.BLOCKS)
+
+    def test_cycle_check_visited_dedup(self):
+        """Diamond graph without cycle — BFS deduplicates via visited set."""
+        slug, issues = self._make_issues("cycle", 5)
+        a, b, c, d, e = [i["id"] for i in issues]
+        # A→C, A→D, C→E, D→E (diamond converging on E)
+        prod.add_issue_link(slug, a, c, IssueRelation.BLOCKS)
+        prod.add_issue_link(slug, a, d, IssueRelation.BLOCKS)
+        prod.add_issue_link(slug, c, e, IssueRelation.BLOCKS)
+        prod.add_issue_link(slug, d, e, IssueRelation.BLOCKS)
+        # B blocks A — not circular, but BFS from A will visit E twice (via C and D)
+        # The second visit hits the 'visited' skip (line 507)
+        prod.add_issue_link(slug, b, a, IssueRelation.BLOCKS)  # should NOT raise
 
 
 class TestEnumValidationInRoutes:

--- a/tests/unit/test_product.py
+++ b/tests/unit/test_product.py
@@ -697,9 +697,9 @@ class TestKeyResultEdgeCases:
 
 class TestIssueEdgeCases:
     def test_create_issue_no_product(self):
-        """Line 266 (implicit): create_issue with missing product still works (empty product_id)."""
-        issue = prod.create_issue(slug="ghost", title="Orphan", created_by="ceo")
-        assert issue["product_id"] == ""
+        """create_issue with missing product raises ValueError."""
+        with pytest.raises(ValueError, match="not found"):
+            prod.create_issue(slug="ghost", title="Orphan", created_by="ceo")
 
     def test_list_issues_skips_non_yaml(self, tmp_path):
         """Line 340: non-yaml files in issues dir are skipped."""
@@ -730,22 +730,22 @@ class TestIssueEdgeCases:
         assert backlog[0]["title"] == "Open"
 
     def test_update_issue_not_found(self):
-        """Lines 363-364: updating missing issue returns None."""
+        """updating missing issue raises ValueError."""
         p = prod.create_product(name="UpdateMiss", owner_id="00004")
-        result = prod.update_issue(p["slug"], "issue_nope", title="x")
-        assert result is None
+        with pytest.raises(ValueError, match="not found"):
+            prod.update_issue(p["slug"], "issue_nope", title="x")
 
     def test_close_issue_not_found(self):
-        """Lines 387-388: closing missing issue returns None."""
+        """closing missing issue raises ValueError."""
         p = prod.create_product(name="CloseMiss", owner_id="00004")
-        result = prod.close_issue(p["slug"], "issue_gone")
-        assert result is None
+        with pytest.raises(ValueError, match="not found"):
+            prod.close_issue(p["slug"], "issue_gone")
 
     def test_reopen_issue_not_found(self):
-        """Lines 406-407: reopening missing issue returns None."""
+        """reopening missing issue raises ValueError."""
         p = prod.create_product(name="ReopenMiss", owner_id="00004")
-        result = prod.reopen_issue(p["slug"], "issue_vanish")
-        assert result is None
+        with pytest.raises(ValueError, match="not found"):
+            prod.reopen_issue(p["slug"], "issue_vanish")
 
 
 class TestAppendHistory:
@@ -1567,3 +1567,107 @@ class TestProductActivity:
         log = prod.list_product_activity(slug, limit=1000)
         assert len(log) <= 500
         assert log[0]["event_type"] == "overflow"  # newest first
+
+
+# ---------------------------------------------------------------------------
+# Batch 1 Critical Fixes — Audit Findings
+# ---------------------------------------------------------------------------
+
+
+class TestCreateIssueValidatesProduct:
+    """Fix #1: create_issue() must raise ValueError when product doesn't exist."""
+
+    def test_create_issue_nonexistent_product_raises(self):
+        with pytest.raises(ValueError, match="not found"):
+            prod.create_issue(
+                slug="no-such-product",
+                title="Ghost issue",
+                created_by="ceo",
+            )
+
+    def test_create_issue_existing_product_works(self):
+        p = prod.create_product(name="Valid Prod", owner_id="00010")
+        issue = prod.create_issue(slug=p["slug"], title="Real issue", created_by="ceo")
+        assert issue["product_id"] == p["id"]
+
+
+class TestCircularDependencyDetection:
+    """Fix #2: add_issue_link() must detect circular block dependencies."""
+
+    def _make_issues(self, slug, count=3):
+        p = prod.create_product(name="CycleProd", owner_id="00010")
+        issues = []
+        for i in range(count):
+            issues.append(
+                prod.create_issue(slug=p["slug"], title=f"Issue {i}", created_by="ceo")
+            )
+        return p["slug"], issues
+
+    def test_direct_circular_blocks_raises(self):
+        """A blocks B, then B blocks A → circular dependency error."""
+        slug, issues = self._make_issues("cycle", 2)
+        a_id, b_id = issues[0]["id"], issues[1]["id"]
+        prod.add_issue_link(slug, a_id, b_id, IssueRelation.BLOCKS)
+        with pytest.raises(ValueError, match="[Cc]ircular"):
+            prod.add_issue_link(slug, b_id, a_id, IssueRelation.BLOCKS)
+
+    def test_transitive_circular_blocks_raises(self):
+        """A blocks B, B blocks C, C blocks A → circular dependency error."""
+        slug, issues = self._make_issues("cycle", 3)
+        a, b, c = issues[0]["id"], issues[1]["id"], issues[2]["id"]
+        prod.add_issue_link(slug, a, b, IssueRelation.BLOCKS)
+        prod.add_issue_link(slug, b, c, IssueRelation.BLOCKS)
+        with pytest.raises(ValueError, match="[Cc]ircular"):
+            prod.add_issue_link(slug, c, a, IssueRelation.BLOCKS)
+
+    def test_relates_to_allows_cycles(self):
+        """relates_to links don't have directionality — cycles are fine."""
+        slug, issues = self._make_issues("cycle", 2)
+        a_id, b_id = issues[0]["id"], issues[1]["id"]
+        prod.add_issue_link(slug, a_id, b_id, IssueRelation.RELATES_TO)
+        # Should NOT raise
+        prod.add_issue_link(slug, b_id, a_id, IssueRelation.RELATES_TO)
+
+    def test_blocked_by_circular_raises(self):
+        """A blocks B exists. Then A blocked_by B means B blocks A → circular."""
+        slug, issues = self._make_issues("cycle", 2)
+        a_id, b_id = issues[0]["id"], issues[1]["id"]
+        prod.add_issue_link(slug, a_id, b_id, IssueRelation.BLOCKS)
+        # A blocked_by B → target(B) blocks issue(A) → B blocks A → circular with existing A blocks B
+        with pytest.raises(ValueError, match="[Cc]ircular"):
+            prod.add_issue_link(slug, a_id, b_id, IssueRelation.BLOCKED_BY)
+
+
+class TestEnumValidationInRoutes:
+    """Fix #3: Invalid enum values should raise ValueError (routes wrap in 400)."""
+
+    def test_invalid_issue_status_raises(self):
+        with pytest.raises(ValueError):
+            IssueStatus("not_a_real_status")
+
+    def test_invalid_issue_resolution_raises(self):
+        with pytest.raises(ValueError):
+            IssueResolution("not_a_real_resolution")
+
+    def test_invalid_issue_priority_raises(self):
+        with pytest.raises(ValueError):
+            IssuePriority("not_a_real_priority")
+
+
+class TestMissingIssueRaisesValueError:
+    """Fix #4: update_issue, close_issue, reopen_issue should raise ValueError on missing."""
+
+    def test_update_issue_missing_raises(self):
+        prod.create_product(name="ErrProd", owner_id="00010")
+        with pytest.raises(ValueError, match="not found"):
+            prod.update_issue("err-prod", "nonexistent_id", title="Nope")
+
+    def test_close_issue_missing_raises(self):
+        prod.create_product(name="ErrProd2", owner_id="00010")
+        with pytest.raises(ValueError, match="not found"):
+            prod.close_issue("err-prod2", "nonexistent_id")
+
+    def test_reopen_issue_missing_raises(self):
+        prod.create_product(name="ErrProd3", owner_id="00010")
+        with pytest.raises(ValueError, match="not found"):
+            prod.reopen_issue("err-prod3", "nonexistent_id")

--- a/tests/unit/test_product_triggers.py
+++ b/tests/unit/test_product_triggers.py
@@ -1162,3 +1162,293 @@ class TestActivityAutoLogging:
         log = prod.list_product_activity(slug)
         assert len(log) == 1
         assert "sprint_123" in log[0]["detail"]
+
+
+class TestStaleReviewBadDate:
+    """Cover exception branch when review has invalid created_at."""
+
+    @pytest.mark.asyncio
+    async def test_review_with_bad_created_at_skips_gracefully(self):
+        from onemancompany.core.product_triggers import run_product_check
+        from onemancompany.core.store import _read_yaml, _write_yaml
+
+        p = _make_product(name="BadDateRev")
+        slug = p["slug"]
+        review = prod.create_review(slug=slug, trigger="test", owner="00010")
+        # Corrupt created_at
+        rpath = prod._reviews_dir(slug) / f"{review['id']}.yaml"
+        rdata = _read_yaml(rpath)
+        rdata["created_at"] = "not-a-date"
+        _write_yaml(rpath, rdata)
+
+        with patch("onemancompany.core.project_archive.list_projects", return_value=[]), \
+             patch("onemancompany.core.product_triggers.notify_owner", new_callable=AsyncMock, return_value=False):
+            result = await run_product_check(slug)
+        # Should not crash, just skip that review
+        assert result is not None
+
+
+class TestBlockedLinkBadDate:
+    """Cover exception branch when link has invalid created_at."""
+
+    @pytest.mark.asyncio
+    async def test_blocked_link_bad_created_at_skips(self):
+        from onemancompany.core.product_triggers import run_product_check
+        from onemancompany.core.store import _read_yaml, _write_yaml
+
+        p = _make_product(name="BadLinkDate")
+        slug = p["slug"]
+        i1 = _make_issue(slug, title="Blocker")
+        i2 = _make_issue(slug, title="Blocked")
+        prod.add_issue_link(slug, i1["id"], i2["id"], IssueRelation.BLOCKS)
+        # Corrupt the created_at on the blocked_by link
+        i2_path = prod._issues_dir(slug) / f"{i2['id']}.yaml"
+        i2_data = _read_yaml(i2_path)
+        for link in i2_data.get("issue_links", []):
+            if link["relation"] == IssueRelation.BLOCKED_BY.value:
+                link["created_at"] = "bad-date"
+        _write_yaml(i2_path, i2_data)
+
+        with patch("onemancompany.core.project_archive.list_projects", return_value=[]), \
+             patch("onemancompany.core.product_triggers.notify_owner", new_callable=AsyncMock, return_value=False):
+            result = await run_product_check(slug)
+        assert result is not None
+
+
+class TestStaleKRsWithCompletedProjects:
+    """Cover the stale KRs + completed projects branch (line 559-560)."""
+
+    @pytest.mark.asyncio
+    async def test_zero_progress_kr_with_completed_project(self):
+        from onemancompany.core.product_triggers import run_product_check
+
+        p = _make_product(name="StaleKR")
+        slug = p["slug"]
+        prod.add_key_result(slug, title="Ship v1", target=100)
+        # Don't update progress — stays at 0
+
+        fake_project = {"product_id": p["id"], "status": "archived"}
+        with patch("onemancompany.core.project_archive.list_projects", return_value=[fake_project]), \
+             patch("onemancompany.core.product_triggers.notify_owner", new_callable=AsyncMock, return_value=True):
+            result = await run_product_check(slug)
+        action_str = " ".join(result.get("actions", []))
+        assert "KR" in action_str or "review" in action_str.lower()
+
+
+class TestBlockerUnresolved:
+    """Cover _is_blocker_unresolved with missing blocker (line 676)."""
+
+    def test_missing_blocker_returns_false(self):
+        from onemancompany.core.product_triggers import _is_blocker_unresolved
+        p = _make_product(name="MissingBlocker")
+        assert _is_blocker_unresolved(p["slug"], "nonexistent_issue") is False
+
+
+class TestSprintClosedMissingProduct:
+    """Cover handle_sprint_closed with missing product (lines 691-692)."""
+
+    @pytest.mark.asyncio
+    async def test_sprint_closed_missing_product(self):
+        from onemancompany.core.product_triggers import handle_sprint_closed
+        event = CompanyEvent(
+            type=EventType.SPRINT_CLOSED,
+            payload={"product_slug": "no-such-product", "sprint_id": "sprint_1"},
+        )
+        # Should not crash
+        await handle_sprint_closed(event)
+
+
+class TestLogProductActivityBranches:
+    """Cover _log_product_activity detail generation branches."""
+
+    def test_detail_from_title(self):
+        from onemancompany.core.product_triggers import _log_product_activity
+        p = _make_product(name="LogTitle")
+        slug = p["slug"]
+        event = CompanyEvent(
+            type=EventType.ISSUE_CREATED,
+            payload={"product_slug": slug, "title": "My issue title"},
+        )
+        _log_product_activity(event)
+        log = prod.list_product_activity(slug)
+        assert len(log) == 1
+        assert "My issue title" in log[0]["detail"]
+
+    def test_detail_fallback_to_event_type(self):
+        from onemancompany.core.product_triggers import _log_product_activity
+        p = _make_product(name="LogFallback")
+        slug = p["slug"]
+        # No title, no issue_id, no sprint_id in payload
+        event = CompanyEvent(
+            type=EventType.ISSUE_CREATED,
+            payload={"product_slug": slug},
+        )
+        _log_product_activity(event)
+        log = prod.list_product_activity(slug)
+        assert len(log) == 1
+        assert log[0]["detail"] == EventType.ISSUE_CREATED.value
+
+    def test_log_exception_handled_gracefully(self):
+        from onemancompany.core.product_triggers import _log_product_activity
+        p = _make_product(name="LogErr")
+        slug = p["slug"]
+        event = CompanyEvent(
+            type=EventType.ISSUE_CREATED,
+            payload={"product_slug": slug, "title": "X"},
+        )
+        with patch.object(prod, "append_product_activity", side_effect=RuntimeError("disk full")):
+            # Should not raise
+            _log_product_activity(event)
+
+
+class TestDispatchLoopSprintClosed:
+    """Cover SPRINT_CLOSED branch in _dispatch_loop (line 782)."""
+
+    @pytest.mark.asyncio
+    async def test_dispatch_sprint_closed_event(self):
+        from onemancompany.core.product_triggers import handle_sprint_closed
+        p = _make_product(name="DispatchSprint")
+        slug = p["slug"]
+        event = CompanyEvent(
+            type=EventType.SPRINT_CLOSED,
+            payload={"product_slug": slug, "sprint_id": "sprint_abc"},
+        )
+        # handle_sprint_closed will create a review checklist
+        await handle_sprint_closed(event)
+        reviews = prod.list_reviews(slug)
+        assert len(reviews) == 1
+        assert reviews[0]["trigger_ref"] == "sprint_abc"
+
+
+class TestNotifyOwner:
+    """Tests for notify_owner (push review task to product owner)."""
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_product_returns_false(self):
+        from onemancompany.core.product_triggers import notify_owner
+        assert await notify_owner("no-such-product", reason="test") is False
+
+    @pytest.mark.asyncio
+    async def test_inactive_product_returns_false(self):
+        from onemancompany.core.product_triggers import notify_owner
+        p = prod.create_product(name="InactiveProd", owner_id="00010",
+                                status=prod.ProductStatus.PLANNING)
+        assert await notify_owner(p["slug"], reason="test") is False
+
+    @pytest.mark.asyncio
+    async def test_no_owner_returns_false(self):
+        from onemancompany.core.product_triggers import notify_owner
+        p = prod.create_product(name="NoOwner", owner_id="00010",
+                                status=prod.ProductStatus.ACTIVE)
+        prod.update_product(p["slug"], owner_id="")
+        assert await notify_owner(p["slug"], reason="test") is False
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_false(self):
+        from onemancompany.core.product_triggers import notify_owner
+        p = prod.create_product(name="ErrProd", owner_id="00010",
+                                status=prod.ProductStatus.ACTIVE)
+        prod.create_issue(slug=p["slug"], title="An issue", created_by="ceo")
+        with patch("onemancompany.core.project_archive.list_projects", side_effect=RuntimeError("boom")):
+            assert await notify_owner(p["slug"], reason="test") is False
+
+    @pytest.mark.asyncio
+    async def test_active_product_no_projects_creates_one(self):
+        from onemancompany.core.product_triggers import notify_owner
+        p = prod.create_product(name="ReviewProd", owner_id="00010",
+                                status=prod.ProductStatus.ACTIVE)
+        prod.create_issue(slug=p["slug"], title="Backlog issue", created_by="ceo")
+        with patch("onemancompany.core.project_archive.list_projects", return_value=[]), \
+             patch("onemancompany.core.product_triggers._create_project_for_issue", new_callable=AsyncMock, return_value=None):
+            assert await notify_owner(p["slug"], reason="quarterly review") is False
+
+    @pytest.mark.asyncio
+    async def test_active_product_creates_project_success(self):
+        from onemancompany.core.product_triggers import notify_owner
+        p = prod.create_product(name="ReviewProd2", owner_id="00010",
+                                status=prod.ProductStatus.ACTIVE)
+        prod.create_issue(slug=p["slug"], title="Issue", created_by="ceo")
+        with patch("onemancompany.core.project_archive.list_projects", return_value=[]), \
+             patch("onemancompany.core.product_triggers._create_project_for_issue", new_callable=AsyncMock, return_value="proj_123"):
+            assert await notify_owner(p["slug"], reason="test") is True
+
+    @pytest.mark.asyncio
+    async def test_existing_project_no_tree_file_returns_false(self):
+        from onemancompany.core.product_triggers import notify_owner
+        p = prod.create_product(name="NoTree", owner_id="00010",
+                                status=prod.ProductStatus.ACTIVE)
+        prod.create_issue(slug=p["slug"], title="Issue", created_by="ceo")
+
+        mock_proj = {"project_id": "proj_1", "product_id": p["id"], "status": "active"}
+
+        with patch("onemancompany.core.project_archive.list_projects", return_value=[mock_proj]), \
+             patch("onemancompany.core.project_archive.get_project_dir", return_value="/tmp/fake_nonexistent"):
+            assert await notify_owner(p["slug"], reason="test") is False
+
+    @pytest.mark.asyncio
+    async def test_existing_project_adds_review_task(self):
+        from onemancompany.core.product_triggers import notify_owner
+        p = prod.create_product(name="AddTask", owner_id="00010",
+                                status=prod.ProductStatus.ACTIVE)
+        prod.create_issue(slug=p["slug"], title="Issue", created_by="ceo")
+
+        # Mock tree with no pending review nodes
+        mock_node = MagicMock()
+        mock_node.employee_id = "00010"
+        mock_node.status = "completed"
+        mock_node.title = "Previous task"
+        mock_node.description = ""
+        mock_node.id = "node_1"
+
+        mock_child = MagicMock()
+        mock_child.id = "node_2"
+
+        mock_tree = MagicMock()
+        mock_tree.all_nodes.return_value = [mock_node]
+        mock_tree.get_ea_node.return_value = None
+        mock_tree.root_id = "root"
+        mock_tree.add_child.return_value = mock_child
+
+        mock_proj = {"project_id": "proj_1", "product_id": p["id"], "status": "active"}
+
+        mock_em = MagicMock()
+
+        with patch("onemancompany.core.project_archive.list_projects", return_value=[mock_proj]), \
+             patch("onemancompany.core.project_archive.get_project_dir", return_value="/tmp/fake"), \
+             patch("pathlib.Path.exists", return_value=True), \
+             patch("onemancompany.core.task_tree.get_tree", return_value=mock_tree), \
+             patch("onemancompany.core.vessel._save_project_tree"), \
+             patch("onemancompany.core.product_triggers.employee_manager", mock_em, create=True):
+            # Need to also patch the lazy import inside the function
+            import onemancompany.core.product_triggers as pt
+            with patch.object(pt, "__builtins__", pt.__builtins__):
+                # Simpler: just patch at the agent_loop level
+                with patch("onemancompany.core.agent_loop.employee_manager", mock_em):
+                    result = await notify_owner(p["slug"], reason="test review")
+        assert result is True
+        mock_tree.add_child.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_existing_project_with_pending_review_skips(self):
+        from onemancompany.core.product_triggers import notify_owner
+        p = prod.create_product(name="SkipReview", owner_id="00010",
+                                status=prod.ProductStatus.ACTIVE)
+        prod.create_issue(slug=p["slug"], title="Issue", created_by="ceo")
+
+        mock_node = MagicMock()
+        mock_node.employee_id = "00010"
+        mock_node.status = "pending"
+        mock_node.title = "Product review: quarterly"
+        mock_node.description = ""
+        mock_node.id = "node_1"
+
+        mock_tree = MagicMock()
+        mock_tree.all_nodes.return_value = [mock_node]
+
+        mock_proj = {"project_id": "proj_1", "product_id": p["id"], "status": "active"}
+
+        with patch("onemancompany.core.project_archive.list_projects", return_value=[mock_proj]), \
+             patch("onemancompany.core.project_archive.get_project_dir", return_value="/tmp/fake"), \
+             patch("pathlib.Path.exists", return_value=True), \
+             patch("onemancompany.core.task_tree.get_tree", return_value=mock_tree):
+            assert await notify_owner(p["slug"], reason="test") is False

--- a/tests/unit/test_tool_limits.py
+++ b/tests/unit/test_tool_limits.py
@@ -54,3 +54,11 @@ class TestMaybePersistResult:
 
     def test_empty_string_unchanged(self):
         assert maybe_persist_result("", "test") == ""
+
+    def test_large_result_no_project_dir(self, tmp_path, monkeypatch):
+        """When project_dir is None, falls back to DATA_ROOT/tool_results."""
+        monkeypatch.setattr("onemancompany.core.config.DATA_ROOT", tmp_path)
+        large = "x" * (DEFAULT_MAX_RESULT_SIZE + 100)
+        result = maybe_persist_result(large, "test_tool")
+        assert "Output too large" in result
+        assert (tmp_path / "tool_results").exists()


### PR DESCRIPTION
## Summary
- `create_issue()` now raises `ValueError` when product doesn't exist (was silently creating issues with empty `product_id`)
- `add_issue_link()` detects circular block dependencies via BFS graph walk (A→B→C→A)
- Routes wrap `IssueStatus`/`IssueResolution`/`IssuePriority` enum construction in try-catch, returning 400 instead of 500
- `update_issue()`/`close_issue()`/`reopen_issue()` raise `ValueError` on missing issue (was returning `None`)

## Test plan
- [x] 12 new tests covering all 4 fixes (TDD — tests written first)
- [x] 4 existing tests updated to match new ValueError behavior
- [x] Full suite: 4070 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)