### PR TITLE
Prevent duplicate product creation via product/project code propagation

### DIFF
--- a/src/onemancompany/agents/product_tools.py
+++ b/src/onemancompany/agents/product_tools.py
@@ -35,6 +35,35 @@ def _resolve_caller_id() -> str:
         return "agent"
 
 
+def _propagate_product_id_to_current_node(product_id: str) -> None:
+    """Write product_id onto the currently executing task node.
+
+    Descendant nodes then inherit it via dispatch_child's project_id/product_id
+    propagation, so a directive like "plan product X" carries the product code
+    instead of relying on the receiving agent to guess it from the name.
+    Best-effort — silently no-ops outside of an active task tree context.
+    """
+    try:
+        from onemancompany.core.vessel import _current_task_id
+        from onemancompany.core.task_tree import get_tree_lock
+        from onemancompany.agents import tree_tools
+
+        task_id = _current_task_id.get()
+        if not task_id:
+            return
+        project_dir, tree_path_str = tree_tools._find_entry_for_task(task_id)
+        if not project_dir:
+            return
+        with get_tree_lock(tree_path_str):
+            tree = tree_tools._load_tree(project_dir)
+            node = tree_tools._get_current_node(tree, task_id)
+            if node and node.product_id != product_id:
+                node.product_id = product_id
+                tree_tools._save_tree(project_dir, tree)
+    except Exception as e:
+        logger.debug("create_product_tool: could not propagate product_id to current node: {}", e)
+
+
 # ---------------------------------------------------------------------------
 # Tools
 # ---------------------------------------------------------------------------
@@ -46,6 +75,7 @@ async def create_product_tool(
     description: str,
     key_results: str = "",
     owner_id: str = "",
+    product_code: str = "",
 ) -> str:
     """Create a new product with optional key results.
 
@@ -54,13 +84,38 @@ async def create_product_tool(
         description: Product objective/description
         key_results: Semicolon-separated KRs, each as "title|target|unit" (e.g. "DAU达到1000|1000|users;页面加载<2s|2.0|seconds")
         owner_id: Employee ID of the product owner (optional, defaults to caller)
+        product_code: Known product ID (e.g. "prod_099301bf"). Always pass this
+            when the task context or an upstream directive already names a
+            product code — it short-circuits to that existing product instead
+            of risking a duplicate creation.
     """
     caller = _resolve_caller_id()
     oid = owner_id or caller
 
     try:
+        if product_code:
+            slug = prod.find_slug_by_product_id(product_code)
+            existing = prod.load_product(slug) if slug else None
+            if existing:
+                _propagate_product_id_to_current_node(existing["id"])
+                return (
+                    f"Product '{existing['name']}' already exists "
+                    f"(slug: {existing['slug']}, id: {existing['id']}) — using existing product."
+                )
+            logger.debug("create_product_tool: product_code {} not found, falling back to name lookup", product_code)
+
+        # find_or_create semantics: a product already at this name's canonical
+        # slug is reused rather than duplicated (see core/product.py::create_product).
+        pre_existing = prod.load_product(prod._slugify(name)) is not None
+
         product = prod.create_product(name=name, owner_id=oid, description=description)
         slug = product["slug"]
+        _propagate_product_id_to_current_node(product["id"])
+
+        if pre_existing:
+            return (
+                f"Product '{name}' already exists (slug: {slug}, id: {product['id']}) — using existing product."
+            )
 
         # Parse and add key results
         kr_count = 0
