### PR TITLE
fix: Google Gemini API-key save fails with 'Unknown auth choice' (#405)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.106",
+  "version": "0.7.107",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.106"
+version = "0.7.107"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/auth_choices.py
+++ b/src/onemancompany/core/auth_choices.py
@@ -60,8 +60,10 @@ AUTH_CHOICE_GROUPS: list[AuthChoiceGroup] = [
         AuthChoiceOption("openrouter-api-key", "API Key", provider="openrouter", auth_method="api_key"),
     ]),
     AuthChoiceGroup("google", "Google Gemini", "OAuth + API key", [
-        AuthChoiceOption("google-gemini-oauth", "Gemini CLI OAuth", provider="google", auth_method="oauth", available=False),
-        AuthChoiceOption("google-gemini-api-key", "API Key", provider="google", auth_method="api_key"),
+        # Values must follow the {group_id}-{method} convention (#405): the Settings
+        # UI saves a key by POSTing choice=f"{group_id}-api-key".
+        AuthChoiceOption("google-oauth", "Gemini CLI OAuth", provider="google", auth_method="oauth", available=False),
+        AuthChoiceOption("google-api-key", "API Key", provider="google", auth_method="api_key"),
     ]),
     AuthChoiceGroup("minimax", "MiniMax", "OAuth + API key", [
         AuthChoiceOption("minimax-oauth", "OAuth", provider="minimax", auth_method="oauth", available=False),
@@ -86,7 +88,14 @@ def resolve_auth_choice(choice_value: str) -> AuthChoiceOption | None:
 
 
 def validate_registry_consistency() -> list[str]:
-    """Check that all AUTH_CHOICE_GROUPS group_ids exist in PROVIDER_REGISTRY."""
+    """Check AUTH_CHOICE_GROUPS invariants.
+
+    1. Every group_id must exist in PROVIDER_REGISTRY.
+    2. Every group with an api_key option must expose it under the value
+       f"{group_id}-api-key" — the Settings UI constructs that value client-side
+       (frontend _saveProviderKey), so a divergence makes Save fail with
+       "Unknown auth choice" (#405). Catch it at startup instead of at runtime.
+    """
     from onemancompany.core.config import PROVIDER_REGISTRY
     warnings = []
     for group in AUTH_CHOICE_GROUPS:
@@ -94,6 +103,13 @@ def validate_registry_consistency() -> list[str]:
             warnings.append(
                 f"AUTH_CHOICE_GROUPS group_id '{group.group_id}' "
                 f"not found in PROVIDER_REGISTRY"
+            )
+        api_key_values = {c.value for c in group.choices if c.auth_method == "api_key"}
+        expected = f"{group.group_id}-api-key"
+        if api_key_values and expected not in api_key_values:
+            warnings.append(
+                f"AUTH_CHOICE_GROUPS group '{group.group_id}' has an api_key option "
+                f"but none with value '{expected}' — the Settings UI cannot save it"
             )
     return warnings
 

--- a/tests/unit/core/test_auth_choices.py
+++ b/tests/unit/core/test_auth_choices.py
@@ -77,6 +77,37 @@ class TestAuthChoiceGroupsIntegrity:
                 assert choice.provider, f"Choice {choice.value} missing provider"
                 assert choice.auth_method, f"Choice {choice.value} missing auth_method"
 
+    def test_api_key_choice_follows_group_id_convention(self):
+        """Regression #405: the Settings UI saves a key by POSTing
+        choice=f'{group_id}-api-key' (frontend _saveProviderKey). Every group that
+        has an api_key option MUST expose it under exactly that value, or Save fails
+        with 'Unknown auth choice'. Google Gemini used 'google-gemini-api-key'."""
+        from onemancompany.core.auth_choices import AUTH_CHOICE_GROUPS, resolve_auth_choice
+
+        for group in AUTH_CHOICE_GROUPS:
+            api_key_opts = [c for c in group.choices if c.auth_method == "api_key"]
+            if not api_key_opts:
+                continue
+            expected = f"{group.group_id}-api-key"
+            resolved = resolve_auth_choice(expected)
+            assert resolved is not None and resolved.auth_method == "api_key", (
+                f"Group '{group.group_id}' has an api_key option but "
+                f"resolve_auth_choice('{expected}') did not resolve it — the Settings "
+                f"UI cannot save this provider's key."
+            )
+
+
+class TestGoogleGeminiAuthChoice:
+    def test_resolve_google_api_key(self):
+        """The exact value the frontend constructs for Google Gemini must resolve."""
+        from onemancompany.core.auth_choices import resolve_auth_choice
+
+        option = resolve_auth_choice("google-api-key")
+        assert option is not None
+        assert option.provider == "google"
+        assert option.auth_method == "api_key"
+        assert option.available is True
+
 
 class TestValidateRegistryConsistency:
     def test_all_group_ids_in_provider_registry(self):
@@ -122,7 +153,9 @@ class TestValidateRegistryConsistencyFunction:
                 label="Fake",
                 hint="",
                 choices=[AuthChoiceOption(
-                    value="fake-key", label="Fake Key", hint="",
+                    # Value follows the {group_id}-api-key convention so only the
+                    # registry-missing warning fires (see the dedicated convention test).
+                    value="nonexistent_provider-api-key", label="Fake Key", hint="",
                     provider="nonexistent_provider", auth_method="api_key",
                 )],
             ),
@@ -131,3 +164,4 @@ class TestValidateRegistryConsistencyFunction:
         warnings = validate_registry_consistency()
         assert len(warnings) == 1
         assert "nonexistent_provider" in warnings[0]
+        assert "not found in PROVIDER_REGISTRY" in warnings[0]


### PR DESCRIPTION
Closes #405. Reported by @jgmarinelli-pixel.

## Symptom
Saving a Google Gemini API key in Settings fails with `{"error": "Unknown auth choice", "code": "invalid_choice"}` even though Test validates the key.

## Root cause
The Settings UI derives the submitted choice as `{group_id}-api-key`. Every provider followed that convention except Google: its group ID was `google`, while the option value was `google-gemini-api-key`. The frontend therefore sent `google-api-key`, which `resolve_auth_choice()` could not resolve.

Renaming the group to `google-gemini` would break the provider registry contract, where the provider ID is `google`.

## Fix
- align the Google auth option values with the existing group/provider convention
- keep `group_id="google"`, matching `PROVIDER_REGISTRY`
- extend `validate_registry_consistency()` so future API-key naming drift is detected at startup and in CI
- add a regression test for the exact `google-api-key` value sent by Settings, plus a registry-wide convention test
- rebase onto current `main` and resolve the version bump as `0.7.107`

## Verification
- `tests/unit/core/test_auth_choices.py`: 15 passed
- full suite: 4543 passed, 5 skipped
- `git diff --check`: passed