### PR TITLE
fix: product owner chain audit — validation, release safety, triggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.46",
+  "version": "0.7.47",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.44",
+  "version": "0.7.46",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.44"
+version = "0.7.46"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.46"
+version = "0.7.47"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/product_tools.py
+++ b/src/onemancompany/agents/product_tools.py
@@ -743,6 +743,46 @@ async def delete_product_tool(product_slug: str) -> str:
         return f"Error: {e}"
 
 
+@tool
+async def assign_issue_tool(
+    product_slug: str,
+    issue_id: str,
+    assignee_id: str,
+) -> str:
+    """Assign (or reassign) an issue to an employee.
+
+    Args:
+        product_slug: The product slug
+        issue_id: The issue ID
+        assignee_id: Employee ID to assign
+    """
+    try:
+        issue = prod.update_issue(product_slug, issue_id, assignee_id=assignee_id)
+        return f"Issue {issue_id} assigned to {assignee_id}"
+    except (ValueError, FileNotFoundError) as e:
+        return f"Error: {e}"
+
+
+@tool
+async def transfer_product_ownership_tool(
+    product_slug: str,
+    new_owner_id: str,
+) -> str:
+    """Transfer product ownership to a different employee.
+
+    Args:
+        product_slug: The product slug
+        new_owner_id: Employee ID of the new owner
+    """
+    try:
+        result = prod.update_product(product_slug, owner_id=new_owner_id)
+        if result is None:
+            return f"Error: product '{product_slug}' not found"
+        return f"Product '{product_slug}' ownership transferred to {new_owner_id}"
+    except (ValueError, FileNotFoundError) as e:
+        return f"Error: {e}"
+
+
 # ---------------------------------------------------------------------------
 # Export
 # ---------------------------------------------------------------------------
@@ -770,4 +810,6 @@ PRODUCT_TOOLS = [
     version_management_tool,
     update_product_tool,
     delete_product_tool,
+    assign_issue_tool,
+    transfer_product_ownership_tool,
 ]

