### PR TITLE
fix: handle empty API key in make_llm for newer openai library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.71"
+version = "0.7.72"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -245,6 +245,7 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
     fallback_key = settings.openrouter_api_key
     if not fallback_key:
         logger.warning("make_llm: no API key for provider '{}' and no OpenRouter fallback key; LLM calls will fail", api_provider)
+        fallback_key = "sk-no-key-set"
 
     return ChatOpenAI(
         model=model,


### PR DESCRIPTION
## Summary
- Fix CI failure on main: `openai` library now rejects empty string as `api_key`
- Use placeholder key `sk-no-key-set` so `ChatOpenAI` can be constructed (will fail at call time as intended)
- Version bump 0.7.71 → 0.7.72

## Test plan
- [x] `test_fallback_no_key_warning` passes locally
- [x] Full unit suite: 4223 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)