### PR TITLE
feat: CEO can abandon/redirect a running task

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -10012,6 +10012,10 @@ class AppController {
           <button class="pixel-btn" id="followup-btn" style="font-size:6px;padding:4px 10px;">+ Follow-up Task</button>
           <div id="followup-input-area" class="hidden" style="margin-top:6px;">
             <textarea id="followup-instructions" class="followup-textarea" placeholder="Enter follow-up instructions..." rows="3"></textarea>
+            <label style="display:flex;align-items:center;gap:4px;margin-top:4px;font-size:6px;color:#ccc;cursor:pointer;">
+              <input type="checkbox" id="followup-abandon" style="width:10px;height:10px;">
+              Abandon current task &amp; redirect (stop the running loop first)
+            </label>
             <div style="margin-top:4px;display:flex;gap:4px;">
               <button class="pixel-btn" id="followup-submit" style="font-size:6px;padding:3px 8px;">Send</button>
               <button class="pixel-btn secondary" id="followup-cancel" style="font-size:6px;padding:3px 8px;">Cancel</button>
@@ -10207,7 +10211,8 @@ class AppController {
             const textarea = document.getElementById('followup-instructions');
             const text = textarea?.value?.trim();
             if (!text) return;
-            this._submitFollowup(iterationId, text);
+            const abandonCurrent = document.getElementById('followup-abandon')?.checked || false;
+            this._submitFollowup(iterationId, text, abandonCurrent);
           });
         }
       })
@@ -10243,7 +10248,7 @@ class AppController {
       });
   }
 
