### PR TITLE
feat: first-class Azure AI Foundry provider + fix run_auto dropping endpoint config (#402)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ open http://localhost:8000
 | `.onemancompany/config.yaml` | App config (Talent Market URL, etc.)   |
 | Browser Settings panel       | Frontend preferences                   |
 
+Using Azure AI Foundry / Azure OpenAI? See [docs/providers-azure.md](docs/providers-azure.md).
+
 ---
 
 ## Under the Hood

--- a/docs/providers-azure.md
+++ b/docs/providers-azure.md
@@ -1,0 +1,53 @@
+# Azure AI Foundry (Microsoft Foundry) provider
+
+OneManCompany supports Azure AI Foundry / Azure OpenAI models as a first-class
+provider. Foundry exposes an **OpenAI-compatible v1 API**, so the same
+`ChatOpenAI` client used for every other OpenAI-style provider works against it.
+
+## Onboarding wizard
+
+Run `onemancompany-init` and pick **Azure AI Foundry** at the provider step.
+You'll be asked for three things:
+
+1. **Resource name or endpoint URL** — either a bare resource name (`myres`) or a
+   full endpoint. A bare name is expanded to
+   `https://<resource>.services.ai.azure.com/openai/v1/`. A pasted URL is
+   normalized to the `/openai/v1/` form (both `*.services.ai.azure.com` and
+   `*.openai.azure.com` hosts work).
+2. **API key** — your Azure resource key. It is sent as `Authorization: Bearer`.
+3. **Deployment name** — this becomes the model id. **Azure uses the deployment
+   name, not the base model id** (e.g. your deployment of `gpt-5.5` might be named
+   `gpt-5-5-prod`).
+
+## Manual `.onemancompany/.env`
+
+You can also configure it by hand:
+
+```env
+DEFAULT_API_PROVIDER=azure
+AZURE_API_KEY=<azure resource key>
+DEFAULT_API_BASE_URL=https://<resource>.services.ai.azure.com/openai/v1/
+DEFAULT_LLM_MODEL=<deployment name>   # Azure deployment name, not the base model id
+```
+
+Notes:
+
+- The endpoint **must** end with `/openai/v1/` — that is the OpenAI-compatible
+  surface. Both `https://<resource>.services.ai.azure.com/openai/v1/` and
+  `https://<resource>.openai.azure.com/openai/v1/` are accepted.
+- No `CUSTOM_CHAT_CLASS` is needed — Azure uses the OpenAI chat format by default.
+- Per-employee model tiering works: set a different deployment name (and optional
+  `api_base_url`) on each employee's `profile.yaml`.
+
+## `--auto` (non-interactive init)
+
+`onemancompany-init --auto` reads an existing `.onemancompany/.env` and
+regenerates the company config from it. It preserves `DEFAULT_API_BASE_URL` and
+`CUSTOM_CHAT_CLASS`, so the Azure endpoint survives a re-init.
+
+## Relationship to the `custom` provider
+
+Before first-class Azure support, Foundry worked through the generic `custom`
+provider (`DEFAULT_API_PROVIDER=custom` + `CUSTOM_CHAT_CLASS=openai` +
+`DEFAULT_API_BASE_URL=...`). That still works; the `azure` provider just removes
+the guesswork and gives you a labelled onboarding path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.99",
+  "version": "0.7.101",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.101",
+  "version": "0.7.102",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.99"
+version = "0.7.101"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.101"
+version = "0.7.102"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/agents/base.py
+++ b/src/onemancompany/agents/base.py
@@ -246,7 +246,9 @@ def make_llm(employee_id: str = "", temperature: float | None = None) -> BaseCha
             # Allow custom base_url override: provider-specific or global
             if api_provider == "openrouter":
                 base_url = settings.openrouter_base_url
-            elif api_provider == "custom":
+            elif api_provider in ("custom", "azure"):
+                # Azure Foundry & custom providers carry a user-supplied endpoint
+                # (resource-specific for Azure) via DEFAULT_API_BASE_URL.
                 base_url = employee_api_base_url or settings.default_api_base_url
             elif settings.default_api_base_url and api_provider == settings.default_api_provider:
                 base_url = settings.default_api_base_url

--- a/src/onemancompany/core/auth_choices.py
+++ b/src/onemancompany/core/auth_choices.py
@@ -67,6 +67,9 @@ AUTH_CHOICE_GROUPS: list[AuthChoiceGroup] = [
         AuthChoiceOption("minimax-oauth", "OAuth", provider="minimax", auth_method="oauth", available=False),
         AuthChoiceOption("minimax-api-key", "API Key", provider="minimax", auth_method="api_key"),
     ]),
