### PR TITLE
Fix: ChatAnthropic missing base_url for custom provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.59"
+version = "0.7.60"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -198,9 +198,13 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
             extra_headers = {}
             if auth_method == AuthMethod.OAUTH or effective_key.startswith("sk-ant-oat"):
                 extra_headers["anthropic-beta"] = "oauth-2025-04-20"
+            base_url = None
+            if api_provider == "custom" and settings.default_api_base_url:
+                base_url = settings.default_api_base_url
             return ChatAnthropic(
                 model=model,
                 api_key=effective_key,
+                base_url=base_url,
                 temperature=effective_temp,
                 max_retries=3,
                 timeout=300.0,


### PR DESCRIPTION
## Background

- **Issue/Motivation**: When using `custom` provider with `chat_class=anthropic` (e.g. MiniMax via `api.minimaxi.com/anthropic`), sending a message in the EA chat fails with `401 authentication_error`.
- **Root Cause**: In `make_llm()`, `ChatAnthropic` was instantiated without the `base_url` parameter, causing it to default to `https://api.anthropic.com` instead of the configured custom endpoint (`https://api.minimaxi.com/anthropic`). This was verified by checking `ChatAnthropic._client.base_url` which showed the wrong endpoint, and the API call returning `401 invalid x-api-key` because the request was routing to the wrong server entirely.

## What Changed

### Key Design Decisions

Added `base_url` resolution for the `custom` provider when `chat_class=anthropic`, mirroring the existing pattern already used for `CHAT_CLASS_OPENAI` providers in the same function. For `custom` + `anthropic`, the `base_url` is set from `settings.default_api_base_url`, which is populated from `DEFAULT_API_BASE_URL` in `.env`.

### Files Changed (annotated)

| File | Change |
|------|--------|
| `src/onemancompany/agents/base.py` | Added `base_url` parameter to `ChatAnthropic` constructor for `custom` provider (4 lines) |

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Visualization / Theme
- [ ] Talent package
- [ ] Documentation
- [ ] Other

## Review Checklist

### Phase 1 — Bug Hunt

- [x] No off-by-one, null-ref, or race conditions introduced (only adds an optional parameter)
- [x] Error paths tested — when `default_api_base_url` is empty, `base_url=None` is passed which falls back to the Anthropic default (correct behavior for real Anthropic API users)
- [x] Edge cases covered — empty `custom_api_key` was already handled upstream in `_resolve_provider_key`

### Phase 2 — Design Principles (docs/design-principles.md)

- [x] **Single Source of Truth** — `base_url` is resolved once at construction time, stored in the `ChatAnthropic` client
- [x] **Systematic Design** — Mirrors the exact same pattern already used for `CHAT_CLASS_OPENAI` in the same function
- [x] **Modular & General-Purpose** — Adding support for a new `anthropic`-compatible custom endpoint requires no new code
- [x] **Complete Data Package** — No new state introduced
- [x] **No Silent Exceptions** — No new exception paths
- [x] **Registry/Dispatch** — No if-elif chains added
- [x] **Status via transition()** — N/A
- [x] **Minimal Complexity** — 4 lines added, no new abstractions

### Phase 3 — Side Effects

- [x] No unintended behavioral changes to existing features (only affects `custom` + `anthropic` path)
- [x] Serialization/persistence formats unchanged
- [x] No new circular imports introduced

## Test Plan

- [x] Compilation check (`.venv/bin/python -c "from onemancompany.agents.base import make_llm; llm = make_llm('00004'); print(llm._client.base_url)"` → `https://api.minimaxi.com/anthropic/`)
- [x] Manual testing — EA chat in local OneManCompany instance now succeeds after hot-reload

### Manual Test Steps

1. Configure `.env` with `DEFAULT_API_PROVIDER=custom`, `CUSTOM_CHAT_CLASS=anthropic`, `DEFAULT_API_BASE_URL=https://api.minimaxi.com/anthropic`, and a valid `CUSTOM_API_KEY`
2. Start OneManCompany server
3. Open the frontend at `http://localhost:8000`
4. Send a message to the EA (Pat EA) via the chat UI
5. Confirm response is received without `401` error in server log