### PR TITLE
fix: Windows GBK console kills startup via emoji UnicodeEncodeError (#403)

### DIFF
--- a/frontend/xterm-log.js
+++ b/frontend/xterm-log.js
@@ -70,7 +70,10 @@ class XTermLog {
       scrollback: 10000,
       cursorBlink: false,
       cursorStyle: 'bar',
-      cursorWidth: 0,
+      // xterm.js requires cursorWidth >= 1 (0 throws "cursorWidth cannot be less
+      // than 1"). The cursor stays effectively hidden — its color matches the
+      // terminal background. (#403)
+      cursorWidth: 1,
     });
 
     if (typeof FitAddon !== 'undefined') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.102",
+  "version": "0.7.103",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.102"
+version = "0.7.103"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/main.py
+++ b/src/onemancompany/main.py
@@ -43,6 +43,26 @@ OBSERVER_JOIN_TIMEOUT = 2
 
 # ---------------------------------------------------------------------------
 
+
+def _make_stream_utf8(stream) -> None:
+    """Force a text stream to UTF-8 (errors='replace') so emoji/CJK output never
+    raises UnicodeEncodeError on a locale-encoded console.
+
+    Windows PowerShell defaults stdout/stderr to GBK/CP936, which cannot encode
+    the '🏢' in the startup banner. That print runs inside the FastAPI lifespan,
+    so the encode error killed uvicorn during startup (#403). Reconfiguring both
+    streams up front makes every print AND all loguru output safe. Streams without
+    ``.reconfigure`` (already-wrapped writers, test doubles) are left untouched.
+    """
+    reconfigure = getattr(stream, "reconfigure", None)
+    if reconfigure is not None:
+        reconfigure(encoding=ENCODING_UTF8, errors="replace")
+
+
+# Must run before logger.add(sys.stderr) below so loguru writes to UTF-8 streams too.
+for _std_stream in (sys.stdout, sys.stderr):
+    _make_stream_utf8(_std_stream)
+
 # Configure loguru: DEBUG level when OMC_DEBUG=1, else INFO
 _debug_mode = os.environ.get(ENV_OMC_DEBUG, "0") == "1"
 _log_level = LogLevel.DEBUG if _debug_mode else LogLevel.INFO

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -100,6 +100,43 @@ class TestNoCacheStaticMiddleware:
 # ---------------------------------------------------------------------------
 
 
+class TestStdioUtf8Safety:
+    """Regression for #403: emoji output must not crash the app on Windows GBK/CP936
+    consoles. main.py prints '🏢 ... is running!' inside the FastAPI lifespan — on a
+    GBK stream that raised UnicodeEncodeError and killed uvicorn during startup."""
+
+    def test_gbk_stream_cannot_encode_office_emoji(self):
+        """Baseline: the actual crash — a GBK stream can't encode the office emoji."""
+        import io
+        gbk = io.TextIOWrapper(io.BytesIO(), encoding="gbk")
+        with pytest.raises(UnicodeEncodeError):
+            gbk.write("🏢")
+            gbk.flush()
+
+    def test_make_stream_utf8_makes_emoji_safe(self):
+        """After reconfiguring, the same emoji output no longer raises."""
+        import io
+        stream = io.TextIOWrapper(io.BytesIO(), encoding="gbk")
+        main_mod._make_stream_utf8(stream)
+        assert stream.encoding.lower() == "utf-8"
+        stream.write("🏢 One Man Company HQ v1.0 is running!")
+        stream.flush()  # must not raise UnicodeEncodeError
+
+    def test_make_stream_utf8_uses_replace_errors(self):
+        """errors='replace' is set so even a non-representable char degrades, not crashes."""
+        import io
+        stream = io.TextIOWrapper(io.BytesIO(), encoding="gbk")
+        main_mod._make_stream_utf8(stream)
+        assert stream.errors == "replace"
+
+    def test_make_stream_utf8_noop_on_non_reconfigurable(self):
+        """A stream without .reconfigure (e.g. a captured writer) is a graceful no-op."""
+        class _Plain:
+            def write(self, s):
+                return len(s)
+        main_mod._make_stream_utf8(_Plain())  # must not raise
+
+
 class TestSaveEphemeralState:
     def test_save_delegates_to_snapshot_harness(self, monkeypatch):
         """_save_ephemeral_state delegates to core.snapshot.save_snapshot."""


### PR DESCRIPTION
Closes #403. Reported by @Snowbow19.

## Symptom
On Windows PowerShell the launcher prints "OneManCompany is running! Open http://localhost:8000", but the page is blank — the backend already exited during FastAPI lifespan startup.

## Root cause (verified still present on `main`)
Windows PowerShell defaults `sys.stdout`/`sys.stderr` to **GBK/CP936**. The startup banner `print("🏢 One Man Company HQ v... is running!")` runs **inside the FastAPI `lifespan`** (`main.py:652`, before `yield` at 659). GBK can't encode `🏢`, so it raises `UnicodeEncodeError` → uvicorn reports "Application startup failed. Exiting." The streams are never reconfigured, so the `⚠` message at `main.py:412` and emoji-heavy loguru logs (stderr, `main.py:50`) are equally unsafe.

Separately, `frontend/xterm-log.js:73` sets `cursorWidth: 0`, which xterm.js rejects (`cursorWidth cannot be less than 1`).

## Fix — systematic, not per-line
- `main.py`: `_make_stream_utf8()` reconfigures **both** `sys.stdout`/`sys.stderr` to UTF-8 with `errors="replace"` at module import, **before** `logger.add(sys.stderr)`. Makes every print and all loguru output safe on locale-encoded consoles. Non-reconfigurable streams (test doubles, wrapped writers) are a graceful no-op. The emoji stays — modern terminals render it; GBK degrades instead of crashing.
- `frontend/xterm-log.js`: `cursorWidth` 0 → 1 (cursor still hidden via matching color).

## Tests
`tests/unit/test_main.py::TestStdioUtf8Safety` — a GBK stream can't encode the office emoji (reproduces the crash), `_make_stream_utf8` makes it safe (utf-8 + `errors="replace"`), and no-ops on non-reconfigurable streams. Full unit suite green: **4509 passed, 2 skipped**.

## Not included (separate concern)
Reporter's optional #4 — launcher health-checks the port before printing "is running". That's a launcher-UX improvement in `bin/cli.js`, orthogonal to this encoding crash. Happy to do it as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)