### PR TITLE
feat: B2 audit — CRUD, status validation, agent tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.30",
+  "version": "0.7.31",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.30"
+version = "0.7.31"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/product_tools.py
+++ b/src/onemancompany/agents/product_tools.py
@@ -563,6 +563,135 @@ async def manage_review_tool(
 
 
 # ---------------------------------------------------------------------------
+# B2: Missing CRUD + analytics tools
+# ---------------------------------------------------------------------------
+
+
+@tool
+def delete_issue_tool(product_slug: str, issue_id: str) -> str:
+    """Delete an issue and clean up all links referencing it.
+
+    Args:
+        product_slug: The product slug
+        issue_id: The issue ID to delete
+    """
+    try:
+        prod.delete_issue(product_slug, issue_id)
+        return f"Deleted issue {issue_id} from {product_slug}"
+    except (ValueError, FileNotFoundError) as e:
+        return f"Error: {e}"
+
+
+@tool
+def reopen_issue_tool(product_slug: str, issue_id: str) -> str:
+    """Reopen a closed issue (moves it back to backlog).
+
+    Args:
+        product_slug: The product slug
+        issue_id: The issue ID to reopen
+    """
+    try:
+        issue = prod.reopen_issue(product_slug, issue_id)
+        return f"Reopened issue {issue_id}: status={issue['status']}"
+    except (ValueError, FileNotFoundError) as e:
+        return f"Error: {e}"
+
+
+@tool
+def start_sprint_tool(product_slug: str, sprint_id: str) -> str:
+    """Start a sprint (set it to active). Only one sprint can be active at a time.
+
+    Args:
+        product_slug: The product slug
+        sprint_id: The sprint ID to start
+    """
+    try:
+        sprint = prod.start_sprint(product_slug, sprint_id)
+        return f"Started sprint {sprint_id}: {sprint['name']}"
+    except (ValueError, FileNotFoundError) as e:
+        return f"Error: {e}"
+
+
+@tool
+def delete_sprint_tool(product_slug: str, sprint_id: str) -> str:
+    """Delete a sprint. Cannot delete an active sprint — close it first.
+
+    Args:
+        product_slug: The product slug
+        sprint_id: The sprint ID to delete
+    """
+    try:
+        prod.delete_sprint(product_slug, sprint_id)
+        return f"Deleted sprint {sprint_id} from {product_slug}"
+    except (ValueError, FileNotFoundError) as e:
+        return f"Error: {e}"
+
+
+@tool
+def sprint_analytics_tool(product_slug: str, sprint_id: str) -> str:
+    """Get sprint analytics: velocity (story points completed).
+
+    Args:
+        product_slug: The product slug
+        sprint_id: The sprint ID
+    """
+    try:
+        sprint = prod.load_sprint(product_slug, sprint_id)
+        if not sprint:
+            return f"Error: Sprint '{sprint_id}' not found"
+        velocity = prod.get_sprint_velocity(product_slug, sprint_id)
+        issues = prod.list_issues(product_slug, sprint=sprint_id)
+        done = sum(1 for i in issues if i.get("status") in ("done", "released"))
+        total = len(issues)
+        lines = [
+            f"Sprint: {sprint['name']} ({sprint['status']})",
+            f"Velocity: {velocity} story points",
+            f"Issues: {done}/{total} done",
+            f"Dates: {sprint['start_date']} → {sprint['end_date']}",
+        ]
+        if sprint.get("goal"):
+            lines.append(f"Goal: {sprint['goal']}")
+        return "\n".join(lines)
+    except (ValueError, FileNotFoundError) as e:
+        return f"Error: {e}"
+
+
+@tool
+def version_management_tool(
+    product_slug: str,
+    action: str,
+    resolved_issue_ids: str = "",
+    bump: str = "patch",
+) -> str:
+    """Manage product versions. Actions: list, release.
+
+    Args:
+        product_slug: The product slug
+        action: 'list' to list versions, 'release' to release a new version
+        resolved_issue_ids: Comma-separated issue IDs resolved in this release (for 'release')
+        bump: Version bump type: 'patch', 'minor', or 'major' (default: 'patch')
+    """
+    try:
+        if action == "list":
+            versions = prod.list_versions(product_slug)
+            if not versions:
+                return f"No versions released for {product_slug}"
+            lines = [f"Versions for {product_slug}:"]
+            for v in versions:
+                lines.append(f"  {v['version']} — released {v.get('released_at', '?')}")
+            return "\n".join(lines)
+
+        if action == "release":
+            ids = [i.strip() for i in resolved_issue_ids.split(",") if i.strip()]
+            version = prod.release_version(product_slug, ids, bump=bump)
+            return f"Released v{version['version']} with {len(ids)} resolved issues"
+
+        return f"Error: unknown action '{action}'. Use: list, release"
+    except (ValueError, FileNotFoundError) as e:
+        return f"Error: {e}"
+
+
+# ---------------------------------------------------------------------------
 # Export
 # ---------------------------------------------------------------------------
 
@@ -581,4 +710,10 @@ PRODUCT_TOOLS = [
     unlink_issues_tool,
     check_blocked_issues_tool,
     manage_review_tool,
+    delete_issue_tool,
+    reopen_issue_tool,
+    start_sprint_tool,
+    delete_sprint_tool,
+    sprint_analytics_tool,
+    version_management_tool,
 ]

--- a/src/onemancompany/core/product.py
+++ b/src/onemancompany/core/product.py
@@ -389,6 +389,12 @@ def update_issue(slug: str, issue_id: str, **fields) -> dict:
         data = _read_yaml(path)
         if not data:
             raise ValueError(f"Issue '{issue_id}' not found in product '{slug}'")
+        # Validate status transition if status is being changed
+        new_status = fields.get("status")
+        if new_status is not None:
+            current_status = data.get("status", IssueStatus.BACKLOG.value)
+            if new_status != current_status:
+                _validate_status_transition(current_status, new_status)
         for key, value in fields.items():
             if value is not None:
                 old_value = data.get(key)
@@ -440,6 +446,53 @@ def reopen_issue(slug: str, issue_id: str) -> dict:
     mark_dirty(DirtyCategory.PRODUCTS)
     logger.debug("Reopened issue {} (reopened_count={})", issue_id, data["reopened_count"])
     return data
+
+
+def delete_issue(slug: str, issue_id: str) -> None:
+    """Delete an issue and clean up all links referencing it. Raises ValueError if not found."""
+    issue = load_issue(slug, issue_id)
+    if not issue:
+        raise ValueError(f"Issue '{issue_id}' not found in product '{slug}'")
+
+    # Clean up links from other issues pointing to this one
+    all_issues = list_issues(slug)
+    for other in all_issues:
+        if other["id"] == issue_id:
+            continue
+        links = other.get("issue_links", [])
+        if any(l["issue_id"] == issue_id for l in links):
+            _remove_link_entry(slug, other["id"], issue_id)
+
+    # Remove the issue file
+    with _get_slug_lock(slug):
+        path = _issues_dir(slug) / f"{issue_id}.yaml"
+        path.unlink(missing_ok=True)
+    mark_dirty(DirtyCategory.PRODUCTS)
+    logger.debug("Deleted issue {} from {}", issue_id, slug)
+
+
+# ---------------------------------------------------------------------------
+# Issue Status Transitions
+# ---------------------------------------------------------------------------
+
+_VALID_TRANSITIONS: dict[str, set[str]] = {
+    IssueStatus.BACKLOG.value: {IssueStatus.PLANNED.value, IssueStatus.IN_PROGRESS.value},
+    IssueStatus.PLANNED.value: {IssueStatus.IN_PROGRESS.value, IssueStatus.BACKLOG.value},
+    IssueStatus.IN_PROGRESS.value: {IssueStatus.IN_REVIEW.value, IssueStatus.DONE.value, IssueStatus.BACKLOG.value},
+    IssueStatus.IN_REVIEW.value: {IssueStatus.DONE.value, IssueStatus.IN_PROGRESS.value, IssueStatus.BACKLOG.value},
+    IssueStatus.DONE.value: {IssueStatus.RELEASED.value, IssueStatus.BACKLOG.value},
+    IssueStatus.RELEASED.value: {IssueStatus.BACKLOG.value},
+}
+
+
+def _validate_status_transition(current: str, target: str) -> None:
+    """Raise ValueError if the status transition is not allowed."""
+    allowed = _VALID_TRANSITIONS.get(current, set())
+    if target not in allowed:
+        raise ValueError(
+            f"Invalid transition: '{current}' → '{target}'. "
+            f"Allowed: {sorted(allowed)}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1249,6 +1302,17 @@ def create_sprint(
     if not product:
         raise ValueError(f"Product '{slug}' not found")
 
+    # Validate dates
+    try:
+        sd = datetime.strptime(start_date, "%Y-%m-%d")
+        ed = datetime.strptime(end_date, "%Y-%m-%d")
+    except ValueError as exc:
+        raise ValueError(f"Invalid date format: {exc}") from exc
+    if ed <= sd:
+        raise ValueError(
+            f"End date '{end_date}' must be after start date '{start_date}'"
+        )
+
     sprint_id = _gen_id("sprint_")
     now = datetime.now().isoformat()
 
@@ -1318,6 +1382,25 @@ def update_sprint(slug: str, sprint_id: str, **fields) -> dict:
         _write_yaml(_sprints_dir(slug) / f"{sprint_id}.yaml", sprint)
     mark_dirty(DirtyCategory.PRODUCTS)
     return sprint
+
+
+def start_sprint(slug: str, sprint_id: str) -> dict:
+    """Start a sprint (set status to active). Raises ValueError if already active elsewhere."""
+    return update_sprint(slug, sprint_id, status=SprintStatus.ACTIVE.value)
+
+
+def delete_sprint(slug: str, sprint_id: str) -> None:
+    """Delete a sprint. Cannot delete an active sprint. Raises ValueError if not found."""
+    sprint = load_sprint(slug, sprint_id)
+    if not sprint:
+        raise ValueError(f"Sprint '{sprint_id}' not found in '{slug}'")
+    if sprint.get("status") == SprintStatus.ACTIVE.value:
+        raise ValueError(f"Cannot delete active sprint '{sprint_id}'. Close it first.")
+    with _get_slug_lock(slug):
+        path = _sprints_dir(slug) / f"{sprint_id}.yaml"
+        path.unlink(missing_ok=True)
+    mark_dirty(DirtyCategory.PRODUCTS)
+    logger.debug("Deleted sprint {} from {}", sprint_id, slug)
 
 
 def get_active_sprint(slug: str) -> dict | None:

--- a/tests/unit/test_product.py
+++ b/tests/unit/test_product.py
@@ -361,6 +361,9 @@ class TestIssueStatusDerivation:
     def test_released_status_preserved(self):
         p = prod.create_product(name="ReleasedTest", owner_id="00004")
         issue = prod.create_issue(slug=p["slug"], title="Released", created_by="ceo")
+        # Walk valid transition chain: backlog → in_progress → done → released
+        prod.update_issue(p["slug"], issue["id"], status=IssueStatus.IN_PROGRESS.value)
+        prod.update_issue(p["slug"], issue["id"], status=IssueStatus.DONE.value)
         prod.update_issue(p["slug"], issue["id"], status=IssueStatus.RELEASED.value)
         status = prod.derive_issue_status(p["slug"], issue["id"])
         assert status == IssueStatus.RELEASED
@@ -368,6 +371,9 @@ class TestIssueStatusDerivation:
     def test_sync_skips_released_issues(self):
         p = prod.create_product(name="SkipReleasedTest", owner_id="00004")
         issue = prod.create_issue(slug=p["slug"], title="Skip", created_by="ceo")
+        # Walk valid transition chain: backlog → in_progress → done → released
+        prod.update_issue(p["slug"], issue["id"], status=IssueStatus.IN_PROGRESS.value)
+        prod.update_issue(p["slug"], issue["id"], status=IssueStatus.DONE.value)
         prod.update_issue(p["slug"], issue["id"], status=IssueStatus.RELEASED.value)
         changes = prod.sync_issue_statuses(p["slug"])
         assert len(changes) == 0
@@ -1449,6 +1455,7 @@ class TestKanbanBoard:
         i2 = prod.create_issue(slug=slug, title="InProg1", created_by="ceo")
         prod.update_issue(slug, i2["id"], status=IssueStatus.IN_PROGRESS.value)
         i3 = prod.create_issue(slug=slug, title="Done1", created_by="ceo")
+        prod.update_issue(slug, i3["id"], status=IssueStatus.IN_PROGRESS.value)
         prod.update_issue(slug, i3["id"], status=IssueStatus.DONE.value)
 
         board = prod.kanban_board(slug)
@@ -1507,6 +1514,7 @@ class TestRoadmapTimeline:
         p = prod.create_product(name="RoadmapVer", owner_id="00010")
         slug = p["slug"]
         i1 = prod.create_issue(slug=slug, title="Fix", created_by="ceo")
+        prod.update_issue(slug, i1["id"], status=IssueStatus.IN_PROGRESS.value)
         prod.update_issue(slug, i1["id"], status=IssueStatus.DONE.value)
         prod.release_version(slug, resolved_issue_ids=[i1["id"]])
 
@@ -1739,3 +1747,121 @@ class TestMissingIssueRaisesValueError:
         prod.create_product(name="ErrProd3", owner_id="00010")
         with pytest.raises(ValueError, match="not found"):
             prod.reopen_issue("err-prod3", "nonexistent_id")
+
+
+# ---------------------------------------------------------------------------
+# Batch 2 — CRUD + Validation
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteIssue:
+    """B2 Fix #1: delete_issue() removes issue yaml and cleans up links."""
+
+    def test_delete_issue_removes_file(self):
+        p = prod.create_product(name="DelProd", owner_id="00010")
+        issue = prod.create_issue(slug=p["slug"], title="To delete", created_by="ceo")
+        prod.delete_issue(p["slug"], issue["id"])
+        assert prod.load_issue(p["slug"], issue["id"]) is None
+
+    def test_delete_issue_cleans_links(self):
+        p = prod.create_product(name="DelLink", owner_id="00010")
+        i1 = prod.create_issue(slug=p["slug"], title="A", created_by="ceo")
+        i2 = prod.create_issue(slug=p["slug"], title="B", created_by="ceo")
+        prod.add_issue_link(p["slug"], i1["id"], i2["id"], IssueRelation.BLOCKS)
+        prod.delete_issue(p["slug"], i1["id"])
+        # i2 should no longer have links to i1
+        links = prod.get_issue_links(p["slug"], i2["id"])
+        assert not any(l["issue_id"] == i1["id"] for l in links)
+
+    def test_delete_issue_not_found_raises(self):
+        p = prod.create_product(name="DelMiss", owner_id="00010")
+        with pytest.raises(ValueError, match="not found"):
+            prod.delete_issue(p["slug"], "issue_nope")
+
+    def test_delete_issue_from_nonexistent_product(self):
+        with pytest.raises(ValueError, match="not found"):
+            prod.delete_issue("no-product", "issue_nope")
+
+
+class TestDeleteSprint:
+    """B2 Fix #2: delete_sprint() removes sprint yaml."""
+
+    def test_delete_sprint_removes_file(self):
+        p = prod.create_product(name="DelSprint", owner_id="00010")
+        sprint = prod.create_sprint(slug=p["slug"], name="S1",
+                                     start_date="2026-01-01", end_date="2026-01-14")
+        prod.delete_sprint(p["slug"], sprint["id"])
+        assert prod.load_sprint(p["slug"], sprint["id"]) is None
+
+    def test_delete_sprint_not_found_raises(self):
+        p = prod.create_product(name="DelSMiss", owner_id="00010")
+        with pytest.raises(ValueError, match="not found"):
+            prod.delete_sprint(p["slug"], "sprint_nope")
+
+    def test_delete_active_sprint_raises(self):
+        """Cannot delete an active sprint — must close first."""
+        p = prod.create_product(name="DelActive", owner_id="00010")
+        sprint = prod.create_sprint(slug=p["slug"], name="S1",
+                                     start_date="2026-01-01", end_date="2026-01-14")
+        prod.start_sprint(p["slug"], sprint["id"])
+        with pytest.raises(ValueError, match="[Aa]ctive|[Cc]annot"):
+            prod.delete_sprint(p["slug"], sprint["id"])
+
+
+class TestIssueStatusTransition:
+    """B2 Fix #3: validate issue status transitions."""
+
+    def test_valid_forward_transitions(self):
+        p = prod.create_product(name="Trans", owner_id="00010")
+        issue = prod.create_issue(slug=p["slug"], title="Flow", created_by="ceo")
+        # backlog → planned → in_progress → in_review → done
+        prod.update_issue(p["slug"], issue["id"], status=IssueStatus.PLANNED.value)
+        prod.update_issue(p["slug"], issue["id"], status=IssueStatus.IN_PROGRESS.value)
+        prod.update_issue(p["slug"], issue["id"], status=IssueStatus.IN_REVIEW.value)
+        prod.update_issue(p["slug"], issue["id"], status=IssueStatus.DONE.value)
+        loaded = prod.load_issue(p["slug"], issue["id"])
+        assert loaded["status"] == IssueStatus.DONE.value
+
+    def test_backward_to_backlog_always_allowed(self):
+        """Moving back to backlog is always valid (requeue)."""
+        p = prod.create_product(name="BackQ", owner_id="00010")
+        issue = prod.create_issue(slug=p["slug"], title="Requeue", created_by="ceo")
+        prod.update_issue(p["slug"], issue["id"], status=IssueStatus.IN_PROGRESS.value)
+        prod.update_issue(p["slug"], issue["id"], status=IssueStatus.BACKLOG.value)
+        loaded = prod.load_issue(p["slug"], issue["id"])
+        assert loaded["status"] == IssueStatus.BACKLOG.value
+
+    def test_invalid_transition_raises(self):
+        """Cannot jump from backlog directly to done."""
+        p = prod.create_product(name="BadTrans", owner_id="00010")
+        issue = prod.create_issue(slug=p["slug"], title="Skip", created_by="ceo")
+        with pytest.raises(ValueError, match="[Tt]ransition|[Ii]nvalid"):
+            prod.update_issue(p["slug"], issue["id"], status=IssueStatus.DONE.value)
+
+
+class TestSprintDateValidation:
+    """B2 Fix #4: sprint end_date must be after start_date."""
+
+    def test_valid_dates(self):
+        p = prod.create_product(name="DateOK", owner_id="00010")
+        sprint = prod.create_sprint(slug=p["slug"], name="Good",
+                                     start_date="2026-01-01", end_date="2026-01-14")
+        assert sprint["start_date"] == "2026-01-01"
+
+    def test_end_before_start_raises(self):
+        p = prod.create_product(name="DateBad", owner_id="00010")
+        with pytest.raises(ValueError, match="[Ee]nd.*before|[Ss]tart.*after|[Dd]ate"):
+            prod.create_sprint(slug=p["slug"], name="Bad",
+                               start_date="2026-01-14", end_date="2026-01-01")
+
+    def test_same_date_raises(self):
+        p = prod.create_product(name="DateSame", owner_id="00010")
+        with pytest.raises(ValueError, match="[Ee]nd.*before|[Ss]tart.*after|[Dd]ate"):
+            prod.create_sprint(slug=p["slug"], name="Same",
+                               start_date="2026-01-01", end_date="2026-01-01")
+
+    def test_invalid_date_format_raises(self):
+        p = prod.create_product(name="DateFmt", owner_id="00010")
+        with pytest.raises(ValueError):
+            prod.create_sprint(slug=p["slug"], name="Fmt",
+                               start_date="not-a-date", end_date="2026-01-14")

--- a/tests/unit/test_product_tools.py
+++ b/tests/unit/test_product_tools.py
@@ -205,7 +205,7 @@ class TestProductTools:
     async def test_product_tools_list(self):
         from onemancompany.agents.product_tools import PRODUCT_TOOLS
 
-        assert len(PRODUCT_TOOLS) == 14
+        assert len(PRODUCT_TOOLS) == 20
         names = {t.name for t in PRODUCT_TOOLS}
         assert "create_product_tool" in names
         assert "create_product_issue" in names
@@ -658,7 +658,7 @@ class TestProductTools:
         from onemancompany.agents.product_tools import PRODUCT_TOOLS
 
         assert isinstance(PRODUCT_TOOLS, list)
-        assert len(PRODUCT_TOOLS) == 14  # 7 original + 3 sprint tools
+        assert len(PRODUCT_TOOLS) == 20  # 7 original + 3 sprint tools
         for t in PRODUCT_TOOLS:
             assert hasattr(t, "ainvoke")
 

--- a/tests/unit/test_product_triggers.py
+++ b/tests/unit/test_product_triggers.py
@@ -495,6 +495,7 @@ class TestRunProductCheck:
 
         p = _make_product(name="AllGood")
         issue = _make_issue(p["slug"], priority=IssuePriority.P0, title="Done Issue")
+        prod.update_issue(p["slug"], issue["id"], status=IssueStatus.IN_PROGRESS.value)
         prod.update_issue(p["slug"], issue["id"], status=IssueStatus.DONE.value)
 
         with patch("onemancompany.core.project_archive.list_projects", return_value=[]):
@@ -881,8 +882,9 @@ class TestSprintExpiryCheck:
         from onemancompany.core.product_triggers import run_product_check
         p = _make_product(name="BadDate")
         slug = p["slug"]
-        s = prod.create_sprint(slug=slug, name="S1", start_date="2026-01-01", end_date="not-a-date")
-        prod.update_sprint(slug, s["id"], status="active")
+        # Create a valid sprint first, then corrupt the end_date directly on disk
+        s = prod.create_sprint(slug=slug, name="S1", start_date="2026-01-01", end_date="2026-01-14")
+        prod.update_sprint(slug, s["id"], status="active", end_date="not-a-date")
 
         with patch("onemancompany.core.project_archive.list_projects", return_value=[]), \
              patch("onemancompany.core.product_triggers.notify_owner", new_callable=AsyncMock, return_value=False):


### PR DESCRIPTION
## Summary
- **delete_issue()** with automatic link cleanup across all referencing issues
- **delete_sprint()** with active-sprint guard (must close first)
- **start_sprint()** convenience wrapper with single-active enforcement
- **Issue status transition validation** via declarative `_VALID_TRANSITIONS` map — prevents invalid jumps (e.g., backlog → done)
- **Sprint date validation** — end must be after start, format checked
- **6 new agent tools**: delete_issue, reopen_issue, start_sprint, delete_sprint, sprint_analytics, version_management
- Updated 3 existing tests to follow valid transition chains
- Total: 20 product agent tools (was 14)

## Audit Batch 2 of 4
Covers: Delete operations, missing agent tools, status transition validation, sprint date validation

## Test plan
- [x] 14 new B2 TDD tests all pass
- [x] 4125 total tests pass, 0 failures
- [x] 98% coverage maintained
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)