@@ -78,7 +133,7 @@ async def create_product_tool(
                     prod.add_key_result(slug, title=title, target=target, unit=unit)
                     kr_count += 1
 
-        result = f"Created product '{name}' (slug: {slug})"
+        result = f"Created product '{name}' (slug: {slug}, id: {product['id']})"
         if kr_count:
             result += f" with {kr_count} key results"
         return result

--- a/src/onemancompany/agents/tree_tools.py
+++ b/src/onemancompany/agents/tree_tools.py
@@ -361,6 +361,7 @@ def dispatch_child(
             title=title,
         )
         child.project_id = current_node.project_id
+        child.product_id = current_node.product_id
         child.project_dir = project_dir
 
         # Propagate directive chain: inherit parent's directives + add new directive

--- a/src/onemancompany/core/product.py
+++ b/src/onemancompany/core/product.py
@@ -122,28 +122,46 @@ def create_product(
     description: str = "",
     status: ProductStatus = ProductStatus.PLANNING,
     current_version: str = "0.1.0",
+    find_or_create: bool = True,
 ) -> dict:
-    """Create a new product. Returns the product dict."""
-    _validate_employee_id(owner_id, label="Owner")
-    slug = _dedup_slug(_slugify(name))
-    product_id = _gen_id("prod_")
-    now = datetime.now().isoformat()
+    """Create a new product. Returns the product dict.
 
-    data = {
-        "id": product_id,
-        "name": name,
-        "slug": slug,
-        "owner_id": owner_id,
-        "description": description,
-        "status": status,
-        "current_version": current_version,
-        "key_results": [],
-        "workspace_initialized": False,
-        "created_at": now,
-        "updated_at": now,
-    }
+    find_or_create: when True (default), a product already existing at the
+    canonical slug for `name` is returned as-is instead of minting a
+    duplicate. Pass find_or_create=False to always create a new product,
+    auto-incrementing the slug on conflict (-2, -3, ...).
+    """
+    _validate_employee_id(owner_id, label="Owner")
+    base_slug = _slugify(name)
+    slug = base_slug if find_or_create else _dedup_slug(base_slug)
 
     with _get_slug_lock(slug):
+        if find_or_create:
+            existing = load_product(slug)
+            if existing:
+                logger.debug(
+                    "create_product: found existing product {} (slug={}), skipping create",
+                    existing.get("id"), slug,
+                )
+                return existing
+
+        product_id = _gen_id("prod_")
+        now = datetime.now().isoformat()
+
+        data = {
+            "id": product_id,
+            "name": name,
+            "slug": slug,
+            "owner_id": owner_id,
+            "description": description,
+            "status": status,
+            "current_version": current_version,
+            "key_results": [],
+            "workspace_initialized": False,
+            "created_at": now,
+            "updated_at": now,
+        }
+
         path = _product_yaml_path(slug)
         path.parent.mkdir(parents=True, exist_ok=True)
         _write_yaml(path, data)
@@ -1133,6 +1151,7 @@ def import_product(bundle: dict, owner_id: str = "", auto_activate: bool = True)
         owner_id=owner_id,
         description=product_data.get("description", ""),
         status=status,
+        find_or_create=False,
     )
     slug = product["slug"]
 

