### PR TITLE
fix: /clear wipes EA chat history on disk (was oneonone-only)

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -2745,10 +2745,18 @@ class AppController {
           this._ceoTerm?.appendMessage({ role: 'system', text: '/clear only works in EA chat.', source: 'system' });
           return;
         }
-        // Forget old conversation and create a new one
-        this._eaChatConvId = null;
-        localStorage.removeItem('ea-chat-conv-id');
-        await this._ensureEaChatConversation();
+        // Clear history on disk (SSOT) for the current conversation, keeping the
+        // same conv_id so a page refresh does not resurrect the old messages.
+        if (!this._eaChatConvId) {
+          await this._ensureEaChatConversation();
+        }
+        if (this._eaChatConvId) {
+          try {
+            await fetch(`/api/conversation/${this._eaChatConvId}/clear`, { method: 'POST' });
+          } catch (e) {
+            console.error('Failed to clear EA chat history:', e);
+          }
+        }
         this._ceoTerm?.showChat(this._EA_CHAT, []);
       }},
     ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.94"
+version = "0.7.95"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -6801,14 +6801,19 @@ async def close_conversation(conv_id: str, wait_hooks: bool = False) -> dict:
 
 @router.post("/api/conversation/{conv_id}/clear")
 async def clear_conversation_history(conv_id: str) -> dict:
-    """Clear all 1-on-1 message history for the current conversation's employee."""
+    """Clear message history on disk for conversations of the same type/employee.
+
+    Supports both ``oneonone`` (1-on-1 chat) and ``ea_chat`` (CEO console EA chat).
+    Clearing writes an empty list to ``messages.yaml`` so a page refresh — which is
+    disk-sourced — does not resurrect the cleared history (磁盘即唯一真相源).
+    """
     try:
         conv = _get_conv_svc().get(conv_id)
     except ValueError:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    if conv.type != "oneonone":
-        raise HTTPException(status_code=400, detail="Clear history is only supported for oneonone conversations")
+    if conv.type not in ("oneonone", "ea_chat"):
+        raise HTTPException(status_code=400, detail="Clear history is only supported for oneonone and ea_chat conversations")
     if not conv.employee_id:
         raise HTTPException(status_code=400, detail="Conversation has no employee_id")
 
@@ -6836,7 +6841,7 @@ async def clear_conversation_history(conv_id: str) -> dict:
         except Exception:
             logger.warning("[conversation] skip unreadable meta when clearing history: {}", conv_dir)
             continue
-        if c.type != "oneonone" or c.employee_id != conv.employee_id:
+        if c.type != conv.type or c.employee_id != conv.employee_id:
             continue
         scanned += 1
         msg_path = conv_dir / "messages.yaml"
@@ -6844,10 +6849,11 @@ async def clear_conversation_history(conv_id: str) -> dict:
             write_text_utf(msg_path, "[]\n")
             cleared += 1
 
-    # Keep legacy 1-on-1 history endpoint consistent.
-    legacy_history_path = conversation_core.EMPLOYEES_DIR / conv.employee_id / "oneonone_history.yaml"
-    if legacy_history_path.exists():
-        write_text_utf(legacy_history_path, "[]\n")
+    # Keep legacy 1-on-1 history endpoint consistent (oneonone only).
+    if conv.type == "oneonone":
+        legacy_history_path = conversation_core.EMPLOYEES_DIR / conv.employee_id / "oneonone_history.yaml"
+        if legacy_history_path.exists():
+            write_text_utf(legacy_history_path, "[]\n")
 
     return {
         "status": "cleared",

--- a/tests/integration/test_conversation_api.py
+++ b/tests/integration/test_conversation_api.py
@@ -184,6 +184,40 @@ async def test_clear_current_agent_oneonone_history(client, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_clear_ea_chat_history_persists(client, tmp_path):
+    """Regression: CEO console /clear must wipe ea_chat history on disk.
+
+    Previously /clear only touched the frontend view and the clear endpoint
+    rejected ea_chat, so a page refresh (disk-sourced) resurrected the history.
+    """
+    resp = await client.post("/api/conversation/create", json={
+        "type": "ea_chat",
+        "employee_id": "00004",
+        "tools_enabled": True,
+    })
+    assert resp.status_code == 200
+    conv_id = resp.json()["id"]
+
+    # Seed on-disk history (what the CEO wants cleared).
+    msg_path = tmp_path / "employees" / "00004" / "conversations" / conv_id / "messages.yaml"
+    msg_path.parent.mkdir(parents=True, exist_ok=True)
+    msg_path.write_text(yaml.dump([
+        {"sender": "ceo", "role": "CEO", "text": "old chat", "timestamp": "2026-03-19T00:00:00+00:00", "attachments": []},
+    ], allow_unicode=True), encoding="utf-8")
+
+    # Clear now accepts ea_chat and wipes disk.
+    resp = await client.post(f"/api/conversation/{conv_id}/clear")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "cleared"
+
+    # Disk is empty → a refresh (which reads messages from disk) sees nothing.
+    assert yaml.safe_load(msg_path.read_text(encoding="utf-8")) == []
+    resp = await client.get(f"/api/conversation/{conv_id}/messages")
+    assert resp.status_code == 200
+    assert resp.json().get("messages", []) == []
+
+
+@pytest.mark.asyncio
 async def test_create_invalid_type(client):
     resp = await client.post("/api/conversation/create", json={
         "type": "invalid", "employee_id": "00100",


### PR DESCRIPTION
Split from #387 (issue ②) — one concern per PR.

## Problem
CEO console `/clear` only cleared the frontend view and swapped to a new conversation, but `_ensureEaChatConversation()` reuses the existing `ea_chat` thread, and the disk `messages.yaml` was never touched. A page refresh (disk-sourced) resurrected the old chat. The real clear endpoint (`/api/conversation/{id}/clear`) rejected any non-`oneonone` type, so the UI could never actually clear an EA chat.

## Fix
- **Backend:** generalize `/api/conversation/{conv_id}/clear` to also handle `ea_chat` (filter by `c.type == conv.type`); the legacy `oneonone_history.yaml` wipe stays oneonone-only.
- **Frontend:** `/clear` now POSTs to the endpoint (disk = SSOT) and keeps the same `conv_id`, so a refresh sees an empty thread.

## Tests
`tests/integration/test_conversation_api.py` — ea_chat `/clear` wipes disk and a disk-sourced re-read sees empty (11 passed).

## Verification
Confirmed the root cause still exists on current `main` before splitting: the clear endpoint still had `if conv.type != "oneonone": raise 400`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)