### PR TITLE
chore: add HuggingFace paper badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/github/license/1mancompany/OneManCompany" alt="License" /></a>
   <a href="https://github.com/1mancompany/OneManCompany/commits/main"><img src="https://img.shields.io/github/last-commit/1mancompany/OneManCompany" alt="Last commit" /></a>
   <a href="https://discord.gg/B6BfZ9tWa"><img src="https://img.shields.io/discord/1352123168498921472?color=5865F2&label=Discord&logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://huggingface.co/papers/2604.22446"><img src="https://img.shields.io/badge/%F0%9F%A4%97-Paper-yellow" alt="HuggingFace Paper" /></a>
 </p>
 
 <p align="center">

--- a/README_zh.md
+++ b/README_zh.md
@@ -15,6 +15,7 @@
   <a href="LICENSE"><img src="https://img.shields.io/github/license/1mancompany/OneManCompany" alt="License" /></a>
   <a href="https://github.com/1mancompany/OneManCompany/commits/main"><img src="https://img.shields.io/github/last-commit/1mancompany/OneManCompany" alt="Last commit" /></a>
   <a href="https://discord.gg/B6BfZ9tWa"><img src="https://img.shields.io/discord/1352123168498921472?color=5865F2&label=Discord&logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://huggingface.co/papers/2604.22446"><img src="https://img.shields.io/badge/%F0%9F%A4%97-Paper-yellow" alt="HuggingFace Paper" /></a>
 </p>
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.66",
+  "version": "0.7.67",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.66"
+version = "0.7.67"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Summary
- Add 🤗 Paper badge linking to https://huggingface.co/papers/2604.22446 in both README.md and README_zh.md

## Quality Checklist

| # | Check | Answer |
|---|-------|--------|
| 1 | **What changed** | Added HF paper badge to badge rows in both READMEs |
| 2 | **Root cause fix** | N/A — additive change |
| 3 | **Single source of truth** | Yes — both READMEs share the same badge |
| 4 | **Test regression** | Pre-commit passed (docs-only, tests skipped) |
| 5 | **Reuse** | Follows existing badge pattern |

🤖 Generated with [Claude Code](https://claude.com/claude-code)