### PR TITLE
[codex] fix Anthropic onboarding provider handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.71",
+  "version": "0.7.72",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.71"
+version = "0.7.72"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -59,6 +59,7 @@ _TC_NAME_KEY = "name"  # tool_call dict key
 _TC_ATTR = "tool_calls"  # AIMessage attribute name
 _UNKNOWN_TOOL = "unknown"
 _NO_OUTPUT = "(no output)"
+_MISSING_API_KEY_SENTINEL = "missing-api-key"
 
 
 def _extract_text(content) -> str:
@@ -244,7 +245,14 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
 
     fallback_key = settings.openrouter_api_key
     if not fallback_key:
-        logger.warning("make_llm: no API key for provider '{}' and no OpenRouter fallback key; LLM calls will fail", api_provider)
+        logger.warning(
+            "make_llm: no API key for provider '{}' and no OpenRouter fallback key; "
+            "LLM calls will fail. Set DEFAULT_API_PROVIDER with the matching provider API key in {}, "
+            "or set OPENROUTER_API_KEY for fallback.",
+            api_provider,
+            _cfg.DATA_ROOT / _cfg.DOT_ENV_FILENAME,
+        )
+        fallback_key = _MISSING_API_KEY_SENTINEL
 
     return ChatOpenAI(
         model=model,

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -384,21 +384,15 @@ def _step_llm(console: Console) -> tuple[str, str, str, str]:
         if not base_url:
             console.print("  [red]Base URL is required for custom providers.[/red]")
             base_url = _inq.text(message="Base URL:", style=INQ_STYLE).execute().strip()
-    elif provider != PROVIDER_OPENROUTER:
-        console.print(
-            f"  [dim]Custom API base URL (press Enter to keep default).[/dim]\n"
-            f"  [dim]Examples: https://api.openai.com/v1, https://your-server.com/v1[/dim]"
-        )
-        from onemancompany.core.config import PROVIDER_REGISTRY
-        default_url = PROVIDER_REGISTRY.get(provider, None)
-        default_url = default_url.base_url if default_url else ""
-        base_url = _inq.text(
-            message="Base URL:",
-            default=default_url,
-            style=INQ_STYLE,
-        ).execute().strip()
 
     # 4. Select model — try fetching from provider, fall back to manual input
+    model = _select_or_enter_model(console, provider, api_key)
+    return provider, api_key.strip(), model, base_url, custom_chat_class
+
+
+def _select_or_enter_model(console: Console, provider: str, api_key: str) -> str:
+    from InquirerPy import inquirer as _inq
+
     console.print()
     all_models = _fetch_provider_models(console, provider, api_key)
     if all_models:
@@ -412,8 +406,7 @@ def _step_llm(console: Console) -> tuple[str, str, str, str]:
             default=default_model,
             style=INQ_STYLE,
         ).execute().strip()
-
-    return provider, api_key.strip(), model, base_url, custom_chat_class
+    return model
 
 
 def _step_server(console: Console) -> tuple[str, int]:

--- a/tests/unit/agents/test_base.py
+++ b/tests/unit/agents/test_base.py
@@ -1003,6 +1003,54 @@ class TestGetEmployeeTalentPersona:
 # ---------------------------------------------------------------------------
 
 class TestMakeLlmAnthropic:
+    def test_default_anthropic_with_company_api_key(self, monkeypatch):
+        from onemancompany.agents import base as base_mod
+        from onemancompany.core import config as config_mod
+
+        mock_settings = MagicMock()
+        mock_settings.default_llm_model = "claude-sonnet-4-6"
+        mock_settings.default_api_provider = "anthropic"
+        mock_settings.anthropic_auth_method = "api_key"
+        mock_settings.anthropic_api_key = "sk-ant-test-key-123"
+        mock_settings.anthropic_oauth_token = ""
+        mock_settings.custom_chat_class = ""
+        mock_settings.openrouter_api_key = ""
+        monkeypatch.setattr(config_mod, "settings", mock_settings)
+        monkeypatch.setattr(base_mod, "employee_configs", {})
+
+        mock_chat_anthropic = MagicMock()
+        mock_module = MagicMock()
+        mock_module.ChatAnthropic = mock_chat_anthropic
+        monkeypatch.setitem(__import__("sys").modules, "langchain_anthropic", mock_module)
+
+        base_mod.make_llm()
+
+        mock_chat_anthropic.assert_called_once()
+        call_kwargs = mock_chat_anthropic.call_args[1]
+        assert call_kwargs["model"] == "claude-sonnet-4-6"
+        assert call_kwargs["api_key"] == "sk-ant-test-key-123"
+
+    def test_missing_default_provider_key_does_not_require_openai_env(self, monkeypatch):
+        from onemancompany.agents import base as base_mod
+        from onemancompany.core import config as config_mod
+
+        mock_settings = MagicMock()
+        mock_settings.default_llm_model = "claude-sonnet-4-6"
+        mock_settings.default_api_provider = "anthropic"
+        mock_settings.anthropic_auth_method = "api_key"
+        mock_settings.anthropic_api_key = ""
+        mock_settings.anthropic_oauth_token = ""
+        mock_settings.custom_chat_class = ""
+        mock_settings.openrouter_api_key = ""
+        mock_settings.openrouter_base_url = "https://openrouter.ai/api/v1"
+        monkeypatch.setattr(config_mod, "settings", mock_settings)
+        monkeypatch.setattr(base_mod, "employee_configs", {})
+
+        llm = base_mod.make_llm()
+
+        assert llm is not None
+        assert llm.model_name == "claude-sonnet-4-6"
+
     def test_anthropic_with_api_key(self, monkeypatch):
         from onemancompany.agents import base as base_mod
         from onemancompany.core import config as config_mod