--- a/src/onemancompany/core/vessel.py
+++ b/src/onemancompany/core/vessel.py
@@ -320,6 +320,15 @@ def _build_tree_context(tree, node, project_dir: str) -> str:
     """
     parts: list[str] = []
 
+    # Surface stable entity codes up front so the receiving agent never has to
+    # guess a project/product from its name (e.g. when re-calling create_product_tool).
+    if node.project_id:
+        parts.append(f"[Project code: {node.project_id}]")
+    if node.product_id:
+        parts.append(f"[Product code: {node.product_id}]")
+    if node.project_id or node.product_id:
+        parts.append("")
+
     # Walk up: ancestors
     ancestors: list[tuple] = []  # (node, distance)
     current = node

--- a/tests/unit/agents/test_tree_tools.py
+++ b/tests/unit/agents/test_tree_tools.py
@@ -98,6 +98,45 @@ class TestDispatchChild:
         finally:
             _reset_context(tok_v, tok_t)
 
+    def test_dispatch_propagates_project_and_product_id(self):
+        """Child node inherits parent's project_id and product_id (issue #395).
+
+        Without this, a directive naming a product only by name (not code) leaves
+        the receiving agent to guess and re-call create_product_tool, minting a
+        duplicate product.
+        """
+        from onemancompany.agents.tree_tools import dispatch_child
+
+        tree = _make_tree_with_root(project_id="proj1")
+        root_id = tree.root_id
+        root_node = tree.get_node(root_id)
+        root_node.product_id = "prod_deadbeef"
+
+        vessel = _make_vessel_and_task()
+        tok_v, tok_t = _set_context(vessel, root_id)
+
+        mock_em = _make_mock_em(root_id)
+
+        try:
+            with (
+                patch("onemancompany.agents.tree_tools._load_tree", return_value=tree),
+                patch("onemancompany.agents.tree_tools._save_tree"),
+                patch("onemancompany.core.store.load_employee", return_value={"id": "00100", "name": "Test"}),
+                patch("onemancompany.core.vessel.employee_manager", mock_em),
+            ):
+                result = dispatch_child.invoke({
+                    "target_employee_id": "00100",
+                    "description": "plan the product",
+                    "acceptance_criteria": ["done"],
+                })
+
+            assert result["status"] == "dispatched"
+            child_node = tree.get_node(result["node_id"])
+            assert child_node.project_id == "proj1"
+            assert child_node.product_id == "prod_deadbeef"
+        finally:
+            _reset_context(tok_v, tok_t)
+
     def test_dispatch_adds_employee_to_project_team(self, tmp_path):
         """dispatch_child auto-registers the dispatched employee in project.yaml team."""
         import yaml

--- a/tests/unit/core/test_context_windowing.py
+++ b/tests/unit/core/test_context_windowing.py
@@ -78,6 +78,23 @@ class TestBuildTreeContext:
         ctx = _build_tree_context(tree, root, str(tmp_path))
         assert "Child result: API done" in ctx
 
+    def test_project_and_product_code_surfaced(self, tmp_path):
+        """Issue #395: entity codes must be visible so a directive naming a
+        product/project only by name doesn't force the receiving agent to guess."""
+        from onemancompany.core.vessel import _build_tree_context
+        tree, root, _, _, _ = self._make_tree(tmp_path)
+        root.product_id = "prod_deadbeef"
+        ctx = _build_tree_context(tree, root, str(tmp_path))
+        assert "[Project code: test]" in ctx
+        assert "[Product code: prod_deadbeef]" in ctx
+
+    def test_no_product_code_when_unset(self, tmp_path):
+        from onemancompany.core.vessel import _build_tree_context
+        tree, root, _, _, _ = self._make_tree(tmp_path)
+        ctx = _build_tree_context(tree, root, str(tmp_path))
+        assert "[Project code: test]" in ctx
+        assert "Product code" not in ctx
+
 
 # Need TaskPhase for status transitions
 from onemancompany.core.task_lifecycle import TaskPhase

--- a/tests/unit/test_product.py
+++ b/tests/unit/test_product.py
@@ -82,13 +82,31 @@ class TestProductCRUD:
         assert loaded["description"] == "New desc"
 
     def test_slug_dedup(self):
-        p1 = prod.create_product(name="Dupe Name", owner_id="00010")
-        p2 = prod.create_product(name="Dupe Name", owner_id="00011")
+        """find_or_create=False always mints a new product, incrementing the slug."""
+        p1 = prod.create_product(name="Dupe Name", owner_id="00010", find_or_create=False)
+        p2 = prod.create_product(name="Dupe Name", owner_id="00011", find_or_create=False)
         assert p1["slug"] == "dupe-name"
         assert p2["slug"] == "dupe-name-2"
+        assert p1["id"] != p2["id"]
         # Third should get -3
-        p3 = prod.create_product(name="Dupe Name", owner_id="00012")
+        p3 = prod.create_product(name="Dupe Name", owner_id="00012", find_or_create=False)
         assert p3["slug"] == "dupe-name-3"