+    AuthChoiceGroup("azure", "Azure AI Foundry", "OpenAI-compatible v1 endpoint + API key", [
+        AuthChoiceOption("azure-api-key", "API Key", provider="azure", auth_method="api_key"),
+    ]),
     AuthChoiceGroup("custom", "Custom Provider", "Any OpenAI/Anthropic compatible endpoint", [
         AuthChoiceOption("custom-api-key", "Custom API Key", provider="custom", auth_method="api_key"),
     ]),

--- a/src/onemancompany/core/config.py
+++ b/src/onemancompany/core/config.py
@@ -152,6 +152,8 @@ ENV_KEY_TALENT_MARKET = "TALENT_MARKET_API_KEY"
 ENV_KEY_OPENROUTER = "OPENROUTER_API_KEY"
 ENV_KEY_DEFAULT_PROVIDER = "DEFAULT_API_PROVIDER"
 ENV_KEY_DEFAULT_MODEL = "DEFAULT_LLM_MODEL"
+ENV_KEY_DEFAULT_BASE_URL = "DEFAULT_API_BASE_URL"
+ENV_KEY_CUSTOM_CHAT_CLASS = "CUSTOM_CHAT_CLASS"
 ENV_KEY_HOST = "HOST"
 ENV_KEY_PORT = "PORT"
 ENV_KEY_SANDBOX_ENABLED = "SANDBOX_ENABLED"
@@ -491,6 +493,15 @@ PROVIDER_REGISTRY: dict[str, ProviderConfig] = {
         env_key="minimax_api_key",
         health_url="https://api.minimax.chat/v1/models",
     ),