--- a/src/onemancompany/core/product.py
+++ b/src/onemancompany/core/product.py
@@ -19,6 +19,7 @@ from loguru import logger
 
 from onemancompany.core.config import (
     ACTIVITY_LOG_DIR_NAME,
+    EMPLOYEES_DIR,
     ISSUES_DIR_NAME,
     PRODUCT_YAML_FILENAME,
     PRODUCTS_DIR,
@@ -99,6 +100,17 @@ def _gen_id(prefix: str) -> str:
     return f"{prefix}{uuid.uuid4().hex[:8]}"
 
 
+def _validate_employee_id(emp_id: str, label: str = "Employee") -> None:
+    """Raise ValueError if emp_id does not correspond to a valid employee directory.
+
+    Empty string is allowed (means "no owner/assignee assigned").
+    """
+    if not emp_id:
+        return  # empty = unassigned, valid
+    if not (EMPLOYEES_DIR / emp_id).is_dir():
+        raise ValueError(f"{label} '{emp_id}' not found in employee registry")
+
+
 # ---------------------------------------------------------------------------
 # Product CRUD
 # ---------------------------------------------------------------------------
@@ -112,6 +124,7 @@ def create_product(
     current_version: str = "0.1.0",
 ) -> dict:
     """Create a new product. Returns the product dict."""
+    _validate_employee_id(owner_id, label="Owner")
     slug = _dedup_slug(_slugify(name))
     product_id = _gen_id("prod_")
     now = datetime.now().isoformat()
@@ -165,6 +178,8 @@ def list_products() -> list[dict]:
 
 def update_product(slug: str, **fields) -> dict | None:
     """Update product fields. Returns updated dict or None if not found."""
+    if "owner_id" in fields and fields["owner_id"] is not None:
+        _validate_employee_id(fields["owner_id"], label="Owner")
     with _get_slug_lock(slug):
         path = _product_yaml_path(slug)
         data = _read_yaml(path)
@@ -314,6 +329,8 @@ def create_issue(
     product = load_product(slug)
     if not product:
         raise ValueError(f"Product '{slug}' not found")
+    if assignee_id:
+        _validate_employee_id(assignee_id, label="Assignee")
     issue_id = _gen_id("issue_")
     product_id = product["id"]
     now = datetime.now().isoformat()
@@ -424,6 +441,9 @@ def update_issue(slug: str, issue_id: str, *, _skip_transition_check: bool = Fal
     _skip_transition_check: internal flag for system-derived status updates
     that may jump non-adjacent states (e.g. sync_issue_statuses).
     """
+    new_assignee = fields.get("assignee_id")
+    if new_assignee is not None and new_assignee != "":
+        _validate_employee_id(new_assignee, label="Assignee")
     with _get_slug_lock(slug):
         path = _issues_dir(slug) / f"{issue_id}.yaml"
         data = _read_yaml(path)
@@ -441,6 +461,11 @@ def update_issue(slug: str, issue_id: str, *, _skip_transition_check: bool = Fal
                 if old_value != value:
                     _append_history(data, key, old_value, value, changed_by="system")
                 data[key] = value
+        # Auto-set closed_at and resolution when status transitions to DONE
+        if new_status == IssueStatus.DONE.value and not data.get("closed_at"):
+            data["closed_at"] = datetime.now().isoformat()
+            if not data.get("resolution"):
+                data["resolution"] = IssueResolution.FIXED.value
         _write_yaml(path, data)
     mark_dirty(DirtyCategory.PRODUCTS)
     return data
@@ -999,12 +1024,25 @@ def release_version(
         product["current_version"] = new_version
         _write_yaml(_product_yaml_path(product_slug), product)
 
-    # Mark resolved issues as released (bypass validation — release is a system operation)
+    # Mark resolved issues as released — only DONE issues are eligible
+    skipped_issues: list[str] = []
     for issue_id in resolved_issue_ids:
         issue = load_issue(product_slug, issue_id)
-        if issue and issue.get("status") != IssueStatus.RELEASED.value:
-            update_issue(product_slug, issue_id, _skip_transition_check=True, status=IssueStatus.RELEASED.value)
+        if not issue:
+            skipped_issues.append(issue_id)
+            continue
+        if issue.get("status") == IssueStatus.RELEASED.value:
+            continue  # already released
+        if issue.get("status") != IssueStatus.DONE.value:
+            skipped_issues.append(issue_id)
+            logger.warning(
+                "[VERSION] Skipping issue {} — status '{}' is not DONE",
+                issue_id, issue.get("status"),
+            )
+            continue
+        update_issue(product_slug, issue_id, _skip_transition_check=True, status=IssueStatus.RELEASED.value)
 
+    version_record["skipped_issues"] = skipped_issues
     mark_dirty(DirtyCategory.PRODUCTS)
     logger.info("[VERSION] Released {} for product '{}'", new_version, product_slug)
     return version_record
@@ -1355,6 +1393,24 @@ def create_sprint(
             f"End date '{end_date}' must be after start date '{start_date}'"
         )
 
+    # Check for date overlap with non-closed sprints
+    existing_sprints = list_sprints(slug)
+    for existing in existing_sprints:
+        if existing.get("status") == SprintStatus.CLOSED.value:
+            continue
+        try:
+            ex_sd = datetime.strptime(existing["start_date"], "%Y-%m-%d")
+            ex_ed = datetime.strptime(existing["end_date"], "%Y-%m-%d")
+        except (ValueError, KeyError):
+            logger.debug("Skipping overlap check for sprint with invalid dates: {}", existing.get("id"))
+            continue
+        # Overlap: ranges overlap if start < other_end AND other_start < end
+        if sd < ex_ed and ex_sd < ed:
+            raise ValueError(
+                f"Sprint dates {start_date}..{end_date} overlap with "
+                f"'{existing['name']}' ({existing['start_date']}..{existing['end_date']})"
+            )
+
     sprint_id = _gen_id("sprint_")
     now = datetime.now().isoformat()
 
@@ -1478,8 +1534,9 @@ def close_sprint(slug: str, sprint_id: str) -> dict:
     total_count = len(all_issues)
     unfinished = [i for i in all_issues if i.get("status") not in _DONE_STATUSES]
 
-    # 3. Carry-over: find next planning sprint
+    # 3. Carry-over: find next planning sprint (sorted by start_date, earliest first)
     planning_sprints = list_sprints(slug, status=SprintStatus.PLANNING.value)
+    planning_sprints.sort(key=lambda s: s.get("start_date", ""))
     next_sprint = planning_sprints[0] if planning_sprints else None
 
     for issue in unfinished:

--- a/src/onemancompany/core/product_triggers.py
+++ b/src/onemancompany/core/product_triggers.py
@@ -34,6 +34,12 @@ STALE_REVIEW_HOURS: int = 24            # Hours before an open review is conside
 BLOCKED_DAYS_THRESHOLD: int = 7         # Days before a blocked issue is flagged
 UNHANDLED_BACKLOG_THRESHOLD: int = 2    # Unhandled backlog issues before alert
 
+def _get_threshold(product: dict, key: str, default: int) -> int:
+    """Read per-product config threshold, falling back to module-level default."""
+    config = product.get("config") or {}
+    return config.get(key, default)
+
+
 # ---------------------------------------------------------------------------
 # Trigger handlers
 # ---------------------------------------------------------------------------
@@ -148,6 +154,76 @@ async def _create_project_for_issue(slug: str, issue: dict) -> str:
         return ""
 
 
+async def _create_review_project(product_slug: str, reason: str) -> str:
+    """Create a standalone review project for the product owner.
+
+    Unlike _create_project_for_issue, this doesn't take an issue dict —
+    it constructs a proper review-scoped project.
+    Returns project_id or empty string.
+    """
+    from pathlib import Path
+    from onemancompany.core.config import CEO_ID, EA_ID, TASK_TREE_FILENAME
+    from onemancompany.core.project_archive import async_create_project_from_task, get_project_dir
+    from onemancompany.core.task_lifecycle import NodeType, TaskPhase
+
+    product = prod.load_product(product_slug)
+    if not product:
+        return ""
+    product_id = product["id"]
+    owner_id = product.get("owner_id", "")
+    task_description = f"Product review for '{product['name']}': {reason}"
+
+    try:
+        project_id, iter_id = await async_create_project_from_task(
+            task_description,
+            product_id=product_id,
+        )
+        pdir = get_project_dir(project_id)
+        ctx_id = f"{project_id}/{iter_id}" if iter_id else project_id
+
+        product_ctx = prod.build_product_context(product_slug)
+        review_task = (
+            f"Product review needed: {reason}\n\n"
+            f"{product_ctx}\n\n"
+            f"[Project ID: {ctx_id}] [Project workspace: {pdir}]"
+        )
+
+        from onemancompany.core.task_tree import TaskTree
+        from onemancompany.core.vessel import _save_project_tree
+
+        tree = TaskTree(project_id=ctx_id, mode="standard")
+        ceo_root = tree.create_root(employee_id=CEO_ID, description=task_description)
+        ceo_root.node_type = NodeType.CEO_PROMPT.value
+        ceo_root.set_status(TaskPhase.PROCESSING)
+
+        owner_node = tree.add_child(
+            parent_id=ceo_root.id,
+            employee_id=owner_id or EA_ID,
+            description=review_task,
+            acceptance_criteria=[],
+            title=f"Product review: {reason[:50]}",
+        )
+        _save_project_tree(pdir, tree)
+
+        from onemancompany.core.agent_loop import employee_manager
+        target_id = owner_id or EA_ID
+        tree_path = str(Path(pdir) / TASK_TREE_FILENAME)
+        employee_manager.schedule_node(target_id, owner_node.id, tree_path)
+        employee_manager._schedule_next(target_id)
+
+        logger.info(
+            "[PRODUCT_TRIGGER] Created review project {} for product '{}' (reason: {})",
+            project_id, product_slug, reason,
+        )
+        return project_id
+    except Exception:
+        logger.exception(
+            "[PRODUCT_TRIGGER] Failed to create review project for '{}'",
+            product_slug,
+        )
+        return ""
+
+
 async def handle_project_complete(event: CompanyEvent) -> None:
     """When a project with product context completes, close issues + release version."""
     slug = event.payload.get("product_slug", "")
@@ -236,78 +312,69 @@ async def notify_owner(product_slug: str, reason: str = "") -> bool:
         f"[skill: product-review]"
     )
 
-    try:
-        from pathlib import Path
-        from onemancompany.core.config import CEO_ID, TASK_TREE_FILENAME
-        from onemancompany.core.project_archive import list_projects, get_project_dir
-        from onemancompany.core.task_tree import get_tree
-        from onemancompany.core.vessel import _save_project_tree
+    from pathlib import Path
+    from onemancompany.core.config import CEO_ID, TASK_TREE_FILENAME
+    from onemancompany.core.project_archive import list_projects, get_project_dir
+    from onemancompany.core.task_tree import get_tree
+    from onemancompany.core.vessel import _save_project_tree
 
-        # Find existing active project for this product
-        all_projects = list_projects()
-        active_product_projects = [
-            p for p in all_projects
-            if p.get("product_id") == product["id"] and p.get("status") == "active"
-        ]
+    # Find existing active project for this product
+    all_projects = list_projects()
+    active_product_projects = [
+        p for p in all_projects
+        if p.get("product_id") == product["id"] and p.get("status") == "active"
+    ]
 
-        if active_product_projects:
-            # Add task to existing project's tree
-            proj = active_product_projects[0]
-            pdir = get_project_dir(proj["project_id"])
-            tree_path = Path(pdir) / TASK_TREE_FILENAME
-            if not tree_path.exists():
-                logger.debug("[PRODUCT_TRIGGER] Tree not found for project {}", proj["project_id"])
+    if active_product_projects:
+        # Add task to existing project's tree
+        proj = active_product_projects[0]
+        pdir = get_project_dir(proj["project_id"])
+        tree_path = Path(pdir) / TASK_TREE_FILENAME
+        if not tree_path.exists():
+            logger.debug("[PRODUCT_TRIGGER] Tree not found for project {}", proj["project_id"])
+            return False
+
+        tree = get_tree(str(tree_path))
+
+        # Check if owner already has a pending/processing review task — skip if so
+        from onemancompany.core.task_lifecycle import TaskPhase
+        for node in tree.all_nodes():
+            if (node.employee_id == owner_id
+                    and node.status in (TaskPhase.PENDING.value, TaskPhase.PROCESSING.value)
+                    and "review" in (node.title or node.description or "").lower()):
+                logger.debug("[PRODUCT_TRIGGER] Owner {} already has pending review task {}, skip",
+                             owner_id, node.id)
                 return False
 
-            tree = get_tree(str(tree_path))
+        # Find a suitable parent (EA node or root)
+        ea_node = tree.get_ea_node()
+        parent_id = ea_node.id if ea_node else tree.root_id
 
-            # Check if owner already has a pending/processing review task — skip if so
-            from onemancompany.core.task_lifecycle import TaskPhase
-            for node in tree.all_nodes():
-                if (node.employee_id == owner_id
-                        and node.status in (TaskPhase.PENDING.value, TaskPhase.PROCESSING.value)
-                        and "review" in (node.title or node.description or "").lower()):
-                    logger.debug("[PRODUCT_TRIGGER] Owner {} already has pending review task {}, skip",
-                                 owner_id, node.id)
-                    return False
+        child = tree.add_child(
+            parent_id=parent_id,
+            employee_id=owner_id,
+            description=task_desc,
+            acceptance_criteria=[],
+            title=f"Product review: {reason[:50]}",
+        )
+        _save_project_tree(pdir, tree)
 
-            # Find a suitable parent (EA node or root)
-            ea_node = tree.get_ea_node()
-            parent_id = ea_node.id if ea_node else tree.root_id
+        # Schedule owner to execute
+        from onemancompany.core.agent_loop import employee_manager
+        employee_manager.schedule_node(owner_id, child.id, str(tree_path))
+        employee_manager._schedule_next(owner_id)
 
-            child = tree.add_child(
-                parent_id=parent_id,
-                employee_id=owner_id,
-                description=task_desc,
-                acceptance_criteria=[],
-                title=f"Product review: {reason[:50]}",
-            )
-            _save_project_tree(pdir, tree)
+        logger.info("[PRODUCT_TRIGGER] Pushed review task to owner {} on project {} (reason: {})",
+                    owner_id, proj["project_id"], reason)
+    else:
+        # No active project — create a dedicated review project
+        project_id = await _create_review_project(product_slug, reason)
+        if not project_id:
+            return False
+        logger.info("[PRODUCT_TRIGGER] Created review project {} for owner {} (reason: {})",
+                    project_id, owner_id, reason)
 
-            # Schedule owner to execute
-            from onemancompany.core.agent_loop import employee_manager
-            employee_manager.schedule_node(owner_id, child.id, str(tree_path))
-            employee_manager._schedule_next(owner_id)
-
-            logger.info("[PRODUCT_TRIGGER] Pushed review task to owner {} on project {} (reason: {})",
-                        owner_id, proj["project_id"], reason)
-        else:
-            # No active project — create one
-            project_id = await _create_project_for_issue(product_slug, {
-                "id": f"review_{product_slug}",
-                "title": f"Product review: {product['name']}",
-                "description": task_desc,
-                "priority": IssuePriority.P2.value,
-            })
-            if not project_id:
-                return False
-            logger.info("[PRODUCT_TRIGGER] Created review project {} for owner {} (reason: {})",
-                        project_id, owner_id, reason)
-
-        return True
-    except Exception:
-        logger.exception("[PRODUCT_TRIGGER] Failed to push review task for '{}'", product_slug)
-        return False
+    return True
 
 
 def sync_issue_statuses(product_slug: str) -> list[dict]:
@@ -398,6 +465,8 @@ async def run_product_check(product_slug: str) -> dict:
     if not owner_id:
         return {"skipped": True, "reason": "no owner"}
 
+    max_active = _get_threshold(product, "max_active_projects", MAX_ACTIVE_PROJECTS)
+
     from onemancompany.core.project_archive import list_projects
     all_projects = list_projects()
     active_for_product = [
@@ -425,7 +494,7 @@ async def run_product_check(product_slug: str) -> dict:
 
         # High priority + no active project → create project
         if priority in _AUTO_PROJECT_PRIORITIES and not linked:
-            if len(active_for_product) >= MAX_ACTIVE_PROJECTS:
+            if len(active_for_product) >= max_active:
                 logger.debug("[PRODUCT_CHECK] Skipping project for issue {} — 3+ active projects", issue["id"])
                 continue
             project_id = await _create_project_for_issue(product_slug, issue)
@@ -440,7 +509,7 @@ async def run_product_check(product_slug: str) -> dict:
 
         # Has assignee but no project → create project
         elif issue.get("assignee_id") and not linked:
-            if len(active_for_product) >= MAX_ACTIVE_PROJECTS:
+            if len(active_for_product) >= max_active:
                 continue
             project_id = await _create_project_for_issue(product_slug, issue)
             if project_id:
@@ -460,10 +529,12 @@ async def run_product_check(product_slug: str) -> dict:
         if target <= 0 or current >= target:
             continue  # met or invalid
 
+        kr_id = kr.get("id", "")
         kr_title = kr.get("title", "")
-        # Check if any open issue is related to this KR (by title match)
+        kr_label = f"kr:{kr_id}"
+        # Check if any open issue is already tracking this KR (by kr_id label)
         has_issue = any(
-            kr_title in i.get("title", "") or kr.get("id", "") in i.get("title", "")
+            kr_label in i.get("labels", [])
             for i in all_issues
             if i.get("status") not in (IssueStatus.DONE.value, IssueStatus.RELEASED.value)
         )
@@ -475,7 +546,7 @@ async def run_product_check(product_slug: str) -> dict:
                 description=f"Key result '{kr_title}' is at {current}/{target}. Create and execute work to advance this metric.",
                 priority=IssuePriority.P2,
                 created_by="system",
-                labels=["kr-tracking", "auto-created"],
+                labels=["kr-tracking", "auto-created", kr_label],
             )
             actions_taken.append(f"Created issue for KR: {kr_title}")
             all_issues.append(issue)  # prevent duplicate creation in same cycle
@@ -663,6 +734,12 @@ async def handle_issue_assigned(event: CompanyEvent) -> None:
     linked = issue.get("linked_task_ids", [])
     if linked:
         logger.debug("[PRODUCT_TRIGGER] Issue {} already has linked tasks {}, skip", issue_id, linked)
+        return
+
+    # Re-read to guard against race with handle_issue_created
+    fresh_issue = prod.load_issue(slug, issue_id)
+    if fresh_issue and fresh_issue.get("linked_task_ids"):
+        logger.debug("[PRODUCT_TRIGGER] Race guard: issue {} got linked_task_ids before project creation", issue_id)
         return
 
     logger.info("[PRODUCT_TRIGGER] Issue {} assigned to {} — creating project", issue_id, assignee_id)

--- a/tests/unit/test_product.py
+++ b/tests/unit/test_product.py
@@ -20,8 +20,14 @@ from onemancompany.core.task_lifecycle import TaskPhase
 
 @pytest.fixture(autouse=True)
 def _redirect_products_dir(tmp_path, monkeypatch):
-    """Point PRODUCTS_DIR to a temp directory for every test."""
+    """Point PRODUCTS_DIR and EMPLOYEES_DIR to temp directories for every test."""
     monkeypatch.setattr(prod, "PRODUCTS_DIR", tmp_path)
+    emp_dir = tmp_path / "employees"
+    emp_dir.mkdir()
+    monkeypatch.setattr(prod, "EMPLOYEES_DIR", emp_dir)
+    # Create standard test employee directories used across tests
+    for eid in ("00010", "00011", "00012", "00004", "00005", "00020", "emp001", "emp002"):
+        (emp_dir / eid).mkdir()
 
 
 # ---------------------------------------------------------------------------
@@ -2053,13 +2059,14 @@ class TestReleaseVersionClosesFirstIfNeeded:
         assert v["version"] == "0.1.1"
 
     def test_release_version_with_non_done_issue(self):
-        """Edge case: issue is BACKLOG but included in release. Should not crash."""
+        """Edge case: issue is BACKLOG but included in release. Should skip, not force release."""
         p = prod.create_product(name="RelBack", owner_id="00010")
         issue = prod.create_issue(slug=p["slug"], title="Surprise", created_by="ceo")
-        # Issue is still in BACKLOG — release should handle gracefully
+        # Issue is still in BACKLOG — release should skip it (not force to RELEASED)
         v = prod.release_version(p["slug"], [issue["id"]])
         loaded = prod.load_issue(p["slug"], issue["id"])
-        assert loaded["status"] == IssueStatus.RELEASED.value
+        assert loaded["status"] == IssueStatus.BACKLOG.value  # stays BACKLOG
+        assert issue["id"] in v["skipped_issues"]
         assert v["version"] == "0.1.1"
 
 

--- a/tests/unit/test_product_owner_audit.py
+++ b/tests/unit/test_product_owner_audit.py
@@ -1,0 +1,470 @@
+"""Tests for product owner chain audit fixes.
+
+Covers:
+- Batch 1: owner_id/assignee_id validation, release_version DONE-only, narrow exceptions
+- Batch 2: sprint carry-over sort, DONE status event, KR dedup by kr_id, race guard,
+           notify_owner review project, sprint date overlap
+- Batch 3: per-product config thresholds, assign_issue + transfer_ownership tools
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+from unittest.mock import patch, AsyncMock, MagicMock
+
+import pytest
+
+from onemancompany.core import product as prod
+from onemancompany.core.models import (
+    IssueStatus,
+    IssuePriority,
+    IssueRelation,
+    IssueResolution,
+    ProductStatus,
+    SprintStatus,
+)
+
+
+@pytest.fixture(autouse=True)
+def _redirect_products_dir(tmp_path, monkeypatch):
+    """Point PRODUCTS_DIR and EMPLOYEES_DIR to temp directories for every test."""
+    monkeypatch.setattr(prod, "PRODUCTS_DIR", tmp_path)
+    emp_dir = tmp_path / "employees"
+    emp_dir.mkdir()
+    monkeypatch.setattr(prod, "EMPLOYEES_DIR", emp_dir)
+    # Create standard test employee directories
+    for eid in ("00010", "00011", "00004"):
+        (emp_dir / eid).mkdir()
+
+
+def _make_product(status="planning", **kw):
+    return prod.create_product(
+        name=kw.pop("name", "AuditProd"),
+        owner_id=kw.pop("owner_id", "00010"),
+        description=kw.pop("description", "test"),
+        status=ProductStatus(status),
+        **kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Batch 1: Validate owner_id / assignee_id
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerIdValidation:
+    """create_product and update_product must validate owner_id."""
+
+    def test_create_product_invalid_owner_raises(self):
+        with pytest.raises(ValueError, match="not found in employee registry"):
+            prod.create_product(name="Bad Owner", owner_id="NONEXISTENT_999")
+
+    def test_create_product_valid_owner_succeeds(self, tmp_path):
+        """Valid owner_id (directory exists under EMPLOYEES_DIR) should succeed."""
+        # create_product should work normally with valid owner_id
+        # We need to ensure the validation function recognizes valid IDs
+        p = prod.create_product(name="Good Owner", owner_id="00010")
+        assert p["owner_id"] == "00010"
+
+    def test_update_product_invalid_owner_raises(self):
+        p = _make_product(owner_id="00010")
+        with pytest.raises(ValueError, match="not found in employee registry"):
+            prod.update_product(p["slug"], owner_id="NONEXISTENT_999")
+
+    def test_update_product_valid_owner_succeeds(self):
+        p = _make_product(owner_id="00010")
+        result = prod.update_product(p["slug"], owner_id="00011")
+        assert result["owner_id"] == "00011"
+
+
+class TestAssigneeIdValidation:
+    """create_issue and update_issue must validate assignee_id."""
+
+    def test_create_issue_invalid_assignee_raises(self):
+        p = _make_product()
+        with pytest.raises(ValueError, match="not found in employee registry"):
+            prod.create_issue(
+                slug=p["slug"], title="Bad", created_by="ceo",
+                assignee_id="NONEXISTENT_999",
+            )
+
+    def test_create_issue_no_assignee_ok(self):
+        p = _make_product()
+        issue = prod.create_issue(slug=p["slug"], title="No Assignee", created_by="ceo")
+        assert issue["assignee_id"] is None
+
+    def test_update_issue_invalid_assignee_raises(self):
+        p = _make_product()
+        issue = prod.create_issue(slug=p["slug"], title="Update Test", created_by="ceo")
+        with pytest.raises(ValueError, match="not found in employee registry"):
+            prod.update_issue(p["slug"], issue["id"], assignee_id="NONEXISTENT_999")
+
+
+# ---------------------------------------------------------------------------
+# Batch 1: release_version rejects non-DONE issues
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseVersionValidation:
+    """release_version should only transition DONE issues to RELEASED."""
+
+    def test_release_skips_non_done_issues(self):
+        p = _make_product()
+        slug = p["slug"]
+        # Create two issues: one DONE, one still BACKLOG
+        done_issue = prod.create_issue(slug=slug, title="Done Issue", created_by="ceo")
+        prod.update_issue(slug, done_issue["id"], status=IssueStatus.IN_PROGRESS.value)
+        prod.update_issue(slug, done_issue["id"], status=IssueStatus.DONE.value)
+
+        backlog_issue = prod.create_issue(slug=slug, title="Backlog Issue", created_by="ceo")
+
+        result = prod.release_version(slug, [done_issue["id"], backlog_issue["id"]])
+        # Done issue should be RELEASED
+        done_after = prod.load_issue(slug, done_issue["id"])
+        assert done_after["status"] == IssueStatus.RELEASED.value
+        # Backlog issue should remain BACKLOG (NOT forced to RELEASED)
+        backlog_after = prod.load_issue(slug, backlog_issue["id"])
+        assert backlog_after["status"] == IssueStatus.BACKLOG.value
+        # Result should report skipped issues
+        assert "skipped_issues" in result
+
+    def test_release_done_issues_all_transition(self):
+        p = _make_product()
+        slug = p["slug"]
+        i1 = prod.create_issue(slug=slug, title="I1", created_by="ceo")
+        i2 = prod.create_issue(slug=slug, title="I2", created_by="ceo")
+        for i in [i1, i2]:
+            prod.update_issue(slug, i["id"], status=IssueStatus.IN_PROGRESS.value)
+            prod.update_issue(slug, i["id"], status=IssueStatus.DONE.value)
+        result = prod.release_version(slug, [i1["id"], i2["id"]])
+        assert prod.load_issue(slug, i1["id"])["status"] == IssueStatus.RELEASED.value
+        assert prod.load_issue(slug, i2["id"])["status"] == IssueStatus.RELEASED.value
+        assert len(result.get("skipped_issues", [])) == 0
+
+
+# ---------------------------------------------------------------------------
+# Batch 1: Narrow exception in notify_owner (tested in test_product_triggers)
+# ---------------------------------------------------------------------------
+
+class TestNotifyOwnerExceptionHandling:
+    """notify_owner should catch specific exceptions, not bare Exception."""
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_propagates(self):
+        """TypeError or KeyError should NOT be silently swallowed."""
+        from onemancompany.core.product_triggers import notify_owner
+
+        p = prod.create_product(name="PropagateErr", owner_id="00010",
+                                status=ProductStatus.ACTIVE)
+        prod.create_issue(slug=p["slug"], title="I1", created_by="ceo")
+
+        # Simulate an unexpected TypeError inside the function
+        with patch("onemancompany.core.project_archive.list_projects", side_effect=TypeError("unexpected")):
+            with pytest.raises(TypeError, match="unexpected"):
+                await notify_owner(p["slug"], reason="test")
+
+
+# ---------------------------------------------------------------------------
+# Batch 2: Sprint carry-over sorts by start_date
+# ---------------------------------------------------------------------------
+
+
+class TestSprintCarryOverSort:
+    """close_sprint should carry unfinished issues to the chronologically next sprint."""
+
+    def test_carry_over_picks_earliest_planning_sprint(self):
+        p = _make_product()
+        slug = p["slug"]
+        # Create active sprint
+        active = prod.create_sprint(
+            slug=slug, name="Sprint 1", start_date="2026-01-01", end_date="2026-01-14"
+        )
+        prod.start_sprint(slug, active["id"])
+
+        # Create two planning sprints — later one first (alphabetical order would pick wrong)
+        later = prod.create_sprint(
+            slug=slug, name="Sprint 3", start_date="2026-02-01", end_date="2026-02-14"
+        )
+        earlier = prod.create_sprint(
+            slug=slug, name="Sprint 2", start_date="2026-01-15", end_date="2026-01-28"
+        )
+
+        # Add issue to active sprint
+        issue = prod.create_issue(slug=slug, title="Unfinished", created_by="ceo", sprint=active["id"])
+
+        # Close active sprint
+        prod.close_sprint(slug, active["id"])
+
+        # Issue should be in the EARLIER planning sprint, not the later one
+        updated_issue = prod.load_issue(slug, issue["id"])
+        assert updated_issue["sprint"] == earlier["id"]
+
+
+# ---------------------------------------------------------------------------
+# Batch 2: update_issue with status=DONE sets closed_at
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateIssueDoneAutoClose:
+    """Setting status to DONE via update_issue should set closed_at and resolution."""
+
+    def test_status_done_sets_closed_at(self):
+        p = _make_product()
+        slug = p["slug"]
+        issue = prod.create_issue(slug=slug, title="Auto Close", created_by="ceo")
+        prod.update_issue(slug, issue["id"], status=IssueStatus.IN_PROGRESS.value)
+        prod.update_issue(slug, issue["id"], status=IssueStatus.DONE.value)
+        loaded = prod.load_issue(slug, issue["id"])
+        assert loaded["closed_at"] is not None
+        assert loaded["resolution"] == IssueResolution.FIXED.value
+
+
+# ---------------------------------------------------------------------------
+# Batch 2: KR-to-issue dedup uses kr_id label
+# ---------------------------------------------------------------------------
+
+
+class TestKrIssueDedupByKrId:
+    """Auto-created KR issues should use kr_id label for dedup, not title match."""
+
+    @pytest.mark.asyncio
+    async def test_auto_kr_issue_has_kr_id_label(self):
+        from onemancompany.core.product_triggers import run_product_check
+
+        p = prod.create_product(
+            name="KrDedup", owner_id="00010", status=ProductStatus.ACTIVE
+        )
+        slug = p["slug"]
+        kr = prod.add_key_result(slug, title="Revenue", target=100, unit="$")
+
+        with patch("onemancompany.core.project_archive.list_projects", return_value=[]):
+            result = await run_product_check(slug)
+
+        # Check that the auto-created issue has a label with kr_id
+        issues = prod.list_issues(slug)
+        kr_issues = [i for i in issues if f"kr:{kr['id']}" in i.get("labels", [])]
+        assert len(kr_issues) == 1
+
+    @pytest.mark.asyncio
+    async def test_kr_dedup_prevents_duplicate_on_second_run(self):
+        from onemancompany.core.product_triggers import run_product_check
+
+        p = prod.create_product(
+            name="KrNoDup", owner_id="00010", status=ProductStatus.ACTIVE
+        )
+        slug = p["slug"]
+        prod.add_key_result(slug, title="Revenue", target=100, unit="$")
+
+        with patch("onemancompany.core.project_archive.list_projects", return_value=[]):
+            await run_product_check(slug)
+            await run_product_check(slug)
+
+        # Should still only have 1 issue
+        issues = prod.list_issues(slug)
+        kr_issues = [i for i in issues if "kr-tracking" in i.get("labels", [])]
+        assert len(kr_issues) == 1
+
+
+# ---------------------------------------------------------------------------
+# Batch 2: Race guard in handle_issue_assigned
+# ---------------------------------------------------------------------------
+
+
+class TestIssueAssignedRaceGuard:
+    """handle_issue_assigned re-reads linked_task_ids before creating project."""
+
+    @pytest.mark.asyncio
+    async def test_skips_if_linked_task_ids_appeared_during_race(self):
+        from onemancompany.core.product_triggers import handle_issue_assigned
+        from onemancompany.core.events import CompanyEvent
+        from onemancompany.core.models import EventType
+
+        p = prod.create_product(
+            name="RaceGuard", owner_id="00010", status=ProductStatus.ACTIVE
+        )
+        issue = prod.create_issue(
+            slug=p["slug"], title="Race Issue", created_by="ceo"
+        )
+
+        # Simulate: between event fire and handler, linked_task_ids got populated
+        prod.update_issue(p["slug"], issue["id"], linked_task_ids=["proj_already"])
+
+        event = CompanyEvent(
+            type=EventType.ISSUE_ASSIGNED,
+            payload={
+                "product_slug": p["slug"],
+                "issue_id": issue["id"],
+                "assignee_id": "00010",
+            },
+        )
+        # Should NOT create a project (already has linked_task_ids)
+        with patch("onemancompany.core.product_triggers._create_project_for_issue") as mock_create:
+            await handle_issue_assigned(event)
+            mock_create.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Batch 2: notify_owner uses dedicated _create_review_project
+# ---------------------------------------------------------------------------
+
+
+class TestNotifyOwnerReviewProject:
+    """notify_owner should create a properly structured review project, not fake an issue dict."""
+
+    @pytest.mark.asyncio
+    async def test_creates_review_project_with_proper_structure(self):
+        from onemancompany.core.product_triggers import notify_owner
+
+        p = prod.create_product(
+            name="ReviewProj", owner_id="00010", status=ProductStatus.ACTIVE
+        )
+        prod.create_issue(slug=p["slug"], title="I1", created_by="ceo")
+
+        # No active projects → should create one via _create_review_project
+        with patch("onemancompany.core.project_archive.list_projects", return_value=[]), \
+             patch("onemancompany.core.product_triggers._create_review_project",
+                   new_callable=AsyncMock, return_value="proj_review_1") as mock_create:
+            result = await notify_owner(p["slug"], reason="quarterly review")
+            mock_create.assert_called_once()
+            # Verify it was called with slug and reason, NOT a fake issue dict
+            call_args = mock_create.call_args
+            assert call_args[0][0] == p["slug"]  # first arg is slug
+
+
+# ---------------------------------------------------------------------------
+# Batch 2: Sprint date overlap validation
+# ---------------------------------------------------------------------------
+
+
+class TestSprintDateOverlap:
+    """create_sprint should reject overlapping dates with non-closed sprints."""
+
+    def test_overlapping_sprint_raises(self):
+        p = _make_product()
+        slug = p["slug"]
+        prod.create_sprint(
+            slug=slug, name="Sprint A", start_date="2026-01-01", end_date="2026-01-14"
+        )
+        # Overlapping: starts during Sprint A
+        with pytest.raises(ValueError, match="[Oo]verlap"):
+            prod.create_sprint(
+                slug=slug, name="Sprint B", start_date="2026-01-10", end_date="2026-01-20"
+            )
+
+    def test_adjacent_sprint_ok(self):
+        p = _make_product()
+        slug = p["slug"]
+        prod.create_sprint(
+            slug=slug, name="Sprint A", start_date="2026-01-01", end_date="2026-01-14"
+        )
+        # Adjacent: starts after Sprint A ends
+        s2 = prod.create_sprint(
+            slug=slug, name="Sprint B", start_date="2026-01-15", end_date="2026-01-28"
+        )
+        assert s2["name"] == "Sprint B"
+
+    def test_closed_sprint_no_overlap_check(self):
+        p = _make_product()
+        slug = p["slug"]
+        s1 = prod.create_sprint(
+            slug=slug, name="Sprint A", start_date="2026-01-01", end_date="2026-01-14"
+        )
+        # Start and close the sprint
+        prod.start_sprint(slug, s1["id"])
+        # Add an issue so close_sprint has something to work with
+        prod.close_sprint(slug, s1["id"])
+        # Now create overlapping sprint — should be OK since s1 is closed
+        s2 = prod.create_sprint(
+            slug=slug, name="Sprint B", start_date="2026-01-01", end_date="2026-01-14"
+        )
+        assert s2["name"] == "Sprint B"
+
+
+# ---------------------------------------------------------------------------
+# Batch 3: Per-product config thresholds
+# ---------------------------------------------------------------------------
+
+
+class TestPerProductThresholds:
+    """Products can override global thresholds via config field."""
+
+    def test_default_thresholds_used(self):
+        p = _make_product()
+        loaded = prod.load_product(p["slug"])
+        # No config field → should use defaults
+        assert loaded.get("config") is None or loaded.get("config", {}).get("max_active_projects") is None
+
+    def test_per_product_threshold_stored(self):
+        p = _make_product()
+        prod.update_product(p["slug"], config={"max_active_projects": 5})
+        loaded = prod.load_product(p["slug"])
+        assert loaded["config"]["max_active_projects"] == 5
+
+    @pytest.mark.asyncio
+    async def test_product_check_uses_per_product_threshold(self):
+        from onemancompany.core.product_triggers import run_product_check
+
+        p = prod.create_product(
+            name="CustomThresh", owner_id="00010", status=ProductStatus.ACTIVE
+        )
+        slug = p["slug"]
+        prod.update_product(slug, config={"max_active_projects": 1})
+
+        # Create 1 active project mock
+        mock_proj = {"project_id": "proj_1", "product_id": p["id"], "status": "active"}
+        # Create a P0 issue that would normally trigger project creation
+        prod.create_issue(
+            slug=slug, title="P0 Issue", created_by="ceo", priority=IssuePriority.P0
+        )
+
+        with patch("onemancompany.core.project_archive.list_projects", return_value=[mock_proj]):
+            result = await run_product_check(slug)
+
+        # Should skip because max_active_projects=1 and we already have 1
+        actions = result.get("actions", [])
+        project_actions = [a for a in actions if "Created project for P0" in a]
+        assert len(project_actions) == 0
+
+
+# ---------------------------------------------------------------------------
+# Batch 3: assign_issue_tool and transfer_product_ownership_tool
+# ---------------------------------------------------------------------------
+
+
+class TestAssignIssueTool:
+    """Dedicated assign_issue_tool should validate and emit event."""
+
+    @pytest.mark.asyncio
+    async def test_assign_issue_tool_basic(self):
+        from onemancompany.agents.product_tools import assign_issue_tool
+        p = _make_product()
+        slug = p["slug"]
+        issue = prod.create_issue(slug=slug, title="Assign Me", created_by="ceo")
+
+        result = await assign_issue_tool.ainvoke({
+            "product_slug": slug,
+            "issue_id": issue["id"],
+            "assignee_id": "00010",
+        })
+        assert "assigned" in result.lower() or "00010" in result
+        loaded = prod.load_issue(slug, issue["id"])
+        assert loaded["assignee_id"] == "00010"
+
+
+class TestTransferOwnershipTool:
+    """Dedicated transfer_product_ownership_tool."""
+
+    @pytest.mark.asyncio
+    async def test_transfer_ownership_tool_basic(self):
+        from onemancompany.agents.product_tools import transfer_product_ownership_tool
+        p = _make_product(owner_id="00010")
+        slug = p["slug"]
+
+        result = await transfer_product_ownership_tool.ainvoke({
+            "product_slug": slug,
+            "new_owner_id": "00011",
+        })
+        assert "00011" in result or "transfer" in result.lower()
+        loaded = prod.load_product(slug)
+        assert loaded["owner_id"] == "00011"

--- a/tests/unit/test_product_owner_audit.py
+++ b/tests/unit/test_product_owner_audit.py
@@ -468,3 +468,138 @@ class TestTransferOwnershipTool:
         assert "00011" in result or "transfer" in result.lower()
         loaded = prod.load_product(slug)
         assert loaded["owner_id"] == "00011"
+
+
+# ---------------------------------------------------------------------------
+# Coverage: _create_review_project full function (product_triggers.py:157-224)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateReviewProjectFull:
+    """Exercise _create_review_project body to cover lines 164-224."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_creates_tree_and_schedules(self):
+        """Full flow: product exists, project created, tree built, owner scheduled."""
+        from onemancompany.core.product_triggers import _create_review_project
+
+        p = _make_product(name="ReviewFull", owner_id="00010")
+
+        mock_async_create = AsyncMock(return_value=("proj-rev-1", "iter-1"))
+        mock_get_dir = MagicMock(return_value="/tmp/proj-rev-1")
+        mock_tree_inst = MagicMock()
+        mock_root = MagicMock()
+        mock_root.id = "root-1"
+        mock_owner_node = MagicMock()
+        mock_owner_node.id = "owner-1"
+        mock_tree_inst.create_root.return_value = mock_root
+        mock_tree_inst.add_child.return_value = mock_owner_node
+        mock_tree_cls = MagicMock(return_value=mock_tree_inst)
+        mock_save = MagicMock()
+        mock_em = MagicMock()
+
+        with patch("onemancompany.core.project_archive.async_create_project_from_task", mock_async_create), \
+             patch("onemancompany.core.project_archive.get_project_dir", mock_get_dir), \
+             patch("onemancompany.core.task_tree.TaskTree", mock_tree_cls), \
+             patch("onemancompany.core.vessel._save_project_tree", mock_save), \
+             patch("onemancompany.core.agent_loop.employee_manager", mock_em):
+            result = await _create_review_project(p["slug"], "quarterly review")
+
+        assert result == "proj-rev-1"
+        mock_async_create.assert_called_once()
+        mock_tree_cls.assert_called_once_with(project_id="proj-rev-1/iter-1", mode="standard")
+        mock_tree_inst.create_root.assert_called_once()
+        mock_tree_inst.add_child.assert_called_once()
+        # Verify owner_id (00010) is used as employee_id for the child node
+        add_child_kwargs = mock_tree_inst.add_child.call_args
+        assert add_child_kwargs[1]["employee_id"] == "00010"
+        assert "quarterly review" in add_child_kwargs[1]["title"]
+        mock_save.assert_called_once()
+        mock_em.schedule_node.assert_called_once_with("00010", "owner-1", mock_em.schedule_node.call_args[0][2])
+        mock_em._schedule_next.assert_called_once_with("00010")
+
+    @pytest.mark.asyncio
+    async def test_product_not_found_returns_empty(self):
+        """Line 170-171: nonexistent product slug returns empty string."""
+        from onemancompany.core.product_triggers import _create_review_project
+
+        result = await _create_review_project("nonexistent-slug", "some reason")
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_no_owner_falls_back_to_ea(self):
+        """Line 201: if owner_id is empty, falls back to EA_ID."""
+        from onemancompany.core.product_triggers import _create_review_project
+
+        p = _make_product(name="NoOwnerReview", owner_id="00010")
+        # Clear owner_id after creation
+        prod.update_product(p["slug"], owner_id="")
+
+        mock_async_create = AsyncMock(return_value=("proj-rev-2", ""))
+        mock_get_dir = MagicMock(return_value="/tmp/proj-rev-2")
+        mock_tree_inst = MagicMock()
+        mock_root = MagicMock()
+        mock_root.id = "root-1"
+        mock_child = MagicMock()
+        mock_child.id = "child-1"
+        mock_tree_inst.create_root.return_value = mock_root
+        mock_tree_inst.add_child.return_value = mock_child
+        mock_tree_cls = MagicMock(return_value=mock_tree_inst)
+        mock_em = MagicMock()
+
+        with patch("onemancompany.core.project_archive.async_create_project_from_task", mock_async_create), \
+             patch("onemancompany.core.project_archive.get_project_dir", mock_get_dir), \
+             patch("onemancompany.core.task_tree.TaskTree", mock_tree_cls), \
+             patch("onemancompany.core.vessel._save_project_tree", MagicMock()), \
+             patch("onemancompany.core.agent_loop.employee_manager", mock_em):
+            result = await _create_review_project(p["slug"], "no owner check")
+
+        assert result == "proj-rev-2"
+        # Should use EA_ID as fallback
+        from onemancompany.core.config import EA_ID
+        add_child_kwargs = mock_tree_inst.add_child.call_args
+        assert add_child_kwargs[1]["employee_id"] == EA_ID
+        mock_em.schedule_node.assert_called_once()
+        assert mock_em.schedule_node.call_args[0][0] == EA_ID
+
+    @pytest.mark.asyncio
+    async def test_no_iter_id_uses_project_id_only(self):
+        """Line 182: when iter_id is empty, ctx_id = project_id."""
+        from onemancompany.core.product_triggers import _create_review_project
+
+        p = _make_product(name="NoIterReview", owner_id="00010")
+
+        mock_async_create = AsyncMock(return_value=("proj-rev-3", ""))
+        mock_get_dir = MagicMock(return_value="/tmp/proj-rev-3")
+        mock_tree_inst = MagicMock()
+        mock_root = MagicMock()
+        mock_root.id = "root-1"
+        mock_child = MagicMock()
+        mock_child.id = "child-1"
+        mock_tree_inst.create_root.return_value = mock_root
+        mock_tree_inst.add_child.return_value = mock_child
+        mock_tree_cls = MagicMock(return_value=mock_tree_inst)
+        mock_em = MagicMock()
+
+        with patch("onemancompany.core.project_archive.async_create_project_from_task", mock_async_create), \
+             patch("onemancompany.core.project_archive.get_project_dir", mock_get_dir), \
+             patch("onemancompany.core.task_tree.TaskTree", mock_tree_cls), \
+             patch("onemancompany.core.vessel._save_project_tree", MagicMock()), \
+             patch("onemancompany.core.agent_loop.employee_manager", mock_em):
+            result = await _create_review_project(p["slug"], "no iter")
+
+        assert result == "proj-rev-3"
+        mock_tree_cls.assert_called_once_with(project_id="proj-rev-3", mode="standard")
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_empty_string(self):
+        """Lines 219-224: exception during project creation returns empty string."""
+        from onemancompany.core.product_triggers import _create_review_project
+
+        p = _make_product(name="ExcReview", owner_id="00010")
+
+        mock_async_create = AsyncMock(side_effect=RuntimeError("project creation failed"))
+        with patch("onemancompany.core.project_archive.async_create_project_from_task", mock_async_create):
+            result = await _create_review_project(p["slug"], "exc test")
+
+        assert result == ""

--- a/tests/unit/test_product_tools.py
+++ b/tests/unit/test_product_tools.py
@@ -8,6 +8,11 @@ from onemancompany.core import product as prod
 @pytest.fixture(autouse=True)
 def _isolate(tmp_path, monkeypatch):
     monkeypatch.setattr(prod, "PRODUCTS_DIR", tmp_path)
+    emp_dir = tmp_path / "employees"
+    emp_dir.mkdir()
+    monkeypatch.setattr(prod, "EMPLOYEES_DIR", emp_dir)
+    for eid in ("00004", "00010", "00011", "emp-1", "agent", "emp001"):
+        (emp_dir / eid).mkdir()
     prod.create_product(name="ToolTest", owner_id="00004", description="test product")
     yield
 
@@ -205,7 +210,7 @@ class TestProductTools:
     async def test_product_tools_list(self):
         from onemancompany.agents.product_tools import PRODUCT_TOOLS
 
-        assert len(PRODUCT_TOOLS) == 22
+        assert len(PRODUCT_TOOLS) == 24
         names = {t.name for t in PRODUCT_TOOLS}
         assert "create_product_tool" in names
         assert "create_product_issue" in names
@@ -658,7 +663,7 @@ class TestProductTools:
         from onemancompany.agents.product_tools import PRODUCT_TOOLS
 
         assert isinstance(PRODUCT_TOOLS, list)
-        assert len(PRODUCT_TOOLS) == 22  # 7 original + 3 sprint tools
+        assert len(PRODUCT_TOOLS) == 24  # 7 original + 3 sprint tools
         for t in PRODUCT_TOOLS:
             assert hasattr(t, "ainvoke")
 

--- a/tests/unit/test_product_triggers.py
+++ b/tests/unit/test_product_triggers.py
@@ -10,6 +10,11 @@ from onemancompany.core.events import CompanyEvent
 @pytest.fixture(autouse=True)
 def _isolate(tmp_path, monkeypatch):
     monkeypatch.setattr(prod, "PRODUCTS_DIR", tmp_path)
+    emp_dir = tmp_path / "employees"
+    emp_dir.mkdir()
+    monkeypatch.setattr(prod, "EMPLOYEES_DIR", emp_dir)
+    for eid in ("00004", "00010", "00011", "emp-1"):
+        (emp_dir / eid).mkdir()
     yield
 
 
@@ -1346,13 +1351,15 @@ class TestNotifyOwner:
         assert await notify_owner(p["slug"], reason="test") is False
 
     @pytest.mark.asyncio
-    async def test_exception_returns_false(self):
+    async def test_unexpected_exception_propagates(self):
+        """Unexpected errors should NOT be silently swallowed."""
         from onemancompany.core.product_triggers import notify_owner
         p = prod.create_product(name="ErrProd", owner_id="00010",
                                 status=prod.ProductStatus.ACTIVE)
         prod.create_issue(slug=p["slug"], title="An issue", created_by="ceo")
         with patch("onemancompany.core.project_archive.list_projects", side_effect=RuntimeError("boom")):
-            assert await notify_owner(p["slug"], reason="test") is False
+            with pytest.raises(RuntimeError, match="boom"):
+                await notify_owner(p["slug"], reason="test")
 
     @pytest.mark.asyncio
     async def test_active_product_no_projects_creates_one(self):
@@ -1361,7 +1368,7 @@ class TestNotifyOwner:
                                 status=prod.ProductStatus.ACTIVE)
         prod.create_issue(slug=p["slug"], title="Backlog issue", created_by="ceo")
         with patch("onemancompany.core.project_archive.list_projects", return_value=[]), \
-             patch("onemancompany.core.product_triggers._create_project_for_issue", new_callable=AsyncMock, return_value=None):
+             patch("onemancompany.core.product_triggers._create_review_project", new_callable=AsyncMock, return_value=""):
             assert await notify_owner(p["slug"], reason="quarterly review") is False
 
     @pytest.mark.asyncio
@@ -1371,7 +1378,7 @@ class TestNotifyOwner:
                                 status=prod.ProductStatus.ACTIVE)
         prod.create_issue(slug=p["slug"], title="Issue", created_by="ceo")
         with patch("onemancompany.core.project_archive.list_projects", return_value=[]), \
-             patch("onemancompany.core.product_triggers._create_project_for_issue", new_callable=AsyncMock, return_value="proj_123"):
+             patch("onemancompany.core.product_triggers._create_review_project", new_callable=AsyncMock, return_value="proj_123"):
             assert await notify_owner(p["slug"], reason="test") is True
 
     @pytest.mark.asyncio

--- a/tests/unit/test_product_workspace.py
+++ b/tests/unit/test_product_workspace.py
@@ -198,6 +198,11 @@ class TestLifecycleHooks:
         monkeypatch.setattr(prod, "PRODUCTS_DIR", self.products_dir)
         monkeypatch.setattr(pa, "PRODUCTS_DIR", self.products_dir)
         monkeypatch.setattr(pa, "PROJECTS_DIR", self.projects_dir)
+        emp_dir = tmp_path / "employees"
+        emp_dir.mkdir()
+        monkeypatch.setattr(prod, "EMPLOYEES_DIR", emp_dir)
+        for eid in ("emp001", "00010"):
+            (emp_dir / eid).mkdir()
 
     def _create_product(self) -> dict:
         """Helper: create a product on disk and return its dict."""
@@ -303,6 +308,11 @@ class TestEndToEnd:
         monkeypatch.setattr(prod, "PRODUCTS_DIR", self.products_dir)
         monkeypatch.setattr(pa, "PRODUCTS_DIR", self.products_dir)
         monkeypatch.setattr(pa, "PROJECTS_DIR", self.projects_dir)
+        emp_dir = tmp_path / "employees"
+        emp_dir.mkdir()
+        monkeypatch.setattr(prod, "EMPLOYEES_DIR", emp_dir)
+        for eid in ("emp001", "00010"):
+            (emp_dir / eid).mkdir()
 
     def test_two_projects_promote_sequentially(self):
         """Two projects write different files, both promote cleanly."""


### PR DESCRIPTION
## Summary
- **Batch 1 (Critical)**: Validate owner_id/assignee_id against employee registry, release_version only transitions DONE→RELEASED (skips non-DONE), remove broad exception handler in notify_owner
- **Batch 2 (Important)**: Sprint carry-over sorts by start_date, update_issue auto-sets closed_at on DONE, KR dedup uses kr_id label, race guard in handle_issue_assigned, dedicated _create_review_project, sprint date overlap validation
- **Batch 3 (Suggestions)**: Per-product config thresholds, new assign_issue_tool and transfer_product_ownership_tool

## Test plan
- [x] 24 new audit-specific tests in test_product_owner_audit.py
- [x] Updated 5 existing test files for EMPLOYEES_DIR fixture
- [x] Full suite: 4172 passed, 0 failed
- [x] Pre-commit hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)