### PR TITLE
fix: product planning button must trigger EA agent (issues & KRs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.82",
+  "version": "0.7.83",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.80",
+  "version": "0.7.82",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.82"
+version = "0.7.83"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.80"
+version = "0.7.82"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/product_tools.py
+++ b/src/onemancompany/agents/product_tools.py
@@ -87,6 +87,29 @@ async def create_product_tool(
 
 
 @tool
+async def add_product_key_result(
+    product_slug: str,
+    title: str,
+    target: float,
+    unit: str = "",
+) -> str:
+    """Add a Key Result to an existing product (use during product planning).
+
+    Args:
+        product_slug: The product slug (e.g. "omc-website")
+        title: KR title (e.g. "DAU达到1000")
+        target: Numeric target value
+        unit: Unit of measurement (e.g. "users", "seconds")
+    """
+    try:
+        kr = prod.add_key_result(product_slug, title=title, target=target, unit=unit)
+        logger.debug("add_product_key_result: {} for {}", kr["id"], product_slug)
+        return f"Added key result '{title}' (target={target} {unit}) to {product_slug}"
+    except (ValueError, FileNotFoundError) as e:
+        return f"Error: {e}"
+
+
+@tool
 async def create_product_issue(
     product_slug: str,
     title: str,
@@ -789,6 +812,7 @@ async def transfer_product_ownership_tool(
 
 PRODUCT_TOOLS = [
     create_product_tool,
+    add_product_key_result,
     create_product_issue,
     update_product_issue,
     close_product_issue,

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -7444,6 +7444,25 @@ async def api_start_product_planning(slug: str) -> dict:
         product_slug=slug,
         product_id=product["id"],
     )
+
+    # Kickoff: persist a synthetic CEO message and dispatch to the EA adapter so
+    # the agent posts an opening message and can begin creating KRs/issues.
+    # Without this, the conversation would stay empty until the CEO typed something.
+    kickoff_text = f"开始为产品「{product['name']}」做规划。请先帮我梳理目标和关键结果。"
+    try:
+        kickoff_msg = await conversation_service.send_message(
+            conv.id, sender="ceo", role="CEO", text=kickoff_text,
+        )
+        task = asyncio.create_task(_dispatch_conversation_to_adapter(conv.id, kickoff_msg))
+        _active_adapter_tasks.add(task)
+        _active_adapter_by_conv[conv.id] = task
+        def _cleanup(t, _cid=conv.id):
+            _active_adapter_tasks.discard(t)
+            _active_adapter_by_conv.pop(_cid, None)
+        task.add_done_callback(_cleanup)
+    except Exception:
+        logger.exception("[product_planning] failed to kick off EA for product {}", slug)
+
     return {"conversation_id": conv.id, "existing": False}
 
 

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -7445,13 +7445,14 @@ async def api_start_product_planning(slug: str) -> dict:
         product_id=product["id"],
     )
 
-    # Kickoff: persist a synthetic CEO message and dispatch to the EA adapter so
-    # the agent posts an opening message and can begin creating KRs/issues.
-    # Without this, the conversation would stay empty until the CEO typed something.
+    # Kickoff: persist a synthetic system message and dispatch to the EA adapter
+    # so the agent posts an opening message and can begin creating KRs/issues.
+    # Use SYSTEM_SENDER so the UI doesn't render this as the CEO speaking — the
+    # prompt builder uses `role` only as a label, so EA still gets a coherent prompt.
     kickoff_text = f"开始为产品「{product['name']}」做规划。请先帮我梳理目标和关键结果。"
     try:
         kickoff_msg = await conversation_service.send_message(
-            conv.id, sender="ceo", role="CEO", text=kickoff_text,
+            conv.id, sender=SYSTEM_SENDER, role="System", text=kickoff_text,
         )
         task = asyncio.create_task(_dispatch_conversation_to_adapter(conv.id, kickoff_msg))
         _active_adapter_tasks.add(task)
@@ -7462,6 +7463,13 @@ async def api_start_product_planning(slug: str) -> dict:
         task.add_done_callback(_cleanup)
     except Exception:
         logger.exception("[product_planning] failed to kick off EA for product {}", slug)
+        try:
+            await conversation_service.send_message(
+                conv.id, sender=SYSTEM_SENDER, role="System",
+                text="(Failed to start the planning agent. Please send a message to retry.)",
+            )
+        except Exception:
+            logger.exception("[product_planning] failed to send kickoff-failure notice for {}", conv.id)
 
     return {"conversation_id": conv.id, "existing": False}
 

--- a/src/onemancompany/core/conversation_adapters.py
+++ b/src/onemancompany/core/conversation_adapters.py
@@ -129,6 +129,11 @@ def _build_conversation_prompt(
             lines.append(shared_prompt)
     elif conversation.type == ConversationType.CEO_INBOX:
         lines.append("The CEO is responding to your request. Answer their questions.")
+    elif (
+        conversation.type == ConversationType.PRODUCT
+        or conversation.type == ConversationType.PRODUCT.value
+    ):
+        lines.append(_build_product_planning_prompt(conversation))
     elif conversation.type == ConversationType.EA_CHAT:
         lines.append(
             "This is a direct chat with the CEO. You are their EA (Executive Assistant).\n"
@@ -156,6 +161,55 @@ def _build_conversation_prompt(
         lines.append(build_attachment_prompt_from_paths(list(new_message.attachments)))
     lines.append("\nPlease respond:")
     return "\n".join(lines)
+
+
+def _build_product_planning_prompt(conversation: Conversation) -> str:
+    """Build planning instructions + current product context for PRODUCT conversations."""
+    from onemancompany.core import product as prod
+    from onemancompany.core.models import IssueStatus
+
+    slug = (conversation.metadata or {}).get("product_slug", "")
+    product = prod.load_product(slug) if slug else None
+    if not product:
+        return (
+            "This is a product planning conversation, but the product could not be loaded. "
+            f"Slug: {slug!r}. Ask the CEO to clarify."
+        )
+
+    parts = [
+        "This is a product planning conversation with the CEO. You are the EA (Executive Assistant).",
+        "Your job:",
+        "  1. Clarify the product's objective and success metrics through targeted questions.",
+        "  2. Use add_product_key_result(product_slug, title, target, unit) to record measurable KRs.",
+        "  3. Use create_product_issue(product_slug, title, description, priority) to record concrete work items.",
+        "  4. Keep questions concise and one at a time. Confirm before creating each KR/issue.",
+        "",
+        f"## Current product: {product['name']}  (slug: {slug})",
+    ]
+    if product.get("description"):
+        parts.append(f"Description: {product['description']}")
+
+    krs = product.get("key_results", []) or []
+    if krs:
+        parts.append("\n### Existing Key Results")
+        for kr in krs:
+            target = kr.get("target", 0)
+            current = kr.get("current", 0)
+            parts.append(f"- {kr.get('title','')}: {current}/{target} {kr.get('unit','')}".rstrip())
+    else:
+        parts.append("\n### Existing Key Results: (none yet — propose some after clarifying with CEO)")
+
+    issues = prod.list_issues(slug) or []
+    terminal = {IssueStatus.DONE.value, IssueStatus.RELEASED.value}
+    open_issues = [i for i in issues if i.get("status") not in terminal]
+    if open_issues:
+        parts.append(f"\n### Open Issues ({len(open_issues)})")
+        for issue in open_issues[:10]:
+            parts.append(f"- [{issue.get('priority','?')}] {issue.get('title','')} ({issue.get('id','')})")
+    else:
+        parts.append("\n### Open Issues: (none yet)")
+
+    return "\n".join(parts)
 
 
 def _load_oneonone_workspace_shared_prompt() -> str:

--- a/tests/unit/api/test_routes.py
+++ b/tests/unit/api/test_routes.py
@@ -6841,3 +6841,63 @@ class TestAiSearchSettings:
         # Verify existing api_key was not wiped
         saved = yaml.safe_load(config_file.read_text())
         assert saved["talent_market"]["api_key"] == "existing-key"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/product/{slug}/planning — must kick off EA agent
+# ---------------------------------------------------------------------------
+
+
+class TestStartProductPlanning:
+    """The planning endpoint must (1) create a PRODUCT conversation AND
+    (2) dispatch a kickoff to the EA so the agent posts an opening message.
+
+    Bug: previously, clicking Start Planning created an empty conversation
+    but never invoked the EA, so no opening message appeared and no
+    issues/key-results were ever created.
+    """
+
+    @pytest.mark.asyncio
+    async def test_planning_dispatches_kickoff_to_ea(self, tmp_path, monkeypatch):
+        from onemancompany.core import product as prod
+        monkeypatch.setattr(prod, "PRODUCTS_DIR", tmp_path)
+        product = prod.create_product(name="OMC官网", owner_id="00002", description="官网")
+        slug = product["slug"]
+
+        # Patch conversation service so create() is a no-op returning a stub.
+        from onemancompany.core.conversation import Conversation, ConversationPhase
+        conv_stub = Conversation(
+            id="conv-xyz", type="product", phase=ConversationPhase.ACTIVE.value,
+            employee_id="00002", tools_enabled=True,
+            metadata={"product_slug": slug, "product_id": product["id"]},
+            created_at="2026-03-18T10:00:00",
+        )
+        svc = MagicMock()
+        svc.list_active = MagicMock(return_value=[])
+        svc.create = AsyncMock(return_value=conv_stub)
+        svc.send_message = AsyncMock()
+
+        dispatch_calls = []
+
+        async def fake_dispatch(conv_id, msg):
+            dispatch_calls.append((conv_id, msg))
+
+        with patch("onemancompany.core.conversation.get_conversation_service", return_value=svc), \
+             patch("onemancompany.api.routes._dispatch_conversation_to_adapter", side_effect=fake_dispatch):
+            app = _make_test_app()
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post(f"/api/product/{slug}/planning")
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["conversation_id"] == "conv-xyz"
+        assert data["existing"] is False
+
+        # Allow the dispatched background task to run
+        await asyncio.sleep(0.05)
+
+        # The fix: EA must be kicked off — either via a kickoff message + dispatch,
+        # or via direct adapter call. Either way at least one dispatch must occur.
+        assert len(dispatch_calls) >= 1, (
+            "planning endpoint must dispatch a kickoff to the EA so it posts an opening message"
+        )

--- a/tests/unit/api/test_routes.py
+++ b/tests/unit/api/test_routes.py
@@ -6865,17 +6865,21 @@ class TestStartProductPlanning:
         slug = product["slug"]
 
         # Patch conversation service so create() is a no-op returning a stub.
-        from onemancompany.core.conversation import Conversation, ConversationPhase
+        from onemancompany.core.conversation import Conversation, ConversationPhase, Message
         conv_stub = Conversation(
             id="conv-xyz", type="product", phase=ConversationPhase.ACTIVE.value,
             employee_id="00002", tools_enabled=True,
             metadata={"product_slug": slug, "product_id": product["id"]},
             created_at="2026-03-18T10:00:00",
         )
+
+        async def fake_send_message(conv_id, sender, role, text, attachments=None, mentions=None):
+            return Message(sender=sender, role=role, text=text, timestamp="t0")
+
         svc = MagicMock()
         svc.list_active = MagicMock(return_value=[])
         svc.create = AsyncMock(return_value=conv_stub)
-        svc.send_message = AsyncMock()
+        svc.send_message = AsyncMock(side_effect=fake_send_message)
 
         dispatch_calls = []
 
@@ -6901,3 +6905,10 @@ class TestStartProductPlanning:
         assert len(dispatch_calls) >= 1, (
             "planning endpoint must dispatch a kickoff to the EA so it posts an opening message"
         )
+        dispatched_conv_id, dispatched_msg = dispatch_calls[0]
+        assert dispatched_conv_id == "conv-xyz"
+        # The kickoff must reference the product name so EA has context.
+        assert "OMC官网" in dispatched_msg.text
+        # And it must NOT be attributed to the CEO — otherwise the UI renders
+        # text the user never typed as a CEO message bubble.
+        assert dispatched_msg.sender != "ceo"

--- a/tests/unit/core/test_conversation_adapters.py
+++ b/tests/unit/core/test_conversation_adapters.py
@@ -110,6 +110,36 @@ def test_build_conversation_prompt_with_history():
     assert "Please respond:" in prompt
 
 
+def test_build_conversation_prompt_product_planning(tmp_path, monkeypatch):
+    """PRODUCT conversations must inject product context + planning instructions."""
+    from onemancompany.core import product as prod
+    from onemancompany.core.conversation_adapters import _build_conversation_prompt
+
+    monkeypatch.setattr(prod, "PRODUCTS_DIR", tmp_path)
+    product = prod.create_product(name="OMC Website", owner_id="00002", description="官网")
+    slug = product["slug"]
+    prod.add_key_result(slug, title="DAU=1000", target=1000, unit="users")
+    prod.create_issue(slug=slug, title="加载慢", description="...", created_by="00002")
+
+    conv = Conversation(
+        id="cp1", type="product", phase="active",
+        employee_id="00002", tools_enabled=True,
+        metadata={"product_slug": slug, "product_id": product["id"]},
+        created_at="2026-03-18T10:00:00",
+    )
+    new_msg = Message(sender="ceo", role="CEO", text="开始规划", timestamp="t1")
+    prompt = _build_conversation_prompt(conv, [], new_msg)
+
+    # Must contain product context
+    assert "OMC Website" in prompt
+    assert slug in prompt
+    # Must contain planning instructions referencing the tools
+    assert "create_product_issue" in prompt
+    assert "add_product_key_result" in prompt
+    # Must not look like 1-on-1
+    assert "1-on-1 meeting" not in prompt
+
+
 def test_build_conversation_prompt_ceo_inbox():
     from onemancompany.core.conversation_adapters import _build_conversation_prompt
 

--- a/tests/unit/test_product_tools.py
+++ b/tests/unit/test_product_tools.py
@@ -17,6 +17,35 @@ def _isolate(tmp_path, monkeypatch):
     yield
 
 
+class TestAddKeyResultTool:
+    @pytest.mark.asyncio
+    async def test_add_key_result_to_existing_product(self, product_slug):
+        from onemancompany.agents.product_tools import add_product_key_result
+
+        result = await add_product_key_result.ainvoke({
+            "product_slug": product_slug,
+            "title": "DAU达到1000",
+            "target": 1000,
+            "unit": "users",
+        })
+        assert "DAU达到1000" in result
+        # Verify KR persisted to disk
+        product = prod.load_product(product_slug)
+        krs = product["key_results"]
+        assert any(kr["title"] == "DAU达到1000" and kr["target"] == 1000 for kr in krs)
+
+    @pytest.mark.asyncio
+    async def test_add_key_result_unknown_product(self):
+        from onemancompany.agents.product_tools import add_product_key_result
+
+        result = await add_product_key_result.ainvoke({
+            "product_slug": "does-not-exist",
+            "title": "X",
+            "target": 1,
+        })
+        assert "Error" in result or "not found" in result.lower()
+
+
 @pytest.fixture
 def product_slug():
     return prod.list_products()[0]["slug"]
@@ -210,9 +239,10 @@ class TestProductTools:
     async def test_product_tools_list(self):
         from onemancompany.agents.product_tools import PRODUCT_TOOLS
 
-        assert len(PRODUCT_TOOLS) == 24
+        assert len(PRODUCT_TOOLS) == 25
         names = {t.name for t in PRODUCT_TOOLS}
         assert "create_product_tool" in names
+        assert "add_product_key_result" in names
         assert "create_product_issue" in names
         assert "update_product_issue" in names
         assert "close_product_issue" in names
@@ -663,7 +693,7 @@ class TestProductTools:
         from onemancompany.agents.product_tools import PRODUCT_TOOLS
 
         assert isinstance(PRODUCT_TOOLS, list)
-        assert len(PRODUCT_TOOLS) == 24  # 7 original + 3 sprint tools
+        assert len(PRODUCT_TOOLS) == 25  # 7 original + 3 sprint tools
         for t in PRODUCT_TOOLS:
             assert hasattr(t, "ainvoke")
 


### PR DESCRIPTION
## Summary
Clicking **Start Planning** previously created an empty conversation record but never invoked the EA agent — the terminal stayed blank and no issues / KRs were ever created.

Three stacked problems, fixed together:

1. **No kickoff** — `POST /api/product/{slug}/planning` now persists a kickoff CEO message and dispatches it to the EA via `_dispatch_conversation_to_adapter`, reusing the same active-task bookkeeping as the regular `/api/conversation/{id}/message` endpoint.
2. **No PRODUCT branch in prompt builder** — `_build_conversation_prompt` gains a `ConversationType.PRODUCT` case that injects product objective, existing KRs, open issues, and explicit instructions to clarify-then-call `create_product_issue` / `add_product_key_result`.
3. **Missing tool** — new `add_product_key_result` `@tool` wraps `prod.add_key_result`, so the EA can add KRs to an **existing** product during planning (previously KRs could only be added at product-creation time via `create_product_tool`).

## Test plan
- [x] `tests/unit/test_product_tools.py::TestAddKeyResultTool` — tool happy-path + unknown product
- [x] `tests/unit/test_product_tools.py::test_product_tools_list` — PRODUCT_TOOLS count bumped 24 → 25
- [x] `tests/unit/core/test_conversation_adapters.py::test_build_conversation_prompt_product_planning` — prompt contains product context + tool names
- [x] `tests/unit/api/test_routes.py::TestStartProductPlanning::test_planning_dispatches_kickoff_to_ea` — endpoint dispatches kickoff to adapter
- [x] Full unit suite: 4299 passed, 2 skipped (no regressions)
- [ ] Manual: open a product, click **Start Planning**, confirm EA posts an opening message and creates issues/KRs as the conversation progresses

🤖 Generated with [Claude Code](https://claude.com/claude-code)