### PR TITLE
feat: stream self-hosted Claude session activity live

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.94",
+  "version": "0.7.95",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.94"
+version = "0.7.95"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/claude_session.py
+++ b/src/onemancompany/core/claude_session.py
@@ -23,6 +23,7 @@ import asyncio
 import json
 import os
 import uuid
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -55,6 +56,18 @@ def write_llm_trace(project_id: str, entry: dict) -> None:
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
     except OSError as e:
         logger.debug("[llm-trace] write failed for project={}: {}", project_id, e)
+
+
+def _fmt_tool_call(name: str, args: dict) -> str:
+    """Compact one-line summary of a tool call for live on_log signals."""
+    try:
+        compact = json.dumps(args, ensure_ascii=False)
+    except (TypeError, ValueError):
+        compact = str(args)
+    if len(compact) > 300:
+        compact = compact[:300] + "…"
+    return f"{name}({compact})"
+
 
 # Single-file constants
 SESSIONS_FILENAME = "sessions.json"
@@ -502,11 +515,20 @@ class ClaudeDaemon:
         except Exception as e:
             logger.debug("[debug_trace] daemon write failed for {}: {}", self.employee_id, e)
 
-    async def send_prompt(self, prompt: str, timeout: int = 600) -> dict:
+    async def send_prompt(
+        self,
+        prompt: str,
+        timeout: int = 600,
+        on_log: Callable[[str, object], None] | None = None,
+    ) -> dict:
         """Send a prompt and collect the full response.
 
         Reads NDJSON lines from stdout until a ``result`` message appears.
         Returns dict with keys: output, model, input_tokens, output_tokens.
+
+        ``on_log(type, content)`` is called live per LLM step (assistant text,
+        tool_call, tool_result) so the CEO can see the self-hosted agent working
+        instead of a long silence. Mirrors the LangChain path's on_log schema.
         """
         if not self.alive:
             raise RuntimeError("Daemon process is not running")
@@ -575,8 +597,22 @@ class ClaudeDaemon:
                         self._trace_assistant_message(message)
                         content = message.get("content", [])
                         for block in content:
-                            if isinstance(block, dict) and block.get(BLOCK_KEY_TYPE) == BLOCK_TYPE_TEXT:
-                                text_parts.append(block.get(BLOCK_KEY_TEXT, ""))
+                            if not isinstance(block, dict):
+                                continue
+                            _btype = block.get(BLOCK_KEY_TYPE)
+                            if _btype == BLOCK_TYPE_TEXT:
+                                _text = block.get(BLOCK_KEY_TEXT, "")
+                                text_parts.append(_text)
+                                if on_log and _text.strip():
+                                    on_log("llm_output", _text)
+                            elif _btype == "tool_use" and on_log:
+                                _tname = block.get("name", "tool")
+                                _targs = block.get("input", {})
+                                on_log("tool_call", {
+                                    "tool_name": _tname,
+                                    "tool_args": _targs,
+                                    "content": _fmt_tool_call(_tname, _targs),
+                                })
                         # Extract usage
                         usage = message.get("usage", {})
                         if usage.get("input_tokens"):
@@ -587,6 +623,25 @@ class ClaudeDaemon:
                             model_used = message["model"]
                         # SFT: capture assistant message with tool_calls
                         self._accumulate_debug_assistant(debug_messages, message)
+
+                    elif msg_type == "user" and on_log:
+                        # Tool results come back as user-role messages; surface
+                        # them live so the CEO sees tool activity completing.
+                        umsg = msg_data.get("message", {})
+                        for block in umsg.get("content", []) or []:
+                            if not isinstance(block, dict) or block.get(BLOCK_KEY_TYPE) != "tool_result":
+                                continue
+                            _res = block.get("content", "")
+                            if isinstance(_res, list):
+                                _res = " ".join(
+                                    b.get("text", "") for b in _res
+                                    if isinstance(b, dict) and b.get("text")
+                                )
+                            _res = str(_res)
+                            on_log("tool_result", {
+                                "tool_result": _res,
+                                "content": _res[:500],
+                            })
 
                     elif msg_type == "result":
                         # Final result — response complete
