### PR TITLE
ci: add lint + security workflows, modernize CI with uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
@@ -12,14 +16,16 @@ jobs:
         with:
           fetch-depth: 0  # need full history for version comparison
 
-      - uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: '3.12'
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
 
       - name: Install dependencies
-        run: |
-          pip install -e .
-          pip install pytest pytest-asyncio pytest-timeout
+        run: uv sync --extra sandbox --group dev
 
       - name: Version bump check
         run: |
@@ -27,7 +33,7 @@ jobs:
           MAIN_VERSION=$(git show origin/main:pyproject.toml | grep '^version = ' | head -1 | sed 's/version = "//;s/"//')
           echo "PR version: $PR_VERSION"
           echo "Main version: $MAIN_VERSION"
-          python3 -c "
+          uv run python -c "
           from packaging.version import Version
           pr, main = Version('$PR_VERSION'), Version('$MAIN_VERSION')
           if pr <= main:
@@ -36,10 +42,13 @@ jobs:
           "
 
       - name: Compilation check
-        run: python -c "from onemancompany.api.routes import router; print('OK')"
+        run: uv run python -c "from onemancompany.api.routes import router; print('OK')"
 
       - name: Unit tests
-        run: python -m pytest tests/unit/ -x -q
+        run: uv run python -m pytest tests/unit/ -x -q
+
+      - name: Integration tests
+        run: uv run python -m pytest tests/integration/ -x -q
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,39 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need history to diff against the base branch
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Collect changed Python files
+        id: changed
+        run: |
+          git fetch --no-tags origin "${{ github.base_ref }}"
+          FILES=$(git diff --name-only --diff-filter=ACMR \
+            "origin/${{ github.base_ref }}...HEAD" -- '*.py' | tr '\n' ' ')
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+          echo "Changed Python files: ${FILES:-<none>}"
+
+      - name: Ruff lint (changed files only)
+        if: steps.changed.outputs.files != ''
+        run: uvx ruff check ${{ steps.changed.outputs.files }}
+
+      - name: Ruff format check (changed files only)
+        if: steps.changed.outputs.files != ''
+        run: uvx ruff format --check ${{ steps.changed.outputs.files }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,46 @@
+name: Security
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'  # weekly, Monday 06:00 UTC
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Export resolved dependencies
+        run: uv export --no-emit-project --all-extras -o requirements.txt
+
+      # Report-only for now: the project carries known transitive vulns that
+      # require dependency bumps to clear. Surfaces findings without blocking
+      # PRs; flip to blocking once the backlog is triaged.
+      - name: Audit dependencies for known vulnerabilities
+        continue-on-error: true
+        run: uvx pip-audit -r requirements.txt
+
+  secret-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # gitleaks scans full git history
+
+      - name: Scan for committed secrets
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.85"
+version = "0.7.86"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [
@@ -72,3 +72,11 @@ branch = "main"
 changelog_file = "CHANGELOG.md"
 build_command = ""
 commit_message = "chore(release): {version}"
+
+[tool.ruff]
+target-version = "py312"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+ignore = ["E501"]  # line length is enforced by the formatter, not the linter


### PR DESCRIPTION
## Summary
Extends the existing CI/CD pipeline (left ci.yml's version gate, test.yml, npm-publish.yml, docs.yml, and the Claude workflows in place) with two new workflows and modernizes the main CI job.

- **`lint.yml`** (new) — runs `ruff check` + `ruff format --check`, scoped to only the Python files changed versus the base branch. The repo currently has ~598 lint findings and 247 files needing reformat, so a whole-repo gate would block every PR; diff-scoped linting holds new code to standard without forcing a mass reformat.
- **`security.yml`** (new) — `pip-audit` on resolved deps plus a `gitleaks` secret scan, on PR/push to main and a weekly Monday cron. The dependency audit is **report-only** (`continue-on-error`) because the project carries 23 known transitive vulns that need dependency bumps to clear — surfacing them without blocking PRs. Secret scanning is blocking.
- **`ci.yml`** (modernized) — switched install to `uv` with caching, added a `concurrency` group to cancel stale runs, and added an **integration test** step (verified the 11 integration tests pass offline) alongside the existing unit tests. The version-gate, compilation check, and frontend syntax check are unchanged.
- **`pyproject.toml`** — added a minimal `[tool.ruff]` config (E/F/I/UP/B, line-length 88) and bumped version `0.7.85 → 0.7.86` to satisfy the existing CI version gate.

## Notes
- `uv.lock` was deliberately left untouched. It's currently stale (pins the project at `0.2.383` and is missing recently-added deps like `datasets`/`ddgs`); re-locking is a separate ~1000-line concern and out of scope here. The workflows use non-frozen `uv sync`/`uv export` so they tolerate the stale lock.
- No new secrets required. `gitleaks-action` uses the default `GITHUB_TOKEN`; `NPM_TOKEN` (already configured for publishing) is unaffected.

## Test plan
- [ ] CI workflow runs green on this PR (unit + integration tests, version gate)
- [ ] Lint workflow only inspects changed `.py` files (this PR changes none, so lint steps skip)
- [ ] Security workflow: gitleaks passes, pip-audit reports findings without failing
- [ ] Confirm consider following up with a dedicated PR to bump vulnerable deps + refresh uv.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)