+
+    def test_find_or_create_default_returns_existing(self):
+        """Default find_or_create=True returns the existing product instead of a duplicate."""
+        p1 = prod.create_product(name="Same Name", owner_id="00010")
+        p2 = prod.create_product(name="Same Name", owner_id="00011")
+        assert p1["id"] == p2["id"]
+        assert p1["slug"] == p2["slug"] == "same-name"
+        # Only one product on disk
+        assert len(prod.list_products()) == 1
+
+    def test_find_or_create_false_ignores_existing(self):
+        """find_or_create=False bypasses the existing-product lookup entirely."""
+        p1 = prod.create_product(name="Other Name", owner_id="00010")
+        p2 = prod.create_product(name="Other Name", owner_id="00011", find_or_create=False)
+        assert p1["id"] != p2["id"]
+        assert p2["slug"] == "other-name-2"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_product_tools.py
+++ b/tests/unit/test_product_tools.py
@@ -376,6 +376,61 @@ class TestProductTools:
         assert "Error" in result
         assert "bad input" in result
 
+    @pytest.mark.asyncio
+    async def test_create_product_tool_repeat_call_returns_existing(self):
+        """Issue #395: a downstream agent re-running create_product_tool with the
+        same name must not mint a duplicate product/slug."""
+        from onemancompany.agents.product_tools import create_product_tool
+
+        first = await create_product_tool.ainvoke(
+            {"name": "Web Agent Safety Framework", "description": "d1"}
+        )
+        second = await create_product_tool.ainvoke(
+            {"name": "Web Agent Safety Framework", "description": "d2 (redundant call)"}
+        )
+        assert "Created product" in first
+        assert "already exists" in second
+
+        products = [p for p in prod.list_products() if p["name"] == "Web Agent Safety Framework"]
+        assert len(products) == 1
+        assert products[0]["slug"] == "web-agent-safety-framework"
+
+    @pytest.mark.asyncio
+    async def test_create_product_tool_product_code_short_circuits(self):
+        """Passing a known product_code looks up the existing product without creating."""
+        from onemancompany.agents.product_tools import create_product_tool
+
+        created = prod.create_product(name="Coded Product", owner_id="00004")
+
+        result = await create_product_tool.ainvoke(
+            {
+                "name": "Some Other Name The Agent Guessed",
+                "description": "d",
+                "product_code": created["id"],
+            }
+        )
+        assert "already exists" in result
+        assert created["id"] in result
+
+        products = prod.list_products()
+        assert len(products) == 2  # fixture's ToolTest + Coded Product only, no new one
+        assert not any(p["name"] == "Some Other Name The Agent Guessed" for p in products)
+
+    @pytest.mark.asyncio
+    async def test_create_product_tool_unknown_product_code_falls_back(self):
+        """An unresolvable product_code falls back to name-based find-or-create."""
+        from onemancompany.agents.product_tools import create_product_tool
+
+        result = await create_product_tool.ainvoke(
+            {
+                "name": "Fallback Product",
+                "description": "d",
+                "product_code": "prod_doesnotexist",
+            }
+        )
+        assert "Created product" in result
+        assert prod.load_product("fallback-product") is not None
+
     # ------------------------------------------------------------------
     # create_product_issue error paths (lines 111, 124-125)
     # ------------------------------------------------------------------


### PR DESCRIPTION
Fixes #395.

Two compounding issues caused a downstream agent to re-run `create_product_tool` and mint a duplicate product: `dispatch_child` never propagated `product_id` to child nodes, and `create_product` silently auto-incremented the slug on conflict instead of erroring.

## Changes
- `core/product.py::create_product`: new default `find_or_create=True`, returns existing product at canonical slug instead of duplicating; old behavior behind `find_or_create=False` (used by `import_product`).
- `agents/product_tools.py::create_product_tool`: accepts optional `product_code` to short-circuit to an existing product; writes `product_id` onto the current task node on success.
- `agents/tree_tools.py::dispatch_child`: propagates `child.product_id` alongside existing `project_id` propagation.
- `core/vessel.py::_build_tree_context`: surfaces `[Project code: ...]` and `[Product code: ...]` at the top of every task prompt.

## Test plan
- [x] Two back-to-back `create_product_tool` calls with the same name return the same `id`, no `-2` slug
- [x] `dispatch_child` propagates both `project_id` and `product_id` to the child node
- [x] `_build_tree_context` surfaces `[Project code: ...]` / `[Product code: ...]`
- [ ] Test suite not run locally (sandbox restriction) — please run before merge

Generated with [Claude Code](https://claude.ai/code)