-  _submitFollowup(projectId, instructions) {
+  _submitFollowup(projectId, instructions, abandonCurrent = false) {
     if (!this._checkCooldown('submitFollowup')) return;
     const submitBtn = document.getElementById('followup-submit');
     if (submitBtn) { submitBtn.disabled = true; submitBtn.textContent = '⏳ Submitting...'; }
@@ -10251,7 +10256,7 @@ class AppController {
     fetch(`/api/task/${encodeURIComponent(projectId)}/followup`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ instructions }),
+      body: JSON.stringify({ instructions, abandon_current: abandonCurrent }),
     })
       .then(r => r.json())
       .then(data => {
@@ -10259,7 +10264,9 @@ class AppController {
           this.logEntry('CEO', `Follow-up task failed: ${data.error}`, 'error');
           if (submitBtn) { submitBtn.disabled = false; submitBtn.textContent = 'Send'; }
         } else {
-          this.logEntry('CEO', `Follow-up instructions added, tasks routed to EA`, 'ceo');
+          this.logEntry('CEO', abandonCurrent
+            ? `Abandoned current task, redirected — tasks routed to EA`
+            : `Follow-up instructions added, tasks routed to EA`, 'ceo');
           const modal = document.getElementById('project-modal');
           if (modal) modal.classList.add('hidden');
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.95",
+  "version": "0.7.96",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.95"
+version = "0.7.96"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.94"
+version = "0.7.95"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/api/routes.py
+++ b/src/onemancompany/api/routes.py
@@ -670,6 +670,13 @@ async def task_followup(project_id: str, body: dict) -> dict:
     if not instructions:
         return {"error": "Empty instructions"}
 
+    # CEO "abandon / redirect" intent: when true, cancel the currently-running
+    # task loop for this project before dispatching the new instructions.
+    # Without this, a follow-up only *queues* behind the running task (e.g. a
+    # clone-retry loop), so the old task keeps running and the new direction
+    # never takes effect until the old one finishes on its own.
+    abandon_current = bool(body.get("abandon_current") or body.get("redirect"))
+
     # Load project from filesystem (persistent, not in-memory)
     from pathlib import Path
     from onemancompany.core.project_archive import _resolve_and_load
@@ -683,6 +690,19 @@ async def task_followup(project_id: str, body: dict) -> dict:
         raise HTTPException(status_code=404, detail="Project not found")
 
     original_task = doc.get("task", "")
+
+    # Abandon/redirect: cancel the running task loop for this project up front so
+    # the new instructions dispatch immediately instead of queuing behind it.
+    # abort_project cancels the running asyncio.Task (CancelledError → CANCELLED);
+    # _run_task's finally then reschedules the employee, picking up the new node.
+    if abandon_current:
+        from onemancompany.core.agent_loop import employee_manager as _abort_mgr
+        cancelled_count = _abort_mgr.abort_project(project_id)
+        logger.info(
+            "[FOLLOWUP] abandon_current: cancelled {} task(s) for project {} before redirect",
+            cancelled_count, project_id,
+        )
+        append_action(project_id, "ceo", "abandon current task", instructions[:200])
 
     # Load task tree and collect all previous work results
     tree_path = Path(pdir) / TASK_TREE_FILENAME
@@ -719,21 +739,38 @@ async def task_followup(project_id: str, body: dict) -> dict:
                          project_id)
 
     # Build follow-up task for assignee
-    context_parts = [
-        f"CEO has added follow-up instructions to a completed task:\n",
-        f"Original task: {original_task}\n",
-    ]
-    if work_summary_lines:
-        context_parts.append(f"Previous work results:\n" + "\n".join(work_summary_lines) + "\n")
-    context_parts.append(f"CEO follow-up instructions: {instructions}\n")
     attach_info = _build_attachment_prompt(body.get("attachments") or [])
-    if attach_info:
-        context_parts.append(attach_info.lstrip("\n") + "\n")
-    context_parts.append(
-        f"\nBuild on the existing work — do NOT redo completed subtasks unless the CEO explicitly asks."
-        f" Use dispatch_child() if subtasks are needed.\n\n"
-        f"[Project ID: {project_id}] [Project workspace: {pdir}]"
-    )
+    if abandon_current:
+        context_parts = [
+            "CEO has ABANDONED the previous task and given a new direction.\n",
+            f"Previous task (now cancelled): {original_task}\n",
+        ]
+        if work_summary_lines:
+            context_parts.append("Work done before abandonment (reference only):\n" + "\n".join(work_summary_lines) + "\n")
+        context_parts.append(f"CEO new instructions: {instructions}\n")
+        if attach_info:
+            context_parts.append(attach_info.lstrip("\n") + "\n")
+        context_parts.append(
+            "\nStop the previous approach entirely. Do NOT resume or retry the cancelled task."
+            " Proceed with the new instructions, reusing any useful prior work."
+            " Use dispatch_child() if subtasks are needed.\n\n"
+            f"[Project ID: {project_id}] [Project workspace: {pdir}]"
+        )
+    else:
+        context_parts = [
+            f"CEO has added follow-up instructions to a completed task:\n",
+            f"Original task: {original_task}\n",
+        ]
+        if work_summary_lines:
+            context_parts.append(f"Previous work results:\n" + "\n".join(work_summary_lines) + "\n")
+        context_parts.append(f"CEO follow-up instructions: {instructions}\n")
+        if attach_info:
+            context_parts.append(attach_info.lstrip("\n") + "\n")
+        context_parts.append(
+            f"\nBuild on the existing work — do NOT redo completed subtasks unless the CEO explicitly asks."
+            f" Use dispatch_child() if subtasks are needed.\n\n"
+            f"[Project ID: {project_id}] [Project workspace: {pdir}]"
+        )
     followup_task = "\n".join(context_parts)
 
     # Append to existing tree (or create new if none exists)

--- a/tests/unit/api/test_product_followup.py
+++ b/tests/unit/api/test_product_followup.py
@@ -226,3 +226,81 @@ async def test_task_followup_falls_back_to_ea_when_product_slug_not_found(tmp_pa
 
     assert result["status"] == "ok"
     assert mock_em.schedule_node.call_args[0][0] == EA_ID
+
+
+# ---------------------------------------------------------------------------
+# Issue #1: abandon_current must cancel the running task before redirecting
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_followup_abandon_current_aborts_project(tmp_path):
+    """With abandon_current=True, the running task loop is cancelled via
+    abort_project BEFORE the new instructions are scheduled."""
+    from onemancompany.api.routes import task_followup
+
+    pdir = tmp_path / PROJECT_ID
+    pdir.mkdir()
+    tree = _make_tree_with_root()
+    (pdir / TASK_TREE_FILENAME).write_text("{}")
+
+    project_doc = _make_project_doc(product_id="")
+
+    mock_em = MagicMock()
+    mock_em.abort_project = MagicMock(return_value=1)
+    mock_em.schedule_node = MagicMock()
+    mock_em._schedule_next = MagicMock()
+
+    with patch("onemancompany.core.project_archive.get_project_dir", return_value=str(pdir)), \
+         patch("onemancompany.core.project_archive._resolve_and_load", return_value=("v1", project_doc, "key1")), \
+         patch("onemancompany.core.project_archive.append_action"), \
+         patch("onemancompany.core.task_tree.get_tree", return_value=tree), \
+         patch("onemancompany.core.vessel._save_project_tree"), \
+         patch("onemancompany.core.agent_loop.get_agent_loop", return_value=MagicMock()), \
+         patch("onemancompany.core.agent_loop.employee_manager", mock_em), \
+         patch("onemancompany.core.project_archive._save_resolved"), \
+         patch("onemancompany.api.routes.event_bus", AsyncMock()):
+
+        result = await task_followup(
+            PROJECT_ID, {"instructions": "Stop cloning, use the repo I cloned", "abandon_current": True}
+        )
+
+    assert result["status"] == "ok"
+    # The running loop must be cancelled for this project.
+    mock_em.abort_project.assert_called_once_with(PROJECT_ID)
+    # And the new instructions still get scheduled (to EA here).
+    assert mock_em.schedule_node.call_args[0][0] == EA_ID
+
+
+@pytest.mark.asyncio
+async def test_task_followup_without_abandon_does_not_abort(tmp_path):
+    """A normal follow-up (no abandon_current) must NOT cancel anything —
+    it stays purely additive."""
+    from onemancompany.api.routes import task_followup
+
+    pdir = tmp_path / PROJECT_ID
+    pdir.mkdir()
+    tree = _make_tree_with_root()
+    (pdir / TASK_TREE_FILENAME).write_text("{}")
+
+    project_doc = _make_project_doc(product_id="")
+
+    mock_em = MagicMock()
+    mock_em.abort_project = MagicMock(return_value=0)
+    mock_em.schedule_node = MagicMock()
+    mock_em._schedule_next = MagicMock()
+
+    with patch("onemancompany.core.project_archive.get_project_dir", return_value=str(pdir)), \
+         patch("onemancompany.core.project_archive._resolve_and_load", return_value=("v1", project_doc, "key1")), \
+         patch("onemancompany.core.project_archive.append_action"), \
+         patch("onemancompany.core.task_tree.get_tree", return_value=tree), \
+         patch("onemancompany.core.vessel._save_project_tree"), \
+         patch("onemancompany.core.agent_loop.get_agent_loop", return_value=MagicMock()), \
+         patch("onemancompany.core.agent_loop.employee_manager", mock_em), \
+         patch("onemancompany.core.project_archive._save_resolved"), \
+         patch("onemancompany.api.routes.event_bus", AsyncMock()):
+
+        result = await task_followup(PROJECT_ID, {"instructions": "Also add a README"})
+
+    assert result["status"] == "ok"
+    mock_em.abort_project.assert_not_called()


### PR DESCRIPTION
Split from #387 (issue ①) — one concern per PR.

## Problem
A CEO natural-language "abandon/pivot" instruction went through `/api/task/{id}/followup`, which only *appended* a new node and called `_schedule_next`. That short-circuits while the employee is still in `_running_tasks`, so the new instruction queued behind the running task (e.g. a `git clone` retry loop) and never took effect. The cancellation machinery existed (`abort_project` → `CancelledError` → `CANCELLED`) but was only reachable from the abort buttons.

## Fix
`followup` accepts `abandon_current` (alias `redirect`). When set, it calls `employee_manager.abort_project(project_id)` up front to cancel the running loop; `_run_task`'s `finally` then reschedules the employee and picks up the new node. Context wording switches to an "abandoned, new direction" framing. Frontend gains an "Abandon current task & redirect" checkbox on the follow-up form.

Reuses the existing cancellation machinery — no new subsystem.

## Tests
`tests/unit/api/test_product_followup.py` — `abandon_current` calls `abort_project`; a plain follow-up stays additive (6 passed).

## Notes
- Rebased onto current `main`; the follow-up context builder was merged with main's `_build_attachment_prompt` handling so attachments work in both the abandon and additive branches.
- Confirmed the root cause still exists on `main` before splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)