### PR TITLE
fix: prevent duplicate products via entity-code propagation (#395)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.99",
+  "version": "0.7.100",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.100",
+  "version": "0.7.101",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.100"
+version = "0.7.101"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.99"
+version = "0.7.100"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/product_tools.py
+++ b/src/onemancompany/agents/product_tools.py
@@ -46,23 +46,53 @@ async def create_product_tool(
     description: str,
     key_results: str = "",
     owner_id: str = "",
+    product_code: str = "",
 ) -> str:
-    """Create a new product with optional key results.
+    """Create a new product with optional key results — or link to an existing one.
+
+    If you were handed a product that already exists (an upstream task mentions a
+    Product code like ``prod_xxxxxxxx``, or you can see one in the task context),
+    pass it as ``product_code`` — this links to that product instead of creating a
+    duplicate. Creating by ``name`` is idempotent: if a product with the same name
+    already exists, you get linked to it, not a second copy (#395).
 
     Args:
         name: Product name (e.g. "OneManCompany官网")
         description: Product objective/description
         key_results: Semicolon-separated KRs, each as "title|target|unit" (e.g. "DAU达到1000|1000|users;页面加载<2s|2.0|seconds")
         owner_id: Employee ID of the product owner (optional, defaults to caller)
+        product_code: Existing product code (prod_...) to link to instead of creating. Optional.
     """
     caller = _resolve_caller_id()
     oid = owner_id or caller
+    from onemancompany.agents.tree_tools import set_current_node_product_id
 
     try:
+        # Explicit link path: an upstream agent already created the product.
+        if product_code:
+            slug = prod.find_slug_by_product_id(product_code)
+            existing = prod.load_product(slug) if slug else None
+            if existing is None:
+                return (f"Error: product_code '{product_code}' not found. "
+                        f"Omit product_code to create a new product by name.")
+            set_current_node_product_id(existing["id"])
+            return (f"Linked to existing product '{existing['name']}' "
+                    f"(code: {existing['id']}, slug: {existing['slug']}). "
+                    f"No new product created; use add_product_key_result to add KRs.")
+
+        # Idempotent create: find_or_create returns the existing product on name collision.
+        pre_existing = prod.load_product(prod._slugify(name))
         product = prod.create_product(name=name, owner_id=oid, description=description)
         slug = product["slug"]
+        set_current_node_product_id(product["id"])
 
-        # Parse and add key results
+        if pre_existing is not None and product["id"] == pre_existing["id"]:
+            # Duplicate create averted — link and leave the owner's KRs untouched.
+            return (f"Product '{product['name']}' already exists "
+                    f"(code: {product['id']}, slug: {slug}) — linked to it instead of "
+                    f"creating a duplicate. KRs were not modified.")
+
+        # Parse and add key results (newly-created product only)
         kr_count = 0
         if key_results:
             for kr_str in key_results.split(";"):
@@ -78,7 +108,7 @@ async def create_product_tool(
                     prod.add_key_result(slug, title=title, target=target, unit=unit)
                     kr_count += 1
 
-        result = f"Created product '{name}' (slug: {slug})"
+        result = f"Created product '{name}' (code: {product['id']}, slug: {slug})"
         if kr_count:
             result += f" with {kr_count} key results"
         return result

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -107,6 +107,35 @@ def _get_current_node(tree: TaskTree, task_id: str):
     return tree.get_node(task_id)
 
 
+def set_current_node_product_id(product_id: str) -> bool:
+    """Stamp the currently-executing task node with a linked product_id and persist.
+
+    Called after an agent creates/links a product so descendant nodes inherit it
+    via dispatch_child (regression guard for #395). Returns False when there is no
+    tree context (e.g. system/adhoc tasks) so callers can no-op gracefully.
+    """
+    from onemancompany.core.vessel import _current_vessel, _current_task_id
+    from onemancompany.core.task_tree import get_tree_lock
+
+    vessel = _current_vessel.get()
+    task_id = _current_task_id.get()
+    if not vessel or not task_id:
+        return False
+    project_dir, tree_path_str = _find_entry_for_task(task_id)
+    if not project_dir or not tree_path_str:
+        return False
+    with get_tree_lock(tree_path_str):
+        tree = _load_tree(project_dir)
+        node = _get_current_node(tree, task_id)
+        if not node:
+            return False
+        if node.product_id == product_id:
+            return True  # already linked, nothing to persist
+        node.product_id = product_id
+        _save_tree(project_dir, tree)
+    return True
+
+
 def _create_standalone_ceo_request(
     description: str,
     requester_task_id: str,
@@ -361,6 +390,7 @@ def dispatch_child(
             title=title,
         )
         child.project_id = current_node.project_id
+        child.product_id = current_node.product_id  # inherit linked product (#395)
         child.project_dir = project_dir
 
         # Propagate directive chain: inherit parent's directives + add new directive

--- a/src/onemancompany/core/product.py
+++ b/src/onemancompany/core/product.py
@@ -122,13 +122,52 @@ def create_product(
     description: str = "",
     status: ProductStatus = ProductStatus.PLANNING,
     current_version: str = "0.1.0",
+    find_or_create: bool = True,
 ) -> dict:
-    """Create a new product. Returns the product dict."""
+    """Create a new product. Returns the product dict.
+
+    find_or_create (default True): if a product with the canonical slug already
+    exists, return it instead of minting a duplicate. This makes repeated calls
+    with the same name idempotent (regression guard for #395, where a downstream
+    agent re-ran create_product and silently produced a second product with a
+    ``-2`` slug). Pass find_or_create=False to force the old auto-increment
+    behavior (``-2``/``-3``) for callers that intentionally want distinct records.
+    """
     _validate_employee_id(owner_id, label="Owner")
-    slug = _dedup_slug(_slugify(name))
+    canonical_slug = _slugify(name)
+    if find_or_create:
+        # Serialize on the canonical slug so a concurrent create can't slip a
+        # duplicate in between the existence check and the write.
+        with _get_slug_lock(canonical_slug):
+            existing = load_product(canonical_slug)
+            if existing is not None:
+                logger.debug("find_or_create: returning existing product {} (slug={})",
+                             existing.get("id"), canonical_slug)
+                return existing
+            return _write_new_product(
+                slug=canonical_slug, name=name, owner_id=owner_id,
+                description=description, status=status, current_version=current_version,
+            )
+    slug = _dedup_slug(canonical_slug)
+    with _get_slug_lock(slug):
+        return _write_new_product(
+            slug=slug, name=name, owner_id=owner_id,
+            description=description, status=status, current_version=current_version,
+        )
+
+
+def _write_new_product(
+    *,
+    slug: str,
+    name: str,
+    owner_id: str,
+    description: str,
+    status: ProductStatus,
+    current_version: str,
+) -> dict:
+    """Build and persist a new product record. Caller must hold the slug lock."""
     product_id = _gen_id("prod_")
     now = datetime.now().isoformat()
-
     data = {
         "id": product_id,
         "name": name,
@@ -142,12 +181,9 @@ def create_product(
         "created_at": now,
         "updated_at": now,
     }
-
-    with _get_slug_lock(slug):
-        path = _product_yaml_path(slug)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        _write_yaml(path, data)
-
+    path = _product_yaml_path(slug)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _write_yaml(path, data)
     mark_dirty(DirtyCategory.PRODUCTS)
     logger.debug("Created product {} (slug={})", product_id, slug)
     return data
@@ -1128,11 +1164,14 @@ def import_product(bundle: dict, owner_id: str = "", auto_activate: bool = True)
         raise ValueError("Product name is required")
 
     status = ProductStatus.ACTIVE if auto_activate and owner_id else ProductStatus.PLANNING
+    # Import always creates a distinct record (a copy), even if the name collides
+    # with an existing product — so keep the -2/-3 auto-increment behavior here.
     product = create_product(
         name=name,
         owner_id=owner_id,
         description=product_data.get("description", ""),
         status=status,
+        find_or_create=False,
     )
     slug = product["slug"]
 

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -320,6 +320,21 @@ def _build_tree_context(tree, node, project_dir: str) -> str:
     """
     parts: list[str] = []
 
+    # Stable entity codes up front so the agent references existing records by
+    # code instead of re-creating them by name (#395).
+    if node.project_id:
+        parts.append(f"[Project code: {node.project_id}]")
+    if node.product_id:
+        from onemancompany.core.product import find_slug_by_product_id, load_product
+        _pslug = find_slug_by_product_id(node.product_id)
+        _prod = load_product(_pslug) if _pslug else None
+        _pname = f" — {_prod['name']}" if _prod else ""
+        parts.append(f"[Product code: {node.product_id}{_pname}]")
+        parts.append("This product already exists. Do NOT call create_product_tool to "
+                     "re-create it; pass product_code to link, or use its slug directly.")
+    if node.project_id or node.product_id:
+        parts.append("")
+
     # Walk up: ancestors
     ancestors: list[tuple] = []  # (node, distance)
     current = node

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -325,11 +325,10 @@ def _build_tree_context(tree, node, project_dir: str) -> str:
     if node.project_id:
         parts.append(f"[Project code: {node.project_id}]")
     if node.product_id:
-        from onemancompany.core.product import find_slug_by_product_id, load_product
-        _pslug = find_slug_by_product_id(node.product_id)
-        _prod = load_product(_pslug) if _pslug else None
-        _pname = f" — {_prod['name']}" if _prod else ""
-        parts.append(f"[Product code: {node.product_id}{_pname}]")
+        # Code only — no name lookup. Resolving the name from an id means a full
+        # list_products() disk scan on every dispatch, and the code is all the
+        # agent needs (the product's name is already in the directive).
+        parts.append(f"[Product code: {node.product_id}]")
         parts.append("This product already exists. Do NOT call create_product_tool to "
                      "re-create it; pass product_code to link, or use its slug directly.")
     if node.project_id or node.product_id:

--- a/tests/unit/agents/test_entity_code_propagation.py
+++ b/tests/unit/agents/test_entity_code_propagation.py
@@ -1,0 +1,102 @@
+"""Regression tests for #395: entity code (product_id) propagation.
+
+- dispatch_child copies the parent node's product_id to the child.
+- set_current_node_product_id stamps the running node and persists.
+"""
+from __future__ import annotations
+
+import threading
+from collections import defaultdict
+from unittest.mock import MagicMock, patch
+
+from onemancompany.core.task_tree import TaskTree
+from onemancompany.core.vessel import ScheduleEntry, _current_task_id, _current_vessel
+
+
+def _set_context(vessel, task_id):
+    return _current_vessel.set(vessel), _current_task_id.set(task_id)
+
+
+def _reset_context(tok_v, tok_t):
+    _current_vessel.reset(tok_v)
+    _current_task_id.reset(tok_t)
+
+
+def _make_mock_em(root_id, tree_path="/tmp/proj/task_tree.yaml"):
+    mock_em = MagicMock()
+    mock_em._schedule = defaultdict(list)
+    mock_em._schedule["_any_"] = [ScheduleEntry(node_id=root_id, tree_path=tree_path)]
+    mock_em._current_entries = {}
+    return mock_em
+
+
+class TestDispatchChildProductPropagation:
+    def test_child_inherits_product_id(self):
+        from onemancompany.agents.tree_tools import dispatch_child
+
+        tree = TaskTree(project_id="proj1")
+        root = tree.create_root(employee_id="00003", description="root")
+        root.product_id = "prod_099301bf"
+        root_id = tree.root_id
+
+        vessel = MagicMock()
+        vessel.employee_id = "00003"
+        tok_v, tok_t = _set_context(vessel, root_id)
+        mock_em = _make_mock_em(root_id)
+
+        try:
+            with (
+                patch("onemancompany.agents.tree_tools._load_tree", return_value=tree),
+                patch("onemancompany.agents.tree_tools._save_tree"),
+                patch("onemancompany.agents.tree_tools._add_to_project_team"),
+                patch("onemancompany.core.store.load_employee", return_value={"id": "00010", "name": "Dev"}),
+                patch("onemancompany.core.vessel.employee_manager", mock_em),
+            ):
+                result = dispatch_child.invoke({
+                    "target_employee_id": "00010",
+                    "description": "为 'Web Agent Safety Framework' 产品制定规划",
+                    "acceptance_criteria": ["plan done"],
+                })
+
+            child = tree.get_node(result["node_id"])
+            assert child.product_id == "prod_099301bf"   # inherited (#395)
+            assert child.project_id == root.project_id     # existing behavior preserved
+        finally:
+            _reset_context(tok_v, tok_t)
+
+
+class TestSetCurrentNodeProductId:
+    def test_stamps_and_persists(self):
+        from onemancompany.agents import tree_tools
+
+        tree = TaskTree(project_id="proj1")
+        root = tree.create_root(employee_id="00004", description="root")
+        root_id = tree.root_id
+        assert root.product_id == ""
+
+        vessel = MagicMock()
+        vessel.employee_id = "00004"
+        tok_v, tok_t = _set_context(vessel, root_id)
+        mock_em = _make_mock_em(root_id)
+        saved = []
+
+        try:
+            with (
+                patch("onemancompany.agents.tree_tools._load_tree", return_value=tree),
+                patch("onemancompany.agents.tree_tools._save_tree", side_effect=lambda *a, **k: saved.append(True)),
+                patch("onemancompany.core.task_tree.get_tree_lock", return_value=threading.Lock()),
+                patch("onemancompany.core.vessel.employee_manager", mock_em),
+            ):
+                ok = tree_tools.set_current_node_product_id("prod_099301bf")
+
+            assert ok is True
+            assert tree.get_node(root_id).product_id == "prod_099301bf"
+            assert saved == [True]  # persisted once
+        finally:
+            _reset_context(tok_v, tok_t)
+
+    def test_no_context_returns_false(self):
+        """No vessel/task context (system/adhoc) → graceful no-op."""
+        from onemancompany.agents import tree_tools
+        # No _set_context call — context vars are empty here.
+        assert tree_tools.set_current_node_product_id("prod_x") is False

--- a/tests/unit/core/test_context_windowing.py
+++ b/tests/unit/core/test_context_windowing.py
@@ -37,6 +37,27 @@ class TestBuildTreeContext:
         assert "Great-grandchild: tests" in ctx
         assert "Great-gc result: tests pass" in ctx
 
+    def test_surfaces_entity_codes(self, tmp_path):
+        """Regression #395: project/product codes appear up front so the agent
+        references existing records by code instead of re-creating them."""
+        from onemancompany.core.vessel import _build_tree_context
+        tree, _, _, _, great_gc = self._make_tree(tmp_path)
+        great_gc.project_id = "fb87c5a5ca18"
+        great_gc.product_id = "prod_099301bf"
+        ctx = _build_tree_context(tree, great_gc, str(tmp_path))
+        assert "[Project code: fb87c5a5ca18]" in ctx
+        assert "[Product code: prod_099301bf" in ctx
+        assert "Do NOT call create_product_tool to re-create" in ctx
+
+    def test_no_entity_codes_when_unset(self, tmp_path):
+        """No code lines when the node has no linked project/product."""
+        from onemancompany.core.vessel import _build_tree_context
+        tree, _, _, _, great_gc = self._make_tree(tmp_path)
+        great_gc.project_id = ""
+        great_gc.product_id = ""
+        ctx = _build_tree_context(tree, great_gc, str(tmp_path))
+        assert "[Product code:" not in ctx
+
     def test_parent_has_full_content(self, tmp_path):
         from onemancompany.core.vessel import _build_tree_context
         tree, _, _, grandchild, great_gc = self._make_tree(tmp_path)

--- a/tests/unit/test_product.py
+++ b/tests/unit/test_product.py
@@ -81,14 +81,27 @@ class TestProductCRUD:
         assert loaded["status"] == ProductStatus.ACTIVE.value
         assert loaded["description"] == "New desc"
 
-    def test_slug_dedup(self):
-        p1 = prod.create_product(name="Dupe Name", owner_id="00010")
-        p2 = prod.create_product(name="Dupe Name", owner_id="00011")
+    def test_slug_dedup_explicit_opt_in(self):
+        """The -2/-3 auto-increment only happens when find_or_create=False."""
+        p1 = prod.create_product(name="Dupe Name", owner_id="00010", find_or_create=False)
+        p2 = prod.create_product(name="Dupe Name", owner_id="00011", find_or_create=False)
         assert p1["slug"] == "dupe-name"
         assert p2["slug"] == "dupe-name-2"
         # Third should get -3
-        p3 = prod.create_product(name="Dupe Name", owner_id="00012")
+        p3 = prod.create_product(name="Dupe Name", owner_id="00012", find_or_create=False)
         assert p3["slug"] == "dupe-name-3"
+
+    def test_find_or_create_returns_existing_by_default(self):
+        """Regression for #395: a second create with the same name must NOT mint a
+        duplicate. It returns the existing product (same id, canonical slug, no -2)."""
+        p1 = prod.create_product(name="Web Agent Safety Framework", owner_id="00010")
+        p2 = prod.create_product(name="Web Agent Safety Framework", owner_id="00011")
+        assert p2["id"] == p1["id"]
+        assert p2["slug"] == "web-agent-safety-framework"
+        assert p2["owner_id"] == "00010"  # original owner preserved, not overwritten
+        assert len(prod.list_products()) == 1
+        # No "-2" directory was created
+        assert prod.load_product("web-agent-safety-framework-2") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_product_tools.py
+++ b/tests/unit/test_product_tools.py
@@ -376,6 +376,56 @@ class TestProductTools:
         assert "Error" in result
         assert "bad input" in result
 
+    @pytest.mark.asyncio
+    async def test_create_product_tool_same_name_links_not_dupes(self):
+        """Regression #395: a second create_product_tool with the same name links to
+        the existing product instead of minting a duplicate."""
+        from onemancompany.agents.product_tools import create_product_tool
+
+        r1 = await create_product_tool.ainvoke(
+            {"name": "Web Agent Safety Framework", "description": "framework", "owner_id": "00004"}
+        )
+        assert "Created product" in r1
+        r2 = await create_product_tool.ainvoke(
+            {"name": "Web Agent Safety Framework", "description": "again", "owner_id": "00010"}
+        )
+        assert "already exists" in r2
+        assert "linked" in r2.lower()
+        # Only one product; no -2 slug
+        slugs = {p["slug"] for p in prod.list_products()}
+        assert "web-agent-safety-framework" in slugs
+        assert "web-agent-safety-framework-2" not in slugs
+        # Owner preserved from the first creation
+        p = prod.load_product("web-agent-safety-framework")
+        assert p["owner_id"] == "00004"
+
+    @pytest.mark.asyncio
+    async def test_create_product_tool_links_by_code(self):
+        """product_code links to an existing product without creating anything."""
+        from onemancompany.agents.product_tools import create_product_tool
+
+        existing = prod.create_product(name="Coded Product", owner_id="00004")
+        before = len(prod.list_products())
+        result = await create_product_tool.ainvoke(
+            {"name": "irrelevant", "description": "d", "product_code": existing["id"]}
+        )
+        assert "Linked to existing product" in result
+        assert existing["id"] in result
+        assert len(prod.list_products()) == before  # nothing created
+
+    @pytest.mark.asyncio
+    async def test_create_product_tool_unknown_code_errors(self):
+        """An unknown product_code returns a clear error, creates nothing."""
+        from onemancompany.agents.product_tools import create_product_tool
+
+        before = len(prod.list_products())
+        result = await create_product_tool.ainvoke(
+            {"name": "x", "description": "d", "product_code": "prod_deadbeef"}
+        )
+        assert "Error" in result
+        assert "not found" in result
+        assert len(prod.list_products()) == before
+
     # ------------------------------------------------------------------
     # create_product_issue error paths (lines 111, 124-125)
     # ------------------------------------------------------------------


### PR DESCRIPTION
Closes #395.

## Symptom
CEO dispatches "根据 stage2.json 创建一个新项目" → EA(00004) → COO(00003). Within 18s **two** products named "Web Agent Safety Framework" are created (`prod_099301bf` owned by 00004, and `prod_ff674062` slug `-2` owned by 00003). Downstream issue tracking, OKRs, and ownership routing split across two records.

## Root cause (both verified still present on `main`)
1. `dispatch_child` propagated `project_id` to the child node but **not** `product_id`. The EA's directive named the product ("为 'Web Agent Safety Framework' 产品制定规划") with no code, so the COO read it as "create that product and plan" and called `create_product_tool` again.
2. `core/product.py::create_product` **silently** auto-incremented the slug (`-2`, `-3`) on conflict, so the duplicate call succeeded without error.

## Fix — use the existing entity codes end-to-end (no new fields)
`TaskNode.product_id` and `product.id`/`project.project_id` already exist; the fix uses them.

| Layer | Change |
|---|---|
| `core/product.py` | `create_product` gains `find_or_create=True` (default): repeated create with the same canonical slug returns the existing product. `import_product` opts out (`find_or_create=False`) since it intentionally copies. |
| `agents/tree_tools.py` | `dispatch_child` propagates `child.product_id = current_node.product_id`; new `set_current_node_product_id()` stamps the running node so descendants inherit. |
| `agents/product_tools.py` | `create_product_tool` accepts optional `product_code` (link to an existing product, no re-create), stamps the current node's `product_id`, reports created vs existing. |
| `core/vessel.py` | `_build_tree_context` surfaces `[Project code]` / `[Product code]` up front so the receiving agent references records by code, not name. |

## Tests
- `find_or_create` idempotency + explicit `find_or_create=False` opt-out (updated `test_slug_dedup`)
- `create_product_tool`: same-name links not dupes, `product_code` linking, unknown-code error
- `dispatch_child` propagates `product_id`; `set_current_node_product_id` stamps + persists; no-context no-op
- `_build_tree_context` surfaces codes
- Full unit suite green: **4496 passed, 2 skipped** (one unrelated load-induced timeout flake, passes in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)