### PR TITLE
docs: clarify ecosystem positioning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 >
 > Not building a company — building any company.
 
-OneManCompany is an open-source OS that lets anyone build and run a complete AI-powered company from their browser.
+OneManCompany is an open-source OS that lets anyone build and run a complete AI-powered company from their browser. It doesn't replace tools like Claude Code, Codex, or other agent frameworks — it operates one level above them as an **agentic operating system**, orchestrating hierarchical AI teams built on top of these underlying tools.
 
 **You are the CEO — the only human.** Everyone else — HR, COO, engineers, designers — are AI employees that think, collaborate, and deliver real work autonomously. (*No slacking, no sick days, no raise requests — just the occasional need for a pep talk.*)
 
@@ -198,7 +198,7 @@ These aren't toy demos — each AI company produces **product-level deliverables
 
 ## Quick Start
 
-You only need **Node.js 16+** and **Git**. Everything else is installed automatically.
+You only need **Node.js 18+** and **Git**. Everything else is installed automatically.
 
 ```bash
 npx @1mancompany/onemancompany
@@ -261,7 +261,7 @@ Founding employees (EA, HR, COO, CSO) support three execution modes, switchable 
 | --- | --- | --- |
 | **Company Hosted Agent** | OMC's built-in agent, calls LLMs via OpenRouter | OpenRouter API Key (configured in setup process) |
 | **Claude Code** | More capable, lower token cost | Install [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) + [Claude Pro/Max subscription](https://claude.ai) |
-| **OpenClaw** *(Coming Soon)* | Open-source alternative, multiple LLM backends | Install [OpenClaw CLI](https://github.com/openclaw/openclaw) + compatible LLM API Key |
+| **OpenClaw** *(Experimental)* | Open-source alternative, multiple LLM backends | Install [OpenClaw CLI](https://github.com/openclaw/openclaw) + compatible LLM API Key |
 
 Defaults to Company Hosted Agent — no extra subscription needed to get started. See [Execution Modes docs](https://1mancompany.github.io/OneManCompany/docs/guide/execution-modes/) for details.
 
@@ -418,7 +418,7 @@ This is a living plan — [request a feature](https://github.com/1mancompany/One
 | [Vessel System](docs/vessel-system.md) | Vessel + Talent deep dive, Harness protocols |
 | [Task System](docs/task-system.md) | Task status state machine |
 | [Coding Guide](vibe-coding-guide.md) | Coding guidelines, testing rules, code style |
-| [Changelog](CHANGELOG.md) | Release history |
+| [Changelog](https://github.com/1mancompany/OneManCompany/releases) | Release history |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.49",
+  "version": "0.7.54",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.49"
+version = "0.7.54"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Adds ecosystem positioning statement to the README intro, clarifying that OneManCompany operates one level above agent frameworks (Claude Code, Codex, etc.) as an agentic operating system — not as a replacement for them.
- Addresses third-party feedback that the project's place in the ecosystem was unclear to newcomers.

## Test plan
- [ ] Verify the updated intro reads naturally on GitHub rendered view
- [ ] Confirm no other sections need corresponding updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)