### PR TITLE
fix: debug LLM logging and task tree node overflow

### DIFF
--- a/frontend/task-tree-g6.js
+++ b/frontend/task-tree-g6.js
@@ -26,11 +26,11 @@ const STATUS_STYLES = {
     blocked:    { color: '#f97316', label: '\u2298 Blocked' },
 };
 
-const CARD_W = 240;
+const CARD_W = 260;
 const CARD_MIN_H = 72;       // minimum card height (no description)
 const DESC_LINE_H = 14;      // height per description line
-const DESC_MAX_LINES = 6;    // cap description lines
-const DESC_CHARS_PER_LINE = 34;
+const DESC_MAX_LINES = 12;   // cap description lines (was 6 — caused overflow/truncation)
+const DESC_CHARS_PER_LINE = 38;
 const CHILDREN_PAGE_SIZE = 5;
 
 /* ─────────────────── Word-wrap helper (shared with old code) ────── */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.47",
+  "version": "0.7.48",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.47"
+version = "0.7.48"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -641,6 +641,7 @@ class BaseAgentRunner:
                         content = last_msg.content or ""
                         if isinstance(content, str):
                             on_log("llm_input", f"[{type(last_msg).__name__}] {content}")
+                            logger.debug("[LLM INPUT] employee={}: {}", self.employee_id, content[:3000])
             elif kind == "on_chat_model_end":
                 output = data.get("output", None)
                 if output:
@@ -671,6 +672,7 @@ class BaseAgentRunner:
                         if text.strip():
                             final_content = text  # track last AI output
                             on_log("llm_output", text)
+                            logger.debug("[LLM OUTPUT] employee={}: {}", self.employee_id, text[:3000])
                         tool_calls = getattr(output, "tool_calls", None)
                         if tool_calls:
                             last_tool_calls = []
@@ -685,11 +687,13 @@ class BaseAgentRunner:
                                     "tool_args": args_dict,
                                     "content": f"{name}({args})",
                                 })
+                                logger.debug("[TOOL CALL] employee={}: {}({})", self.employee_id, name, args[:1000])
             elif kind == "on_tool_end":
                 output = data.get("output", "")
                 name = event.get("name", "tool")
                 result_str = str(output)
                 last_tool_results.append(f"{name} → {result_str}")
+                logger.debug("[TOOL RESULT] employee={}: {} → {}", self.employee_id, name, result_str[:2000])
                 on_log("tool_result", {
                     "tool_name": name,
                     "tool_result": result_str,


### PR DESCRIPTION
## Summary
- **Bug #13**: Add `logger.debug` for LLM input, output, tool calls, and tool results in `base.py`. Prints to console when `--debug` / `OMC_DEBUG=1` is active. Task prompt was already logged in vessel.py; this completes the full request/response trace.
- **Bug #8**: Increase task tree card width 240→260px, max description lines 6→12, chars per line 34→38. Node height was already dynamic; the 6-line cap caused premature truncation.

## Test plan
- [x] All 4177 tests pass
- [ ] Verify `--debug` mode prints LLM input/output to console
- [ ] Verify task tree nodes display longer descriptions without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)