### PR TITLE
fix: settings model selection not persisting after save

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.55"
+version = "0.7.56"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.54"
+version = "0.7.55"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -595,7 +595,13 @@ settings = Settings()
 
 
 def update_env_var(key: str, value: str) -> None:
-    """Update or add a variable in the .env file, then reload settings."""
+    """Update or add a variable in the .env file, then reload settings.
+
+    Also syncs os.environ so that pydantic BaseSettings (which reads os.environ
+    with higher priority than .env files) sees the new value immediately.
+    """
+    import os as _os
+
     env_path = DATA_ROOT / DOT_ENV_FILENAME
     lines: list[str] = []
     found = False
@@ -610,6 +616,9 @@ def update_env_var(key: str, value: str) -> None:
     if not found:
         lines.append(f"{key}={value}")
     env_path.write_text("\n".join(lines) + "\n", encoding=ENCODING_UTF8)
+    # Sync os.environ — main.py's load_dotenv() seeds it at startup;
+    # without this, the stale env var wins over the updated .env file.
+    _os.environ[key] = value
     reload_settings()
 
 

--- a/tests/unit/core/test_config_coverage.py
+++ b/tests/unit/core/test_config_coverage.py
@@ -80,6 +80,59 @@ class TestReloadSettings:
         assert config_mod.settings is not old_settings
 
 
+class TestUpdateEnvVarSyncsOsEnviron:
+    """Regression: update_env_var must sync os.environ so Settings() sees the
+    new value.  main.py calls load_dotenv() at startup which seeds os.environ;
+    pydantic BaseSettings reads os.environ with higher priority than .env file.
+    If update_env_var only writes the file, the stale os.environ value wins and
+    the setting appears to 'revert' on next read.
+    """
+
+    def test_update_env_var_updates_os_environ(self, tmp_path, monkeypatch):
+        """update_env_var must set os.environ[key] so reload_settings picks it up."""
+        import os
+        import onemancompany.core.config as config_mod
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("DEFAULT_LLM_MODEL=old/model\n")
+        monkeypatch.setattr(config_mod, "DATA_ROOT", tmp_path)
+
+        # Simulate startup: load_dotenv seeds os.environ
+        os.environ["DEFAULT_LLM_MODEL"] = "old/model"
+
+        with patch.object(config_mod, "reload_settings"):
+            config_mod.update_env_var("DEFAULT_LLM_MODEL", "new/model")
+
+        # os.environ must reflect the new value
+        assert os.environ["DEFAULT_LLM_MODEL"] == "new/model"
+
+        # Cleanup
+        monkeypatch.delenv("DEFAULT_LLM_MODEL", raising=False)
+
+    def test_settings_sees_new_model_after_update(self, tmp_path, monkeypatch):
+        """End-to-end: after update_env_var, Settings().default_llm_model must
+        return the NEW value, not the stale os.environ value from startup."""
+        import onemancompany.core.config as config_mod
+
+        env_path = tmp_path / ".env"
+        env_path.write_text("DEFAULT_LLM_MODEL=startup/model\n")
+        monkeypatch.setattr(config_mod, "DATA_ROOT", tmp_path)
+
+        # Simulate startup: load_dotenv seeds os.environ with the old value
+        monkeypatch.setenv("DEFAULT_LLM_MODEL", "startup/model")
+
+        # Save a new model via update_env_var (calls reload_settings internally)
+        config_mod.update_env_var("DEFAULT_LLM_MODEL", "user-chosen/model")
+
+        # os.environ must have the new value so Settings() picks it up
+        import os
+        assert os.environ["DEFAULT_LLM_MODEL"] == "user-chosen/model"
+
+        # A fresh Settings instance must see the new value
+        fresh = config_mod.Settings()
+        assert fresh.default_llm_model == "user-chosen/model"
+
+
 # ---------------------------------------------------------------------------
 # sync_founding_defaults (line 629)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause**: `main.py` calls `load_dotenv()` at startup which loads `.env` values into `os.environ`. When `update_env_var()` later writes a new model to the `.env` file, `reload_settings()` constructs a new pydantic `Settings()` — but `BaseSettings` reads `os.environ` (highest priority) before `.env` file. The stale startup value in `os.environ` always won, making the save appear to revert.
- **Fix**: Added `os.environ[key] = value` in `update_env_var()` before `reload_settings()`, keeping the process environment in sync with the `.env` file.
- **Scope**: Affects all settings saved via `update_env_var`: `DEFAULT_LLM_MODEL`, `DEFAULT_API_PROVIDER`, API keys, base URLs, etc.

## Test plan

- [x] Regression test: `update_env_var` updates `os.environ` (was failing before fix)
- [x] E2E test: `Settings().default_llm_model` returns new value after `update_env_var`
- [x] Full unit test suite passes (4221 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)