--- a/tests/unit/agents/test_base_coverage.py
+++ b/tests/unit/agents/test_base_coverage.py
@@ -260,7 +260,7 @@ class TestMakeLlmBranches:
         assert llm is not None
 
     def test_fallback_no_key_warning(self, monkeypatch):
-        """Cover line 237: no API key warning."""
+        """Missing selected-provider key and fallback key still creates a deferred-failure LLM."""
         from onemancompany.agents.base import make_llm
         mock_settings = MagicMock()
         mock_settings.default_llm_model = "gpt-4"

--- a/tests/unit/test_onboard.py
+++ b/tests/unit/test_onboard.py
@@ -146,6 +146,75 @@ class TestNoStaleRichUI:
         assert "custom model ID" not in source
 
 
+class TestStepLlmBaseUrlPrompt:
+    """Provider-specific Base URL prompt behavior."""
+
+    @pytest.mark.parametrize("selected_provider", [
+        "openai",
+        "anthropic",
+        "kimi",
+        "deepseek",
+        "qwen",
+        "zhipu",
+        "groq",
+        "together",
+        "openrouter",
+        "google",
+        "minimax",
+    ])
+    def test_known_providers_do_not_prompt_for_base_url(self, selected_provider):
+        from onemancompany.onboard import _step_llm
+
+        mock_console = MagicMock()
+        mock_select = MagicMock()
+        mock_select.execute.return_value = selected_provider
+        mock_secret = MagicMock()
+        mock_secret.execute.return_value = "sk-test"
+        mock_text = MagicMock()
+        mock_text.execute.return_value = "test-model"
+
+        with patch("InquirerPy.inquirer.select", return_value=mock_select), \
+             patch("InquirerPy.inquirer.secret", return_value=mock_secret), \
+             patch("InquirerPy.inquirer.text", return_value=mock_text) as mock_text_fn, \
+             patch("onemancompany.onboard._fetch_provider_models", return_value=[]):
+            provider, api_key, model, base_url, custom_chat_class = _step_llm(mock_console)
+
+        assert provider == selected_provider
+        assert api_key == "sk-test"
+        assert model == "test-model"
+        assert base_url == ""
+        assert custom_chat_class == ""
+        assert [call.kwargs["message"] for call in mock_text_fn.call_args_list] == ["Model ID:"]
+
+    def test_custom_provider_prompts_for_base_url(self):
+        from onemancompany.onboard import _step_llm
+
+        mock_console = MagicMock()
+        provider_select = MagicMock()
+        provider_select.execute.return_value = "custom"
+        compatibility_select = MagicMock()
+        compatibility_select.execute.return_value = "openai"
+        mock_secret = MagicMock()
+        mock_secret.execute.return_value = "sk-custom"
+        base_url_text = MagicMock()
+        base_url_text.execute.return_value = "https://llm.example.com/v1"
+        model_text = MagicMock()
+        model_text.execute.return_value = "custom-model"
+
+        with patch("InquirerPy.inquirer.select", side_effect=[provider_select, compatibility_select]), \
+             patch("InquirerPy.inquirer.secret", return_value=mock_secret), \
+             patch("InquirerPy.inquirer.text", side_effect=[base_url_text, model_text]) as mock_text_fn, \
+             patch("onemancompany.onboard._fetch_provider_models", return_value=[]):
+            provider, api_key, model, base_url, custom_chat_class = _step_llm(mock_console)
+
+        assert provider == "custom"
+        assert api_key == "sk-custom"
+        assert model == "custom-model"
+        assert base_url == "https://llm.example.com/v1"
+        assert custom_chat_class == "openai"
+        assert [call.kwargs["message"] for call in mock_text_fn.call_args_list] == ["Base URL:", "Model ID:"]
+
+
 class TestOpenclawLaunchShErrorHandling:
     """launch.sh must surface errors instead of silently returning 'No output returned'."""
 


### PR DESCRIPTION
## Summary
- skip the Base URL prompt for all known built-in providers during onboarding
- keep Base URL collection for the custom provider path
- prevent missing fallback keys from surfacing as misleading OPENAI_API_KEY initialization errors

## Root cause
The onboarding flow treated every non-OpenRouter provider as needing an optional OpenAI-style Base URL prompt. Known providers already have endpoints in the provider registry, so users selecting Anthropic, Kimi, DeepSeek, Qwen, Zhipu, Groq, Together, Google, MiniMax, or OpenAI should not be asked for endpoint details during normal setup. Separately, the missing-key fallback initialized ChatOpenAI without a key, causing the OpenAI SDK to emit a misleading credentials error.

## Validation
- pytest tests/unit/test_onboard.py tests/unit/agents/test_base.py tests/unit/agents/test_base_coverage.py tests/unit/agents/test_settings_api_key.py