+    "azure": ProviderConfig(
+        # Azure AI Foundry exposes an OpenAI-compatible v1 API. The resource-specific
+        # endpoint (https://<resource>.services.ai.azure.com/openai/v1/) is user-provided
+        # via DEFAULT_API_BASE_URL, and the model id is the Azure *deployment name*.
+        base_url="",
+        chat_class="openai",
+        env_key="azure_api_key",
+        health_url="",  # resource-specific; skip zero-token health check
+    ),
     "custom": ProviderConfig(
         base_url="",  # user-provided via DEFAULT_API_BASE_URL
         env_key="custom_api_key",
@@ -573,6 +584,7 @@ class Settings(BaseSettings):
     together_api_key: str = ""
     google_api_key: str = ""
     minimax_api_key: str = ""
+    azure_api_key: str = ""
     custom_api_key: str = ""
 
     # Default provider & model

--- a/src/onemancompany/onboard.py
+++ b/src/onemancompany/onboard.py
@@ -26,7 +26,8 @@ SOURCE_ROOT = Path(__file__).parent.parent.parent
 from onemancompany.core.config import (
     COMPANY_TEMPLATE_DIR, CONFIG_YAML_FILENAME,
     DATA_DIR_NAME, DOT_ENV_FILENAME, EMPLOYEES_DIR,
-    ENV_KEY_ANTHROPIC, ENV_KEY_ANTHROPIC_AUTH, ENV_KEY_DEFAULT_MODEL,
+    ENV_KEY_ANTHROPIC, ENV_KEY_ANTHROPIC_AUTH, ENV_KEY_CUSTOM_CHAT_CLASS,
+    ENV_KEY_DEFAULT_BASE_URL, ENV_KEY_DEFAULT_MODEL,
     ENV_KEY_DEFAULT_PROVIDER, ENV_KEY_HOST, ENV_KEY_OPENROUTER,
     ENV_KEY_PORT, ENV_KEY_SANDBOX_ENABLED, ENV_KEY_SKILLSMP,
     ENV_KEY_TALENT_MARKET,
@@ -385,9 +386,61 @@ def _step_llm(console: Console) -> tuple[str, str, str, str]:
             console.print("  [red]Base URL is required for custom providers.[/red]")
             base_url = _inq.text(message="Base URL:", style=INQ_STYLE).execute().strip()
 
-    # 4. Select model — try fetching from provider, fall back to manual input
-    model = _select_or_enter_model(console, provider, api_key)
+    # 3b. Azure AI Foundry: build the OpenAI-compatible v1 endpoint from a resource
+    #     name (or accept a full URL), then take the model id as the deployment name.
+    if provider == "azure":
+        console.print(
+            "\n  [dim]Enter your Azure resource name or full endpoint.[/dim]\n"
+            "  [dim]Name 'myres' -> https://myres.services.ai.azure.com/openai/v1/[/dim]"
+        )
+        while not base_url:
+            resource = _inq.text(
+                message="Azure resource name or endpoint URL:",
+                default="",
+                style=INQ_STYLE,
+            ).execute().strip()
+            if resource:
+                base_url = _azure_base_url(resource)
+            if not base_url:
+                console.print("  [red]An Azure resource name or endpoint URL is required.[/red]")
+        console.print(f"  [bright_green]▸[/bright_green] Endpoint: [bold bright_cyan]{base_url}[/bold bright_cyan]")
+
+    # 4. Select model — for Azure the id is the deployment name (manual entry);
+    #    otherwise try fetching from the provider, falling back to manual input.
+    if provider == "azure":
+        console.print(
+            "\n  [dim]Enter your Azure *deployment name* (not the base model id).[/dim]"
+        )
+        model = ""
+        while not model:
+            model = _inq.text(message="Deployment name:", style=INQ_STYLE).execute().strip()
+            if not model:
+                console.print("  [red]Deployment name is required for Azure.[/red]")
+        console.print(f"  [bright_green]▸[/bright_green] Deployment: [bold bright_cyan]{model}[/bold bright_cyan]")
+    else:
+        model = _select_or_enter_model(console, provider, api_key)
     return provider, api_key.strip(), model, base_url, custom_chat_class
+
+
+def _azure_base_url(resource: str) -> str:
+    """Build the Azure Foundry OpenAI-compatible v1 base URL from a resource name.
+
+    Accepts a bare resource name (``myres``) or a full endpoint URL. Any URL is
+    normalized to end with ``/openai/v1/`` so ``ChatOpenAI`` hits the v1 API.
+    """
+    resource = resource.strip().rstrip("/")
+    if not resource:
+        return ""
+    if resource.startswith(("http://", "https://")):
+        host = resource
+    else:
+        host = f"https://{resource}.services.ai.azure.com"
+    # Normalize to the /openai/v1/ form regardless of what the user pasted.
+    marker = "/openai/v1"
+    idx = host.find(marker)
+    if idx != -1:
+        host = host[:idx]
+    return f"{host}/openai/v1/"
 
 
 def _select_or_enter_model(console: Console, provider: str, api_key: str) -> str:
@@ -995,6 +1048,11 @@ def run_auto(*, skip_confirm: bool = False) -> None:
     host = env.get(ENV_KEY_HOST, "0.0.0.0")
     port = int(env.get(ENV_KEY_PORT, "8000"))
 
+    # Preserve custom/Azure endpoint config from the source .env — otherwise the
+    # regenerated .env drops these and the setup silently falls back to defaults.
+    base_url = env.get(ENV_KEY_DEFAULT_BASE_URL, "")
+    custom_chat_class = env.get(ENV_KEY_CUSTOM_CHAT_CLASS, "")
+
     extras: dict[str, str] = {}
     if env.get(ENV_KEY_ANTHROPIC):
         extras[ENV_KEY_ANTHROPIC] = env[ENV_KEY_ANTHROPIC]
@@ -1022,7 +1080,9 @@ def run_auto(*, skip_confirm: bool = False) -> None:
             console.print("\n  Aborted.")
             return
 
-    _step_execute(console, provider, api_key, model, host, port, extras, sandbox_enabled=sandbox_enabled)
+    _step_execute(console, provider, api_key, model, host, port, extras,
+                  sandbox_enabled=sandbox_enabled, base_url=base_url,
+                  custom_chat_class=custom_chat_class)
     _step_done(console, host, port)
 
 

--- a/tests/unit/agents/test_settings_api_key.py
+++ b/tests/unit/agents/test_settings_api_key.py
@@ -61,9 +61,11 @@ def test_test_provider_key_uses_valid_model():
     # a) Use the provider's health_url for verification, or
     # b) Use a sensible default model name
 
-    # Verify all providers have health_url configured (custom excluded — user-provided)
+    # Verify all providers have health_url configured. Providers with a
+    # user-supplied endpoint (empty registry base_url — e.g. custom, azure)
+    # can't ship a fixed health_url, so they're excluded.
     for name, prov in PROVIDER_REGISTRY.items():
-        if name == "custom":
+        if not prov.base_url:
             continue
         assert prov.health_url, f"Provider '{name}' missing health_url for key verification"
 

--- a/tests/unit/core/test_auth_choices.py
+++ b/tests/unit/core/test_auth_choices.py
@@ -34,6 +34,24 @@ class TestResolveAuthChoice:
         assert option.provider == "custom"
         assert option.auth_method == "api_key"
 
+    def test_resolve_azure(self):
+        from onemancompany.core.auth_choices import resolve_auth_choice
+
+        option = resolve_auth_choice("azure-api-key")
+        assert option is not None
+        assert option.provider == "azure"
+        assert option.auth_method == "api_key"
+        assert option.available is True
+
+    def test_azure_in_provider_registry(self):
+        """Unlike 'custom', 'azure' is a first-class registry provider."""
+        from onemancompany.core.config import PROVIDER_REGISTRY, get_provider
+
+        assert "azure" in PROVIDER_REGISTRY
+        prov = get_provider("azure")
+        assert prov.chat_class == "openai"
+        assert prov.env_key == "azure_api_key"
+
 
 class TestAuthChoiceGroupsIntegrity:
     def test_all_groups_have_choices(self):

--- a/tests/unit/test_onboard.py
+++ b/tests/unit/test_onboard.py
@@ -222,6 +222,34 @@ class TestStepLlmBaseUrlPrompt:
         assert custom_chat_class == ""
         assert [call.kwargs["message"] for call in mock_text_fn.call_args_list] == ["Model ID:"]
 
+    def test_azure_provider_builds_endpoint_and_uses_deployment_name(self):
+        from onemancompany.onboard import _step_llm
+
+        mock_console = MagicMock()
+        provider_select = MagicMock()
+        provider_select.execute.return_value = "azure"
+        mock_secret = MagicMock()
+        mock_secret.execute.return_value = "az-key"
+        resource_text = MagicMock()
+        resource_text.execute.return_value = "myres"
+        deployment_text = MagicMock()
+        deployment_text.execute.return_value = "gpt-5.5"
+
+        with patch("InquirerPy.inquirer.select", return_value=provider_select), \
+             patch("InquirerPy.inquirer.secret", return_value=mock_secret), \
+             patch("InquirerPy.inquirer.text", side_effect=[resource_text, deployment_text]) as mock_text_fn:
+            provider, api_key, model, base_url, custom_chat_class = _step_llm(mock_console)
+
+        assert provider == "azure"
+        assert api_key == "az-key"
+        # Azure uses the *deployment name* as the model id — no /models fetch.
+        assert model == "gpt-5.5"
+        assert base_url == "https://myres.services.ai.azure.com/openai/v1/"
+        # chat_class stays the registry default (openai); no CUSTOM_CHAT_CLASS needed.
+        assert custom_chat_class == ""
+        prompts = [call.kwargs["message"] for call in mock_text_fn.call_args_list]
+        assert prompts == ["Azure resource name or endpoint URL:", "Deployment name:"]
+
     def test_custom_provider_prompts_for_base_url(self):
         from onemancompany.onboard import _step_llm
 
@@ -502,3 +530,68 @@ class TestSandboxPromptRemoved:
         from onemancompany.onboard import TOTAL_STEPS
 
         assert TOTAL_STEPS == 5
+
+
+class TestAzureBaseUrl:
+    """_azure_base_url builds the OpenAI-compatible v1 endpoint from a resource."""
+
+    def test_bare_resource_name(self):
+        from onemancompany.onboard import _azure_base_url
+        assert _azure_base_url("myres") == "https://myres.services.ai.azure.com/openai/v1/"
+
+    def test_full_services_endpoint_normalized(self):
+        from onemancompany.onboard import _azure_base_url
+        url = _azure_base_url("https://myres.services.ai.azure.com")
+        assert url == "https://myres.services.ai.azure.com/openai/v1/"
+
+    def test_openai_azure_com_endpoint(self):
+        from onemancompany.onboard import _azure_base_url
+        url = _azure_base_url("https://myres.openai.azure.com/")
+        assert url == "https://myres.openai.azure.com/openai/v1/"
+
+    def test_already_has_openai_v1_suffix_is_idempotent(self):
+        from onemancompany.onboard import _azure_base_url
+        url = _azure_base_url("https://myres.services.ai.azure.com/openai/v1/")
+        assert url == "https://myres.services.ai.azure.com/openai/v1/"
+
+    def test_empty_resource_returns_empty(self):
+        from onemancompany.onboard import _azure_base_url
+        assert _azure_base_url("") == ""
+        assert _azure_base_url("   ") == ""
+
+
+class TestRunAutoPreservesEndpointConfig:
+    """run_auto must not drop DEFAULT_API_BASE_URL / CUSTOM_CHAT_CLASS (issue #402)."""
+
+    def _write_env(self, tmp_path, body):
+        (tmp_path / ".onemancompany.env").write_text(body, encoding="utf-8")
+
+    def test_run_auto_passes_base_url_and_chat_class(self, tmp_path, monkeypatch):
+        import onemancompany.onboard as onboard
+
+        env_body = (
+            "DEFAULT_API_PROVIDER=azure\n"
+            "AZURE_API_KEY=az-secret\n"
+            "DEFAULT_LLM_MODEL=gpt-5.5\n"
+            "DEFAULT_API_BASE_URL=https://myres.services.ai.azure.com/openai/v1/\n"
+            "CUSTOM_CHAT_CLASS=openai\n"
+        )
+        self._write_env(tmp_path, env_body)
+        monkeypatch.setattr(onboard, "DOT_ENV_FILENAME", ".onemancompany.env")
+        monkeypatch.chdir(tmp_path)
+
+        captured = {}
+
+        def fake_execute(console, provider, api_key, model, host, port, extras, **kwargs):
+            captured.update(kwargs)
+            captured["provider"] = provider
+            captured["api_key"] = api_key
+
+        with patch.object(onboard, "_step_execute", side_effect=fake_execute), \
+             patch.object(onboard, "_step_done"):
+            onboard.run_auto(skip_confirm=True)
+
+        assert captured["provider"] == "azure"
+        assert captured["api_key"] == "az-secret"
+        assert captured["base_url"] == "https://myres.services.ai.azure.com/openai/v1/"
+        assert captured["custom_chat_class"] == "openai"


### PR DESCRIPTION
## Background

Closes #402.

Azure AI Foundry (Microsoft Foundry) already ran on OneManCompany **today** through the generic `custom` provider, because Foundry exposes an OpenAI-compatible **v1 API** (`https://<resource>.services.ai.azure.com/openai/v1/`) that accepts the key as `Authorization: Bearer`. But it required undocumented manual steps (`custom` + `DEFAULT_API_BASE_URL` + `CUSTOM_CHAT_CLASS`) and had a real bug in non-interactive init. This PR makes Azure first-class and fixes the bug.

## What changed

Addresses all four asks in #402:

1. **`azure` provider in `PROVIDER_REGISTRY`** (`core/config.py`) — `chat_class="openai"`, `env_key="azure_api_key"`, resource-specific `base_url` supplied via `DEFAULT_API_BASE_URL`. Added `azure_api_key` to `Settings`.
2. **Onboarding wizard option** ("Azure AI Foundry" in `auth_choices.py` + `onboard.py`) — prompts for a resource name or full endpoint (normalized to the `/openai/v1/` form) and the **deployment name** (used as the model id). New `_azure_base_url()` helper.
3. **`run_auto()` bug fix** — it called `_step_execute()` without `base_url`/`custom_chat_class`, so `onemancompany-init --auto` silently dropped `DEFAULT_API_BASE_URL` and `CUSTOM_CHAT_CLASS` from the regenerated `.env`. Now preserved from the source `.env`. This fixes custom providers too, not just Azure.
4. **Docs** — `docs/providers-azure.md` (endpoint form, deployment-name-as-model, `.env` example, `--auto` behavior) + README pointer.

`make_llm()` resolves the azure `base_url` from the user-supplied endpoint via the same path as `custom`.

### Model id = deployment name
Azure uses the **deployment name** as the model id (not the base model). The wizard asks for it explicitly and the doc calls it out.

## Files

| File | Change |
|------|--------|
| `core/config.py` | `azure` registry entry, `azure_api_key` setting, `ENV_KEY_DEFAULT_BASE_URL`/`ENV_KEY_CUSTOM_CHAT_CLASS` constants |
| `core/auth_choices.py` | "Azure AI Foundry" auth choice group |
| `agents/base.py` | `make_llm` resolves azure base_url from the user endpoint |
| `onboard.py` | Azure onboarding block, `_azure_base_url()`, `run_auto()` preserves endpoint config |
| `docs/providers-azure.md`, `README.md` | Setup docs |
| `tests/...` | Onboarding flow, URL normalization, run_auto preservation, registry/auth-choice consistency |

## Testing

- Full unit suite via pre-commit hook: **4496 passed, 2 skipped**.
- End-to-end smoke: `make_llm()` with `DEFAULT_API_PROVIDER=azure` builds a `ChatOpenAI` pointed at `https://<resource>.services.ai.azure.com/openai/v1/` with the deployment name as the model.
- Version bumped to `0.7.101` (> main `0.7.99`) for the CI version gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)