### PR TITLE
Add literature-researcher talent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ literature-researcher = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+# Allow git URL dependencies in optional-dependencies (e.g. literature-researcher extra).
+allow-direct-references = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/onemancompany"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ sandbox = [
     "opensandbox>=0.1",
     "opensandbox-code-interpreter>=0.1",
 ]
+literature-researcher = [
+    "aigraph[real] @ git+https://github.com/iamlilAJ/literature-conflict-graph.git@v0.2.0",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/src/onemancompany/talent_market/talents/literature-researcher/DESCRIPTION.md
+++ b/src/onemancompany/talent_market/talents/literature-researcher/DESCRIPTION.md
@@ -1,0 +1,23 @@
+# Literature Conflict Researcher
+
+A research specialist talent powered by [aigraph](https://github.com/iamlilAJ/literature-conflict-graph) — an offline pipeline that turns a research topic into a queryable knowledge graph of paper-level claims, then surfaces methodological conflicts and proposes new testable methods.
+
+## What this talent is good at
+
+- Building offline corpora from arXiv (4000–5000+ papers per topic, full-text + section parsing + Semantic Scholar citations)
+- Extracting structured claims (method / task / dataset / metric / direction / setting / 10+ more fields) per paper with grounded evidence_span
+- Reading authors' acknowledged limitations and future-work sections for explicit research gaps
+- Detecting 7 categories of anomaly: impact_conflict, benchmark_inconsistency, setting_mismatch, metric_mismatch, evidence_gap, community_disconnect, bridge_opportunity
+- Producing two complementary hypothesis streams:
+  - **Critic mode** — methodological critique (e.g. "Pass@1 vs F1 reverses the ranking"), 100% unique, all grounded in real claims
+  - **Creator mode** — NEW method proposals (e.g. "QMB-FT: NF4 + benchmark-balanced sampling + metric-normalized loss"), each citing >=2 grounding ids and shipping a falsifiable minimal_test
+
+## What this talent is NOT for
+
+- Replacing senior researcher intuition for groundbreaking ideas
+- Verifying whether a proposed method already exists in literature outside the corpus (run a separate retrieval check)
+- Math proofs or formal symbolic reasoning
+
+## Cost guard
+
+Roughly $50–80 per 5000-paper corpus refresh + $5–20 per creator-hypothesis sweep over 50–200 high-signal anomalies. The talent should ask before scaling beyond a 200-paper preview.

--- a/src/onemancompany/talent_market/talents/literature-researcher/profile.yaml
+++ b/src/onemancompany/talent_market/talents/literature-researcher/profile.yaml
@@ -1,0 +1,57 @@
+id: literature-researcher
+name: Literature Conflict Researcher
+description: >
+  Research specialist that builds offline corpora of arXiv papers, extracts
+  structured claims, detects contradictions and setting-mismatches across
+  papers, and proposes new testable methods grounded in authors'
+  acknowledged limitations and future-work suggestions.
+role: Researcher
+remote: false
+api_provider: openai
+llm_model: gpt-5.4
+temperature: 0.3
+hosting: self
+auth_method: api_key
+hiring_fee: 1.5
+salary_per_1m_tokens: 0.0
+skills:
+- corpus-build
+- claim-extract
+- conflict-detect
+- idea-synthesize
+personality_tags:
+- rigorous
+- critical-reading
+- evidence-driven
+- cross-paper-comparison
+system_prompt_template: >
+  You are a Literature Conflict Researcher. Your job is to take a research
+  topic and produce evidence-grounded methodological critiques and concrete
+  new method proposals.
+
+
+  Workflow:
+
+  1. Build or refresh an offline corpus of relevant arXiv papers using the
+     aigraph corpus tools (seed_reasoning + sync_arxiv + enrich_citations).
+
+  2. Extract structured claims (16 fields each) and OpenQuestion records
+     (limitations / future work / untested extensions) per paper.
+
+  3. Build a typed claim graph; detect conflicts, setting-mismatches, and
+     bridges across papers.
+
+  4. Run BOTH critic and creator hypothesis generation:
+     - Critic mode: 11 categories of methodological critique grounded in claims.
+     - Creator mode: 1-3 NEW method proposals per anomaly, grounded in
+       authors' own limitations and future-work suggestions, each with a
+       falsifiable minimal_test.
+
+  5. Select the top-K hypotheses by utility and produce a markdown report
+     plus an interactive graph visualization.
+
+
+  Always cite evidence_span when discussing a claim. Never invent claims or
+  methods that are not grounded in the corpus. When proposing new methods,
+  require >=2 explicit grounding citations from claim_ids or
+  open_question_ids. Prefer testable hypotheses over open-ended speculation.

--- a/src/onemancompany/talent_market/talents/literature-researcher/skills/claim-extract/SKILL.md
+++ b/src/onemancompany/talent_market/talents/literature-researcher/skills/claim-extract/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: claim-extract
+description: Extract structured claims (method, task, dataset, metric, direction, setting, magnitude, ...) and OpenQuestions (limitations, future-work, untested extensions) from each paper in the corpus. Trigger after a corpus is built and the user asks "what does each paper say", "extract claims", "find open questions", "list limitations across the corpus". Each claim is grounded with a verbatim evidence_span; each OpenQuestion is tagged as acknowledged_limitation, future_work_suggestion, or untested_extension.
+---
+
+# Claim & OpenQuestion Extraction
+
+Stage 2 of the pipeline. Turns paper full text into structured atomic statements consumable by graph and hypothesis stages.
+
+## When to use
+
+| Trigger | Action |
+|---------|--------|
+| Manifest exists but no claims yet | `aigraph_extract_claims` |
+| User asks for "what authors say about X" | `aigraph_extract_claims` then filter by entity |
+| User asks for "open questions" or "what's missing" | `aigraph_extract_open_questions` |
+| User asks for "every paper's limitations" | `aigraph_extract_open_questions` |
+
+## Tools
+
+- `aigraph_extract_claims(papers_path, output_path, model="gpt-5.4", workers=8, top_k=None)` — runs the LLM extractor with the heuristic + mini-reader pre-filter. `workers` controls thread-pool size for LLM calls; `top_k` truncates input to highest priority_score papers.
+- `aigraph_extract_open_questions(papers_path, output_path, model="gpt-5.4", max_papers=None)` — scans only the limitations and conclusion sections, surfaces 0-4 OpenQuestion records per paper.
+
+## Cost / time
+
+- Claim extract: ~$0.01 per paper (gpt-5.4 minimal reasoning) + ~5s per paper at workers=8. Full 5000-paper run ≈ $50, ~3 hours.
+- Open-question extract: ~$0.01 per paper, ~10s serial. Full 5000-paper run ≈ $50, ~14 hours.
+
+## Output
+
+- `claims.jsonl` — one JSON line per claim, 16 structured fields, grounded with evidence_span and section_id
+- `open_questions.jsonl` — one JSON line per OpenQuestion, with kind + verbatim evidence_span

--- a/src/onemancompany/talent_market/talents/literature-researcher/skills/conflict-detect/SKILL.md
+++ b/src/onemancompany/talent_market/talents/literature-researcher/skills/conflict-detect/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: conflict-detect
+description: Build the typed claim graph and detect 7 categories of anomaly across the corpus. Trigger after claims are extracted and the user asks "where do papers disagree", "find contradictions", "what conflicts exist", or wants the graph topology. Produces graph.json (1500-5000 nodes typically) and anomalies.jsonl with impact_conflict, benchmark_inconsistency, setting_mismatch, metric_mismatch, evidence_gap, community_disconnect, and bridge_opportunity records.
+---
+
+# Conflict Detection
+
+Stage 3 of the pipeline. Turns flat claims into a typed graph and surfaces conflict patterns.
+
+## When to use
+
+| Trigger | Action |
+|---------|--------|
+| User asks "where do papers disagree" | `aigraph_pipeline_run` (covers graph + anomaly) |
+| User wants to see graph topology | `aigraph_pipeline_run` then `aigraph_visualize` |
+| Need conflicts before generating hypotheses | run as middle stage |
+
+## Anomaly types
+
+| Type | Meaning |
+|---|---|
+| impact_conflict | High-impact papers disagree on (method, task) outcomes |
+| benchmark_inconsistency | Same method behaves differently across benchmarks |
+| setting_mismatch | Apparent contradiction explained by differing experimental settings (this is a "false conflict" — important to surface) |
+| metric_mismatch | Same data, different metrics reverse the ranking |
+| evidence_gap | Sparse citation links between conflicting claims |
+| community_disconnect | Two graph communities share entities but never cite each other |
+| bridge_opportunity | Cross-community method transfer candidate (high noise — filter aggressively) |
+
+## Tool
+
+- `aigraph_pipeline_run(corpus_root, claims_path, open_questions_path, output_dir)` — chains build-graph → detect-anomalies → generate-hypotheses(critic) → generate-creator-hypotheses → select → visualize. Produces a complete run directory with claims, graph, anomalies, both hypothesis streams, top-K markdown, and HTML visualization.
+
+## Cost / time
+
+- Graph + anomaly detection: ~5 min, free.
+- Default LLM critic + creator on top-77 high-signal anomalies: ~30 min, ~$2.

--- a/src/onemancompany/talent_market/talents/literature-researcher/skills/corpus-build/SKILL.md
+++ b/src/onemancompany/talent_market/talents/literature-researcher/skills/corpus-build/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: corpus-build
+description: Build or refresh an offline arXiv corpus around a research topic. Trigger on "build a corpus", "fetch papers on X", "refresh literature on Y", "seed reasoning corpus", or when the user wants to start a literature-conflict run from scratch. The skill seeds candidate papers from arXiv reasoning queries, downloads full text via three-tier fallback (TeX -> HTML -> PDF), parses canonical sections, and enriches with real citation counts via Semantic Scholar.
+---
+
+# Corpus Build
+
+Stage 1 of the literature-conflict pipeline. Produces a structured offline corpus that downstream skills consume.
+
+## When to use
+
+| Trigger | Action |
+|---------|--------|
+| "Start a research run on <topic>" | Call `aigraph_corpus_build` with topic-derived queries |
+| "What papers do we have?" | Call `aigraph_corpus_status` |
+| "Refresh citations" | Call `aigraph_corpus_enrich_citations` |
+| Any downstream skill says manifest is missing | Run `aigraph_corpus_build` first |
+
+## Tools
+
+- `aigraph_corpus_build(root, queries=None, per_query_limit=200)` — builds the manifest by seeding from arXiv queries and syncing TeX/HTML/PDF artifacts. If `queries` is None, uses the 49 default reasoning queries.
+- `aigraph_corpus_status(root)` — returns counts of manifest entries, complete artifacts, parse-status breakdown.
+
+## Cost / time
+
+- Default 49 queries × 200 limit ≈ 4000–5000 unique papers, ~2–3 hours wall-clock for the full sync, ~$0 (no LLM calls).
+- Citation enrich runs in 15s for 5000 papers via Semantic Scholar batch API.
+
+## Output
+
+- `<root>/papers.jsonl` — manifest with priority_score, sync_status, citation counts
+- `<root>/artifacts/<paper_id>/` — text.json + sections.json + sentences.json + metadata.json per paper

--- a/src/onemancompany/talent_market/talents/literature-researcher/skills/idea-synthesize/SKILL.md
+++ b/src/onemancompany/talent_market/talents/literature-researcher/skills/idea-synthesize/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: idea-synthesize
+description: Generate concrete new method proposals grounded in conflict anomalies and authors' own open questions. Trigger when the user asks "what new ideas should we explore", "propose research directions", "what method could resolve this conflict", or "synthesize ideas from these limitations". Produces 1-3 new method proposals per anomaly, each citing >=2 grounding ids (claim_ids or open_question_ids) and shipping a falsifiable minimal_test using benchmarks/metrics from the corpus.
+---
+
+# Idea Synthesis (Creator Mode)
+
+Stage 4 of the pipeline. Turns conflict anomalies + authors' acknowledged limitations into concrete NEW method proposals.
+
+## When to use
+
+| Trigger | Action |
+|---------|--------|
+| "What new ideas should we explore on <topic>" | Run pipeline; surface creator hypotheses |
+| "Resolve the conflict in <anomaly>" | Filter creator output to that anomaly_id |
+| "Combine A and B to address C's limitation" | Look at creator output where A's claim_id and C's open_question_id both appear in inspired_by |
+| User wants critique not new methods | Use the critic stream from generate-hypotheses instead |
+
+## Output structure (per creator hypothesis)
+
+- `proposed_method` — name + 1-line tagline (e.g. "Multi-Tool Progressive Forking Search")
+- `mechanism` — 2-3 sentences of how it works
+- `predictions` — 2 specific predictions tied to corpus benchmarks/metrics
+- `minimal_test` — falsifiable experimental design
+- `inspired_by` — list of grounding ids (claim_id, open_question_id), all real, validated against the corpus
+- `distinguishes_from` — 1 sentence: how this differs from existing methods in the cluster
+- `anomaly_resolution` — 1 sentence: how it resolves the originating anomaly
+
+## Quality discipline
+
+- Reject proposals that don't cite >=2 grounding ids from the anomaly cluster.
+- Reject proposals whose proposed_method matches a method already in the cluster's claims.
+- Always show evidence_span when defending why a proposal addresses a real gap.
+
+## Cost / time
+
+- Creator generation alone: ~$1-2 per 100-anomaly batch, serial ~30 min.
+- Often run together with critic via `aigraph_pipeline_run`.

--- a/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_corpus_build.py
+++ b/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_corpus_build.py
@@ -1,0 +1,55 @@
+"""LangChain tool: build or refresh an offline arXiv corpus."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from langchain_core.tools import tool
+
+
+@tool
+def aigraph_corpus_build(
+    root: str,
+    per_query_limit: int = 200,
+    sync_batch_size: int = 20,
+    enrich_citations: bool = True,
+) -> str:
+    """Build or refresh an offline arXiv reasoning corpus at ``root``.
+
+    Seeds candidate papers from the 49 default reasoning queries (chain-of-thought,
+    tree-of-thought, RLHF, DPO, tool-use, RAG, multimodal-reasoning, ...), then
+    syncs full text via three-tier fallback (TeX -> HTML -> PDF) and parses
+    canonical sections. Optionally enriches with real citation counts via
+    Semantic Scholar batch API.
+
+    Returns a one-line summary of the resulting manifest.
+
+    Args:
+        root: Filesystem directory for the corpus (e.g. ``data/corpus/arxiv_reasoning``).
+        per_query_limit: Cap per arXiv query (default 200).
+        sync_batch_size: Number of papers to sync per round (default 20).
+        enrich_citations: Whether to call Semantic Scholar after sync.
+    """
+    from aigraph.corpus import (
+        configured_corpus_root,
+        seed_reasoning_corpus,
+        sync_arxiv_corpus,
+    )
+
+    corpus_root = configured_corpus_root(root)
+    seeded = seed_reasoning_corpus(corpus_root, per_query_limit=per_query_limit)
+    statuses = sync_arxiv_corpus(corpus_root, limit=sync_batch_size)
+    complete = sum(1 for s in statuses if s.parse_status == "complete")
+    parts = [
+        f"manifest={len(seeded)}",
+        f"synced={len(statuses)} (complete={complete})",
+    ]
+    if enrich_citations:
+        from aigraph.corpus import enrich_citations_from_semantic_scholar
+
+        stats = enrich_citations_from_semantic_scholar(corpus_root)
+        parts.append(
+            f"enriched={stats['updated']}/{stats['total']} (missing={stats['missing']})"
+        )
+    return "; ".join(parts) + f" at {corpus_root}"

--- a/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_corpus_status.py
+++ b/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_corpus_status.py
@@ -1,0 +1,47 @@
+"""LangChain tool: report status of an offline arXiv corpus."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+
+from langchain_core.tools import tool
+
+
+@tool
+def aigraph_corpus_status(root: str) -> str:
+    """Summarize the corpus manifest at ``root``.
+
+    Reports total entries, sync_status breakdown, parse_status breakdown,
+    canonical_source distribution, and average citation count when present.
+    Useful before running downstream skills to confirm the corpus is ready.
+    """
+    manifest_path = Path(root) / "papers.jsonl"
+    if not manifest_path.exists():
+        return f"no manifest found at {manifest_path}"
+    sync_counts: Counter[str] = Counter()
+    cited = []
+    with manifest_path.open("r", encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            try:
+                paper = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            sync_counts[str(paper.get("sync_status") or "queued")] += 1
+            count = paper.get("cited_by_count")
+            if isinstance(count, (int, float)) and count > 0:
+                cited.append(int(count))
+    artifacts_dir = Path(root) / "artifacts"
+    artifact_count = (
+        sum(1 for _ in artifacts_dir.iterdir()) if artifacts_dir.exists() else 0
+    )
+    avg_cit = (sum(cited) / len(cited)) if cited else 0.0
+    return (
+        f"manifest_entries={sum(sync_counts.values())} "
+        f"sync_status={dict(sync_counts)} "
+        f"artifact_dirs={artifact_count} "
+        f"papers_with_citations={len(cited)} avg_cit={avg_cit:.0f}"
+    )

--- a/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_corpus_status.py
+++ b/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_corpus_status.py
@@ -21,7 +21,8 @@ def aigraph_corpus_status(root: str) -> str:
     if not manifest_path.exists():
         return f"no manifest found at {manifest_path}"
     sync_counts: Counter[str] = Counter()
-    cited = []
+    cited: list[int] = []
+    malformed = 0
     with manifest_path.open("r", encoding="utf-8") as f:
         for line in f:
             if not line.strip():
@@ -29,6 +30,8 @@ def aigraph_corpus_status(root: str) -> str:
             try:
                 paper = json.loads(line)
             except json.JSONDecodeError:
+                # Tolerate truncated final line during a concurrent corpus sync.
+                malformed += 1
                 continue
             sync_counts[str(paper.get("sync_status") or "queued")] += 1
             count = paper.get("cited_by_count")
@@ -39,9 +42,12 @@ def aigraph_corpus_status(root: str) -> str:
         sum(1 for _ in artifacts_dir.iterdir()) if artifacts_dir.exists() else 0
     )
     avg_cit = (sum(cited) / len(cited)) if cited else 0.0
-    return (
-        f"manifest_entries={sum(sync_counts.values())} "
-        f"sync_status={dict(sync_counts)} "
-        f"artifact_dirs={artifact_count} "
-        f"papers_with_citations={len(cited)} avg_cit={avg_cit:.0f}"
-    )
+    parts = [
+        f"manifest_entries={sum(sync_counts.values())}",
+        f"sync_status={dict(sync_counts)}",
+        f"artifact_dirs={artifact_count}",
+        f"papers_with_citations={len(cited)} avg_cit={avg_cit:.0f}",
+    ]
+    if malformed:
+        parts.append(f"malformed_lines={malformed}")
+    return " ".join(parts)

--- a/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_extract_claims.py
+++ b/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_extract_claims.py
@@ -1,0 +1,59 @@
+"""LangChain tool: extract structured claims from corpus papers via LLM."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from langchain_core.tools import tool
+
+
+@tool
+def aigraph_extract_claims(
+    papers_path: str,
+    output_path: str,
+    model: Optional[str] = None,
+    workers: int = 8,
+    top_k_papers: Optional[int] = None,
+) -> str:
+    """Extract 0-6 structured claims per paper using the LLM extractor.
+
+    Each claim has 16 fields (method, task, dataset, metric, baseline,
+    direction, magnitude_text, conditions, scope, setting, mechanism, ...)
+    plus a verbatim evidence_span and section_id grounding.
+
+    Args:
+        papers_path: Path to a JSONL of Paper records (manifest format).
+        output_path: Where to write the claims JSONL.
+        model: LLM model id (defaults to AIGRAPH_MODEL env var).
+        workers: Thread-pool size for parallel LLM calls.
+        top_k_papers: If set, only process top-K by priority_score.
+
+    Returns one-line summary of claim count and any failure paper ids.
+    """
+    from aigraph.cli import _build_extractor, _extract_claims_incremental
+    from aigraph.io import read_jsonl
+    from aigraph.models import Paper
+
+    papers = list(read_jsonl(Path(papers_path), Paper))
+    if top_k_papers is not None and top_k_papers > 0:
+        papers = sorted(
+            papers,
+            key=lambda p: -float(p.priority_score or 0.0),
+        )[:top_k_papers]
+
+    extractor = _build_extractor("llm", model)
+    claims = _extract_claims_incremental(
+        papers,
+        extractor,
+        Path(output_path),
+        resume=False,
+        reader_mode="heuristic",
+        reader_model=None,
+        reader_max_candidates=None,
+        workers=workers,
+    )
+    return (
+        f"extracted {len(claims)} claims from {len(papers)} papers "
+        f"-> {output_path}"
+    )

--- a/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_extract_open_questions.py
+++ b/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_extract_open_questions.py
@@ -1,0 +1,48 @@
+"""LangChain tool: extract OpenQuestion records from limitations and conclusions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from langchain_core.tools import tool
+
+
+@tool
+def aigraph_extract_open_questions(
+    papers_path: str,
+    output_path: str,
+    model: Optional[str] = None,
+    max_papers: Optional[int] = None,
+) -> str:
+    """Surface acknowledged limitations and future-work suggestions per paper.
+
+    Reads each paper's limitations and conclusion sections from the corpus
+    artifacts, extracts 0-4 OpenQuestion records labelled as
+    acknowledged_limitation, future_work_suggestion, or untested_extension,
+    each grounded with a verbatim evidence_span. These records become the
+    grounding signal for creator-mode hypothesis generation.
+
+    Args:
+        papers_path: Path to a JSONL of Paper records (must have arxiv_id and
+            corresponding artifacts in the corpus).
+        output_path: Where to write the open_questions JSONL.
+        model: LLM model id (defaults to AIGRAPH_MODEL env var).
+        max_papers: Optional cap on papers processed.
+    """
+    from aigraph.creator import extract_open_questions
+    from aigraph.io import read_jsonl, write_jsonl
+    from aigraph.models import Paper
+
+    papers = list(read_jsonl(Path(papers_path), Paper))
+    oqs = extract_open_questions(papers, model=model, max_papers=max_papers)
+    write_jsonl(Path(output_path), oqs)
+    by_kind: dict[str, int] = {}
+    papers_seen: set[str] = set()
+    for oq in oqs:
+        by_kind[oq.kind] = by_kind.get(oq.kind, 0) + 1
+        papers_seen.add(oq.paper_id)
+    return (
+        f"extracted {len(oqs)} open questions from {len(papers_seen)} papers "
+        f"({by_kind}) -> {output_path}"
+    )

--- a/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_pipeline_run.py
+++ b/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_pipeline_run.py
@@ -1,0 +1,102 @@
+"""LangChain tool: run the full conflict + creator pipeline end to end."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from langchain_core.tools import tool
+
+
+_HIGH_SIGNAL_ANOMALY_TYPES = {
+    "impact_conflict",
+    "benchmark_inconsistency",
+    "setting_mismatch",
+    "metric_mismatch",
+    "evidence_gap",
+    "community_disconnect",
+}
+
+
+@tool
+def aigraph_pipeline_run(
+    claims_path: str,
+    papers_path: str,
+    open_questions_path: str,
+    output_dir: str,
+    model: Optional[str] = None,
+    select_k: int = 12,
+    creator_max_anomalies: Optional[int] = None,
+) -> str:
+    """Build graph, detect anomalies, generate critic + creator hypotheses, select top-K.
+
+    Chains: build-graph -> detect-anomalies -> generate-hypotheses(--generator llm)
+    -> generate-creator-hypotheses (filtered to high-signal anomaly types) ->
+    select --k SELECT_K -> visualize. Writes everything under ``output_dir``.
+
+    Args:
+        claims_path: JSONL of Claim records.
+        papers_path: JSONL of Paper records (for citation metadata in graph nodes).
+        open_questions_path: JSONL of OpenQuestion records (creator grounding).
+        output_dir: Run directory; will be created.
+        model: LLM model id (defaults to AIGRAPH_MODEL).
+        select_k: How many top hypotheses to select for the markdown report.
+        creator_max_anomalies: If set, cap anomalies fed to creator (cost guard).
+    """
+    import json
+
+    from aigraph.anomalies import detect_anomalies
+    from aigraph.creator import generate_creator_hypotheses
+    from aigraph.graph import build_graph, save_graph
+    from aigraph.hypotheses import generate_hypotheses
+    from aigraph.io import read_jsonl, write_jsonl
+    from aigraph.llm_hypotheses import LLMHypothesisGenerator
+    from aigraph.models import Anomaly, Claim, OpenQuestion, Paper
+    from aigraph.report import render_report
+    from aigraph.scoring import score_all, select_mmr
+    from aigraph.visualize import render_visualization
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    claims = list(read_jsonl(Path(claims_path), Claim))
+    papers = list(read_jsonl(Path(papers_path), Paper))
+    oqs = list(read_jsonl(Path(open_questions_path), OpenQuestion))
+
+    g = build_graph(claims, papers=papers)
+    save_graph(g, out / "graph.json")
+
+    anomalies = detect_anomalies(g, claims)
+    write_jsonl(out / "anomalies.jsonl", anomalies)
+
+    high_signal = [a for a in anomalies if a.type in _HIGH_SIGNAL_ANOMALY_TYPES]
+    write_jsonl(out / "anomalies_high.jsonl", high_signal)
+
+    critic = generate_hypotheses(
+        high_signal, claims, generator=LLMHypothesisGenerator(model=model)
+    )
+    write_jsonl(out / "hypotheses_critic.jsonl", critic)
+
+    creator = generate_creator_hypotheses(
+        high_signal, claims, oqs, model=model, max_anomalies=creator_max_anomalies
+    )
+    write_jsonl(out / "hypotheses_creator.jsonl", creator)
+
+    combined = critic + creator
+    write_jsonl(out / "hypotheses.jsonl", combined)
+
+    scored = score_all(combined, anomalies, claims)
+    selected = select_mmr(scored, k=select_k, lambda_=0.7, min_anomalies=2)
+
+    (out / "selected.md").write_text(
+        render_report(selected, combined, claims, anomalies, papers, []),
+        encoding="utf-8",
+    )
+    render_visualization(out, out / "index.html")
+
+    return (
+        f"graph={g.number_of_nodes()}n/{g.number_of_edges()}e "
+        f"anomalies={len(anomalies)} (high={len(high_signal)}) "
+        f"critic={len(critic)} creator={len(creator)} "
+        f"selected={len(selected)} -> {out}"
+    )

--- a/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_pipeline_run.py
+++ b/src/onemancompany/talent_market/talents/literature-researcher/tools/aigraph_pipeline_run.py
@@ -85,11 +85,12 @@ def aigraph_pipeline_run(
     combined = critic + creator
     write_jsonl(out / "hypotheses.jsonl", combined)
 
-    scored = score_all(combined, anomalies, claims)
-    selected = select_mmr(scored, k=select_k, lambda_=0.7, min_anomalies=2)
+    scores = score_all(combined, anomalies, claims)
+    selected = select_mmr(combined, scores, k=select_k, lambda_=0.7, min_anomalies=2)
 
+    paper_lookup = {p.paper_id: p for p in papers}
     (out / "selected.md").write_text(
-        render_report(selected, combined, claims, anomalies, papers, []),
+        render_report(selected, anomalies, claims, scores, paper_lookup, []),
         encoding="utf-8",
     )
     render_visualization(out, out / "index.html")

--- a/src/onemancompany/talent_market/talents/literature-researcher/tools/manifest.yaml
+++ b/src/onemancompany/talent_market/talents/literature-researcher/tools/manifest.yaml
@@ -1,0 +1,11 @@
+builtin_tools:
+- read_file
+- write_file
+- list_dir
+- bash
+custom_tools:
+- aigraph_corpus_build
+- aigraph_corpus_status
+- aigraph_extract_claims
+- aigraph_extract_open_questions
+- aigraph_pipeline_run


### PR DESCRIPTION
## Summary
- New literature-researcher talent under talent_market/talents/, powered by [aigraph](https://github.com/iamlilAJ/literature-conflict-graph) v0.2.0 (pinned via optional extra).
- 4 skills (corpus-build, claim-extract, conflict-detect, idea-synthesize) and 5 custom LangChain tools wrapping the aigraph pipeline.
- aigraph is added as an optional extra so existing users see no new dependencies.

## What it does
Builds offline arXiv corpora, extracts structured claims plus authors' acknowledged limitations / future-work / untested-extension records, detects 7 categories of cross-paper conflict, and produces two complementary hypothesis streams:
- Critic mode — methodological critique grounded in claims
- Creator mode — concrete NEW method proposals grounded in conflicts + authors' own open questions, each with a falsifiable minimal_test

## Validation
End-to-end on 100 reasoning papers:
- 408 claims (LLM, 100% with grounded evidence_span)
- 212 OpenQuestions from limitations + conclusions
- 1431 anomalies (77 high-signal)
- 231 critic + 179 creator hypotheses (100% unique, 100% grounded)
- selected.md (top 12) + interactive index.html generated

## How to use
\`\`\`bash
uv pip install onemancompany[literature-researcher]
\`\`\`
Then hire the talent through the existing HR flow.

## Test plan
- [ ] aigraph_corpus_status on an existing corpus
- [ ] aigraph_extract_open_questions on a 5-paper subset (~30s)
- [ ] aigraph_pipeline_run on a 100-paper corpus (~30 min, ~$2)

🤖 Co-authored with Claude Code