@@ -763,6 +818,7 @@ async def run_claude_session(
     max_turns: int = 50,
     timeout: int = 600,
     task_id: str = "",
+    on_log: Callable[[str, object], None] | None = None,
 ) -> dict:
     """Send a prompt to the employee's persistent Claude daemon.
 
@@ -779,7 +835,7 @@ async def run_claude_session(
             daemon = await _get_or_start_daemon(
                 employee_id, project_id, work_dir, max_turns, task_id,
             )
-            result = await daemon.send_prompt(prompt, timeout=timeout)
+            result = await daemon.send_prompt(prompt, timeout=timeout, on_log=on_log)
 
             # If daemon died during execution, try once more with restart
             if not daemon.alive and not result.get("output"):
@@ -790,7 +846,7 @@ async def run_claude_session(
                 daemon = await _get_or_start_daemon(
                     employee_id, project_id, work_dir, max_turns, task_id,
                 )
-                result = await daemon.send_prompt(prompt, timeout=timeout)
+                result = await daemon.send_prompt(prompt, timeout=timeout, on_log=on_log)
 
             return result
         except FileNotFoundError:

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -575,6 +575,7 @@ class ClaudeSessionExecutor(Launcher):
             prompt=task_description,
             work_dir=context.work_dir,
             task_id=context.task_id,
+            on_log=on_log,
         )
         output = result.get("output", "")
         error: str | None = None

--- a/tests/unit/core/test_agent_loop.py
+++ b/tests/unit/core/test_agent_loop.py
@@ -175,7 +175,7 @@ class TestClaudeSessionLauncher:
             mock_run.return_value = {"output": "Claude output", "model": "test", "input_tokens": 10, "output_tokens": 5}
             on_log = MagicMock()
             result = await launcher.execute("Do task", ctx, on_log=on_log)
-            mock_run.assert_called_once_with("emp01", "proj1", prompt="Do task", work_dir="/tmp/work", task_id="")
+            mock_run.assert_called_once_with("emp01", "proj1", prompt="Do task", work_dir="/tmp/work", task_id="", on_log=on_log)
             assert result.output == "Claude output"
             on_log.assert_called_once()
 
@@ -186,7 +186,7 @@ class TestClaudeSessionLauncher:
         with patch("onemancompany.core.claude_session.run_claude_session", new_callable=AsyncMock) as mock_run:
             mock_run.return_value = {"output": "output", "model": "test", "input_tokens": 0, "output_tokens": 0}
             result = await launcher.execute("Do task", ctx)
-            mock_run.assert_called_once_with("emp01", "default", prompt="Do task", work_dir="", task_id="")
+            mock_run.assert_called_once_with("emp01", "default", prompt="Do task", work_dir="", task_id="", on_log=None)
             assert result.output == "output"
 
     @pytest.mark.asyncio

--- a/tests/unit/core/test_claude_session_coverage.py
+++ b/tests/unit/core/test_claude_session_coverage.py
@@ -231,6 +231,64 @@ class TestSendPrompt:
         assert resp["model"] == "claude-3"
 
     @pytest.mark.asyncio
+    async def test_send_prompt_streams_on_log(self, monkeypatch):
+        """Issue #3: send_prompt emits live on_log per step (assistant text,
+        tool_call, tool_result) so the self-hosted path is observable."""
+        from onemancompany.core.claude_session import ClaudeDaemon
+        monkeypatch.setattr("onemancompany.core.config.IS_DEBUG", False)
+
+        daemon = ClaudeDaemon("emp1", "proj1", "sid1", True)
+        mock_proc = MagicMock()
+        mock_proc.returncode = None
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdin.write = MagicMock()
+        mock_proc.stdin.drain = AsyncMock()
+
+        lines = [
+            json.dumps({"type": "assistant", "message": {
+                "model": "claude-3",
+                "usage": {"input_tokens": 5, "output_tokens": 2},
+                "content": [
+                    {"type": "text", "text": "Cloning the repo now"},
+                    {"type": "tool_use", "name": "bash",
+                     "input": {"command": "git clone https://example/x"}},
+                ],
+            }}).encode() + b"\n",
+            json.dumps({"type": "user", "message": {
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "t1",
+                     "content": "fatal: could not resolve host"},
+                ],
+            }}).encode() + b"\n",
+            json.dumps({"type": "result", "result": "gave up",
+                        "output_tokens": 2}).encode() + b"\n",
+        ]
+        mock_proc.stdout = MagicMock()
+        mock_proc.stdout.readline = AsyncMock(side_effect=lines)
+        daemon.proc = mock_proc
+
+        events: list[tuple[str, object]] = []
+
+        def _on_log(kind, content):
+            events.append((kind, content))
+
+        with patch("onemancompany.core.claude_session._mark_session_used"):
+            resp = await daemon.send_prompt("clone the repo", timeout=5, on_log=_on_log)
+
+        assert resp["output"] == "gave up"
+        kinds = [k for k, _ in events]
+        assert "llm_output" in kinds
+        assert "tool_call" in kinds
+        assert "tool_result" in kinds
+        # tool_call carries a structured dict with a one-line summary.
+        tool_call = next(c for k, c in events if k == "tool_call")
+        assert tool_call["tool_name"] == "bash"
+        assert "git clone" in tool_call["content"]
+        # tool_result surfaces the failure so a stuck/looping clone is visible.
+        tool_result = next(c for k, c in events if k == "tool_result")
+        assert "could not resolve host" in tool_result["content"]
+
+    @pytest.mark.asyncio
     async def test_send_prompt_timeout(self, monkeypatch):
         import onemancompany.core.claude_session as cs_mod
         from onemancompany.core.claude_session import ClaudeDaemon


### PR DESCRIPTION
Split from #387 (issue ③) — one concern per PR.

## Problem
The self-hosted `ClaudeSessionExecutor` path emitted zero live signal for a task's whole duration — `send_prompt` read the NDJSON stream but routed it only to a debug-gated disk trace, calling `on_log` once at the end. Long/stuck tasks looked identical to dead ones.

## Fix
`ClaudeDaemon.send_prompt` now accepts `on_log` and emits `llm_output` / `tool_call` / `tool_result` per step (same schema as the LangChain path), threaded through `run_claude_session` and `ClaudeSessionExecutor.execute`. Rides the existing `AGENT_LOG → event_broadcaster → event-adapter` rails — no new subsystem. Frontend can derive a "last active Ns ago" heartbeat from event timestamps.

## Tests
`tests/unit/core/test_claude_session_coverage.py` — `send_prompt` streams `llm_output`/`tool_call`/`tool_result` to `on_log` (196 passed in the touched-file suites).

## Notes
- Rebased onto current `main`. This path is still active post-ACP (#361) — the ACP `claude_cli_backend` also wraps `run_claude_session`, so the observability threading benefits both.
- Confirmed the gap still exists on `main` before splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)