### PR TITLE
[codex] fix model pricing display for unknown costs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.72",
+  "version": "0.7.73",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.72"
+version = "0.7.73"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -158,8 +158,8 @@ def _step_welcome(console: Console) -> None:
 
 def _format_price(price_str: str | None) -> str:
     """Format per-token price string to $/M tokens."""
-    if not price_str:
-        return PRICE_FREE
+    if price_str is None or price_str == "":
+        return PRICE_NA
     try:
         per_token = float(price_str)
         per_million = per_token * 1_000_000
@@ -226,8 +226,8 @@ def _fetch_provider_models(console: Console, provider: str, api_key: str) -> lis
         models.append({
             MODEL_KEY_ID: model_id,
             MODEL_KEY_NAME: display_name,
-            MODEL_KEY_PROMPT_PRICE: _format_price(pricing.get(OR_FIELD_PROMPT)) if pricing else "",
-            MODEL_KEY_COMPLETION_PRICE: _format_price(pricing.get(OR_FIELD_COMPLETION)) if pricing else "",
+            MODEL_KEY_PROMPT_PRICE: _format_price(pricing.get(OR_FIELD_PROMPT) if pricing else None),
+            MODEL_KEY_COMPLETION_PRICE: _format_price(pricing.get(OR_FIELD_COMPLETION) if pricing else None),
             MODEL_KEY_CONTEXT: m.get(OR_FIELD_CONTEXT_LENGTH) or m.get("context_length") or 0,
         })
 
@@ -294,8 +294,8 @@ def _select_model_interactive(console: Console, all_models: list[dict]) -> str:
     # Build choices with pricing info
     choices = []
     for m in all_models:
-        prompt_price = _format_price(m.get(MODEL_KEY_PROMPT_PRICE))
-        comp_price = _format_price(m.get(MODEL_KEY_COMPLETION_PRICE))
+        prompt_price = m.get(MODEL_KEY_PROMPT_PRICE) or PRICE_NA
+        comp_price = m.get(MODEL_KEY_COMPLETION_PRICE) or PRICE_NA
         label = f"{m[MODEL_KEY_ID]}  [{prompt_price} / {comp_price}]"
         choices.append({"name": label, "value": m[MODEL_KEY_ID]})
 

--- a/tests/unit/test_onboard.py
+++ b/tests/unit/test_onboard.py
@@ -215,6 +215,89 @@ class TestStepLlmBaseUrlPrompt:
         assert [call.kwargs["message"] for call in mock_text_fn.call_args_list] == ["Base URL:", "Model ID:"]
 
 
+class TestModelPricingDisplay:
+    """Model list pricing display must distinguish free from unknown."""
+
+    def test_format_price_missing_is_na_zero_is_free(self):
+        from onemancompany.onboard import PRICE_FREE, PRICE_NA, _format_price
+
+        assert _format_price(None) == PRICE_NA
+        assert _format_price("") == PRICE_NA
+        assert _format_price("0") == PRICE_FREE
+
+    def test_select_model_uses_existing_price_labels_without_reformatting(self):
+        from onemancompany.onboard import (
+            MODEL_KEY_COMPLETION_PRICE,
+            MODEL_KEY_CONTEXT,
+            MODEL_KEY_ID,
+            MODEL_KEY_NAME,
+            MODEL_KEY_PROMPT_PRICE,
+            PRICE_FREE,
+            PRICE_NA,
+            _select_model_interactive,
+        )
+
+        mock_console = MagicMock()
+        fuzzy_prompt = MagicMock()
+        fuzzy_prompt.execute.return_value = "claude-haiku-4-5-20251001"
+        models = [
+            {
+                MODEL_KEY_ID: "claude-haiku-4-5-20251001",
+                MODEL_KEY_NAME: "Claude Haiku 4.5",
+                MODEL_KEY_PROMPT_PRICE: "",
+                MODEL_KEY_COMPLETION_PRICE: "",
+                MODEL_KEY_CONTEXT: 0,
+            },
+            {
+                MODEL_KEY_ID: "openrouter/free-model",
+                MODEL_KEY_NAME: "Free Model",
+                MODEL_KEY_PROMPT_PRICE: PRICE_FREE,
+                MODEL_KEY_COMPLETION_PRICE: PRICE_FREE,
+                MODEL_KEY_CONTEXT: 0,
+            },
+            {
+                MODEL_KEY_ID: "priced-model",
+                MODEL_KEY_NAME: "Priced Model",
+                MODEL_KEY_PROMPT_PRICE: "$0.25/M",
+                MODEL_KEY_COMPLETION_PRICE: "$1.25/M",
+                MODEL_KEY_CONTEXT: 0,
+            },
+        ]
+
+        with patch("InquirerPy.inquirer.fuzzy", return_value=fuzzy_prompt) as mock_fuzzy:
+            selected = _select_model_interactive(mock_console, models)
+
+        choices = mock_fuzzy.call_args.kwargs["choices"]
+        assert selected == "claude-haiku-4-5-20251001"
+        assert choices[0]["name"] == f"claude-haiku-4-5-20251001  [{PRICE_NA} / {PRICE_NA}]"
+        assert choices[1]["name"] == "openrouter/free-model  [free / free]"
+        assert choices[2]["name"] == "priced-model  [$0.25/M / $1.25/M]"
+
+    def test_fetch_provider_models_missing_pricing_is_na(self):
+        from onemancompany.onboard import (
+            MODEL_KEY_COMPLETION_PRICE,
+            MODEL_KEY_PROMPT_PRICE,
+            PRICE_NA,
+            _fetch_provider_models,
+        )
+
+        mock_console = MagicMock()
+        mock_console.status.return_value.__enter__.return_value = None
+        mock_console.status.return_value.__exit__.return_value = None
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {"id": "claude-haiku-4-5-20251001", "display_name": "Claude Haiku 4.5"}
+            ]
+        }
+
+        with patch("httpx.get", return_value=mock_resp):
+            models = _fetch_provider_models(mock_console, "anthropic", "sk-ant-test")
+
+        assert models[0][MODEL_KEY_PROMPT_PRICE] == PRICE_NA
+        assert models[0][MODEL_KEY_COMPLETION_PRICE] == PRICE_NA
+
+
 class TestOpenclawLaunchShErrorHandling:
     """launch.sh must surface errors instead of silently returning 'No output returned'."""
 


### PR DESCRIPTION
## Summary
- show N/A instead of free when provider model listings omit pricing
- preserve free only for explicit zero-priced models
- avoid reformatting already formatted model price labels in the onboarding selector
- bump package version to 0.7.73 for CI version check

## Root cause
The onboarding model selector treated empty pricing fields as zero-cost by passing them through _format_price(), so Anthropic models without pricing metadata appeared as free/free.

## Validation
- pytest tests/unit/test_onboard.py tests/unit/agents/test_base.py tests/unit/agents/test_base_coverage.py tests/unit/agents/test_settings_api_key.py
