### PR TITLE
fix: honor executor contract in general assistant launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.107",
+  "version": "0.7.108",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.108",
+  "version": "0.7.109",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.107"
+version = "0.7.108"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.108"
+version = "0.7.109"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [

--- a/src/onemancompany/core/subprocess_executor.py
+++ b/src/onemancompany/core/subprocess_executor.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import os
 import tempfile
+from pathlib import Path
 from typing import Callable
 
 from loguru import logger
@@ -22,6 +23,66 @@ from onemancompany.core.vessel import Launcher, LaunchResult, TaskContext
 
 _KILL_POLL_INTERVAL = 5
 _KILL_GRACE_PERIOD = 30
+
+_GENERAL_ASSISTANT_LAUNCHER_MARKER = "# General AI Assistant — Ralph-style agent loop"
+_LEGACY_MAX_ITERATIONS = 'MAX_ITERATIONS="${1:-10}"'
+_MANAGED_MAX_ITERATIONS = """if [ -n "${OMC_EMPLOYEE_ID:-}" ]; then
+  MAX_ITERATIONS="${OMC_MAX_ITERATIONS:-10}"
+else
+  MAX_ITERATIONS="${OMC_MAX_ITERATIONS:-${1:-10}}"
+fi"""
+_LEGACY_TASK_RESOLUTION = """# Resolve task: env var > first arg > interactive
+if [ -z "$TASK" ]; then
+  if [ -f "$SCRIPT_DIR/task.txt" ]; then
+    TASK="$(cat "$SCRIPT_DIR/task.txt")"
+  else
+    echo "No task provided. Set TASK env var or create task.txt"
+    exit 1
+  fi
+fi"""
+_MANAGED_TASK_RESOLUTION = """# Resolve task using the SubprocessExecutor protocol, then legacy fallbacks.
+if [ -n "${OMC_TASK_DESCRIPTION_FILE:-}" ] && [ -f "$OMC_TASK_DESCRIPTION_FILE" ]; then
+  TASK="$(cat "$OMC_TASK_DESCRIPTION_FILE")"
+elif [ -n "${OMC_TASK_DESCRIPTION:-}" ]; then
+  TASK="$OMC_TASK_DESCRIPTION"
+elif [ -n "${TASK:-}" ]; then
+  :
+elif [ -f "$SCRIPT_DIR/task.txt" ]; then
+  TASK="$(cat "$SCRIPT_DIR/task.txt")"
+else
+  echo "No task provided. Set OMC_TASK_DESCRIPTION_FILE, OMC_TASK_DESCRIPTION, TASK, or create task.txt"
+  exit 1
+fi"""
+
+
+def _migrate_managed_general_assistant_launcher(script_path: str) -> bool:
+    """Upgrade known built-in launcher fragments without replacing custom scripts."""
+    path = Path(script_path)
+    if not path.is_file():
+        return False
+
+    try:
+        content = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        logger.debug("Skipping launch script migration for {}: {}", path, exc)
+        return False
+
+    if _GENERAL_ASSISTANT_LAUNCHER_MARKER not in content:
+        return False
+
+    migrated = content.replace(_LEGACY_MAX_ITERATIONS, _MANAGED_MAX_ITERATIONS)
+    migrated = migrated.replace(_LEGACY_TASK_RESOLUTION, _MANAGED_TASK_RESOLUTION)
+    if migrated == content:
+        return False
+
+    try:
+        path.write_text(migrated, encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Could not migrate managed launch script {}: {}", path, exc)
+        return False
+
+    logger.info("Migrated managed general-assistant launcher at {}", path)
+    return True
 
 
 class SubprocessExecutor(Launcher):
@@ -35,6 +96,7 @@ class SubprocessExecutor(Launcher):
     ) -> None:
         self.employee_id = employee_id
         self.script_path = script_path or str(EMPLOYEES_DIR / employee_id / LAUNCH_SH_FILENAME)
+        _migrate_managed_general_assistant_launcher(self.script_path)
         self.timeout_seconds = timeout_seconds
         self._process: asyncio.subprocess.Process | None = None
 

--- a/src/onemancompany/talent_market/talents/general-assistant/general-assistant/launch.sh
+++ b/src/onemancompany/talent_market/talents/general-assistant/general-assistant/launch.sh
@@ -3,6 +3,7 @@
 # Iteratively runs the standalone agent, checking for task completion each round.
 #
 # Usage:
+#   ./launch.sh <employee_dir>  # SubprocessExecutor mode
 #   ./launch.sh [max_iterations]
 #   ./launch.sh 20              # run up to 20 iterations
 #   OMC_TASK_DESCRIPTION_FILE=/tmp/task.txt ./launch.sh
@@ -12,7 +13,11 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MAX_ITERATIONS="${1:-10}"
+if [ -n "${OMC_EMPLOYEE_ID:-}" ]; then
+  MAX_ITERATIONS="${OMC_MAX_ITERATIONS:-10}"
+else
+  MAX_ITERATIONS="${OMC_MAX_ITERATIONS:-${1:-10}}"
+fi
 PROGRESS_FILE="$SCRIPT_DIR/progress.log"
 
 # Initialize progress log

--- a/src/onemancompany/talent_market/talents/general-assistant/general-assistant/launch.sh
+++ b/src/onemancompany/talent_market/talents/general-assistant/general-assistant/launch.sh
@@ -5,7 +5,9 @@
 # Usage:
 #   ./launch.sh [max_iterations]
 #   ./launch.sh 20              # run up to 20 iterations
-#   TASK="Research this project" ./launch.sh   # pass task via env var
+#   OMC_TASK_DESCRIPTION_FILE=/tmp/task.txt ./launch.sh
+#   OMC_TASK_DESCRIPTION="Research this project" ./launch.sh
+#   TASK="Research this project" ./launch.sh   # legacy fallback
 
 set -e
 
@@ -20,14 +22,18 @@ if [ ! -f "$PROGRESS_FILE" ]; then
   echo "---" >> "$PROGRESS_FILE"
 fi
 
-# Resolve task: env var > first arg > interactive
-if [ -z "$TASK" ]; then
-  if [ -f "$SCRIPT_DIR/task.txt" ]; then
-    TASK="$(cat "$SCRIPT_DIR/task.txt")"
-  else
-    echo "No task provided. Set TASK env var or create task.txt"
-    exit 1
-  fi
+# Resolve task using the SubprocessExecutor protocol, then legacy fallbacks.
+if [ -n "${OMC_TASK_DESCRIPTION_FILE:-}" ] && [ -f "$OMC_TASK_DESCRIPTION_FILE" ]; then
+  TASK="$(cat "$OMC_TASK_DESCRIPTION_FILE")"
+elif [ -n "${OMC_TASK_DESCRIPTION:-}" ]; then
+  TASK="$OMC_TASK_DESCRIPTION"
+elif [ -n "${TASK:-}" ]; then
+  :
+elif [ -f "$SCRIPT_DIR/task.txt" ]; then
+  TASK="$(cat "$SCRIPT_DIR/task.txt")"
+else
+  echo "No task provided. Set OMC_TASK_DESCRIPTION_FILE, OMC_TASK_DESCRIPTION, TASK, or create task.txt"
+  exit 1
 fi
 
 echo "Starting agent loop — Max iterations: $MAX_ITERATIONS"

--- a/src/onemancompany/talent_market/talents/general-assistant/launch.sh
+++ b/src/onemancompany/talent_market/talents/general-assistant/launch.sh
@@ -3,6 +3,7 @@
 # Iteratively runs the standalone agent, checking for task completion each round.
 #
 # Usage:
+#   ./launch.sh <employee_dir>  # SubprocessExecutor mode
 #   ./launch.sh [max_iterations]
 #   ./launch.sh 20              # run up to 20 iterations
 #   OMC_TASK_DESCRIPTION_FILE=/tmp/task.txt ./launch.sh
@@ -12,7 +13,11 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-MAX_ITERATIONS="${1:-10}"
+if [ -n "${OMC_EMPLOYEE_ID:-}" ]; then
+  MAX_ITERATIONS="${OMC_MAX_ITERATIONS:-10}"
+else
+  MAX_ITERATIONS="${OMC_MAX_ITERATIONS:-${1:-10}}"
+fi
 PROGRESS_FILE="$SCRIPT_DIR/progress.log"
 
 # Initialize progress log

--- a/src/onemancompany/talent_market/talents/general-assistant/launch.sh
+++ b/src/onemancompany/talent_market/talents/general-assistant/launch.sh
@@ -5,7 +5,9 @@
 # Usage:
 #   ./launch.sh [max_iterations]
 #   ./launch.sh 20              # run up to 20 iterations
-#   TASK="Research this project" ./launch.sh   # pass task via env var
+#   OMC_TASK_DESCRIPTION_FILE=/tmp/task.txt ./launch.sh
+#   OMC_TASK_DESCRIPTION="Research this project" ./launch.sh
+#   TASK="Research this project" ./launch.sh   # legacy fallback
 
 set -e
 
@@ -20,14 +22,18 @@ if [ ! -f "$PROGRESS_FILE" ]; then
   echo "---" >> "$PROGRESS_FILE"
 fi
 
-# Resolve task: env var > first arg > interactive
-if [ -z "$TASK" ]; then
-  if [ -f "$SCRIPT_DIR/task.txt" ]; then
-    TASK="$(cat "$SCRIPT_DIR/task.txt")"
-  else
-    echo "No task provided. Set TASK env var or create task.txt"
-    exit 1
-  fi
+# Resolve task using the SubprocessExecutor protocol, then legacy fallbacks.
+if [ -n "${OMC_TASK_DESCRIPTION_FILE:-}" ] && [ -f "$OMC_TASK_DESCRIPTION_FILE" ]; then
+  TASK="$(cat "$OMC_TASK_DESCRIPTION_FILE")"
+elif [ -n "${OMC_TASK_DESCRIPTION:-}" ]; then
+  TASK="$OMC_TASK_DESCRIPTION"
+elif [ -n "${TASK:-}" ]; then
+  :
+elif [ -f "$SCRIPT_DIR/task.txt" ]; then
+  TASK="$(cat "$SCRIPT_DIR/task.txt")"
+else
+  echo "No task provided. Set OMC_TASK_DESCRIPTION_FILE, OMC_TASK_DESCRIPTION, TASK, or create task.txt"
+  exit 1
 fi
 
 echo "Starting agent loop — Max iterations: $MAX_ITERATIONS"

--- a/tests/unit/core/test_subprocess_executor.py
+++ b/tests/unit/core/test_subprocess_executor.py
@@ -11,6 +11,57 @@ from onemancompany.core.vessel import LaunchResult, TaskContext
 
 
 class TestSubprocessExecutor:
+    def test_init_migrates_managed_legacy_general_assistant_launcher(self, tmp_path):
+        """Existing built-in launchers are upgraded without a re-hire."""
+        from onemancompany.core.subprocess_executor import SubprocessExecutor
+
+        launch_sh = tmp_path / "launch.sh"
+        launch_sh.write_text(
+            "#!/bin/bash\n"
+            "# General AI Assistant — Ralph-style agent loop\n"
+            'MAX_ITERATIONS="${1:-10}"\n'
+            '# Resolve task: env var > first arg > interactive\n'
+            'if [ -z "$TASK" ]; then\n'
+            '  if [ -f "$SCRIPT_DIR/task.txt" ]; then\n'
+            '    TASK="$(cat "$SCRIPT_DIR/task.txt")"\n'
+            "  else\n"
+            '    echo "No task provided. Set TASK env var or create task.txt"\n'
+            "    exit 1\n"
+            "  fi\n"
+            "fi\n"
+        )
+
+        SubprocessExecutor(employee_id="00010", script_path=str(launch_sh))
+
+        migrated = launch_sh.read_text()
+        assert "OMC_TASK_DESCRIPTION_FILE" in migrated
+        assert "OMC_MAX_ITERATIONS" in migrated
+        assert 'MAX_ITERATIONS="${1:-10}"' not in migrated
+
+    def test_init_preserves_custom_launcher(self, tmp_path):
+        """Migration must never rewrite an unrecognized user launcher."""
+        from onemancompany.core.subprocess_executor import SubprocessExecutor
+
+        launch_sh = tmp_path / "launch.sh"
+        custom_content = "#!/bin/bash\necho custom launcher\n"
+        launch_sh.write_text(custom_content)
+
+        SubprocessExecutor(employee_id="00010", script_path=str(launch_sh))
+
+        assert launch_sh.read_text() == custom_content
+
+    def test_init_preserves_non_utf8_launcher(self, tmp_path):
+        """Binary or non-UTF-8 launchers are ignored by the managed migration."""
+        from onemancompany.core.subprocess_executor import SubprocessExecutor
+
+        launch_sh = tmp_path / "launch.sh"
+        custom_content = b"\xca\xfe\xba\xbe"
+        launch_sh.write_bytes(custom_content)
+
+        SubprocessExecutor(employee_id="00010", script_path=str(launch_sh))
+
+        assert launch_sh.read_bytes() == custom_content
+
     @pytest.mark.asyncio
     async def test_execute_happy_path(self):
         """Execute runs launch.sh and captures JSON output."""

--- a/tests/unit/talent_market/test_general_assistant_launch.py
+++ b/tests/unit/talent_market/test_general_assistant_launch.py
@@ -1,0 +1,69 @@
+"""Regression tests for the built-in general-assistant launch protocol."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parents[3]
+LAUNCH_SCRIPTS = (
+    REPO_ROOT / "src/onemancompany/talent_market/talents/general-assistant/launch.sh",
+    REPO_ROOT / "src/onemancompany/talent_market/talents/general-assistant/general-assistant/launch.sh",
+)
+
+
+def _run_launch(tmp_path: Path, script: Path, env_updates: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Run a launch script with a fake Python agent that completes immediately."""
+    launch_script = tmp_path / "launch.sh"
+    shutil.copy2(script, launch_script)
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python"
+    fake_python.write_text("#!/bin/sh\ncat\nprintf '<done>COMPLETE</done>\\n'\n")
+    fake_python.chmod(0o755)
+
+    env = os.environ.copy()
+    env.pop("TASK", None)
+    env.pop("OMC_TASK_DESCRIPTION", None)
+    env.pop("OMC_TASK_DESCRIPTION_FILE", None)
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env.update(env_updates)
+
+    return subprocess.run(
+        ["bash", str(launch_script)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("script", LAUNCH_SCRIPTS)
+def test_launch_reads_subprocess_executor_task_file(tmp_path: Path, script: Path) -> None:
+    prompt_file = tmp_path / "task-prompt.txt"
+    prompt_file.write_text("task delivered through the executor file")
+
+    result = _run_launch(tmp_path, script, {"OMC_TASK_DESCRIPTION_FILE": str(prompt_file)})
+
+    assert result.returncode == 0, result.stderr
+    assert "Task: task delivered through the executor file" in result.stdout
+
+
+@pytest.mark.parametrize("script", LAUNCH_SCRIPTS)
+def test_launch_falls_back_to_direct_task_description(tmp_path: Path, script: Path) -> None:
+    result = _run_launch(
+        tmp_path,
+        script,
+        {"OMC_TASK_DESCRIPTION": "task delivered directly in the environment"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Task: task delivered directly in the environment" in result.stdout

--- a/tests/unit/talent_market/test_general_assistant_launch.py
+++ b/tests/unit/talent_market/test_general_assistant_launch.py
@@ -17,7 +17,13 @@ LAUNCH_SCRIPTS = (
 )
 
 
-def _run_launch(tmp_path: Path, script: Path, env_updates: dict[str, str]) -> subprocess.CompletedProcess[str]:
+def _run_launch(
+    tmp_path: Path,
+    script: Path,
+    env_updates: dict[str, str],
+    *,
+    executor_mode: bool = True,
+) -> subprocess.CompletedProcess[str]:
     """Run a launch script with a fake Python agent that completes immediately."""
     launch_script = tmp_path / "launch.sh"
     shutil.copy2(script, launch_script)
@@ -35,8 +41,20 @@ def _run_launch(tmp_path: Path, script: Path, env_updates: dict[str, str]) -> su
     env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
     env.update(env_updates)
 
+    command = ["bash", str(launch_script)]
+    if executor_mode:
+        employee_dir = tmp_path / "employee"
+        employee_dir.mkdir()
+        env["OMC_EMPLOYEE_ID"] = "00010"
+        env["OMC_MAX_ITERATIONS"] = "1"
+        command.append(str(employee_dir))
+    else:
+        env.pop("OMC_EMPLOYEE_ID", None)
+        env.pop("OMC_MAX_ITERATIONS", None)
+        command.append("1")
+
     return subprocess.run(
-        ["bash", str(launch_script)],
+        command,
         cwd=tmp_path,
         env=env,
         capture_output=True,
@@ -67,3 +85,16 @@ def test_launch_falls_back_to_direct_task_description(tmp_path: Path, script: Pa
 
     assert result.returncode == 0, result.stderr
     assert "Task: task delivered directly in the environment" in result.stdout
+
+
+@pytest.mark.parametrize("script", LAUNCH_SCRIPTS)
+def test_launch_preserves_legacy_numeric_iteration_argument(tmp_path: Path, script: Path) -> None:
+    result = _run_launch(
+        tmp_path,
+        script,
+        {"TASK": "legacy standalone task"},
+        executor_mode=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Max iterations: 1" in result.stdout


### PR DESCRIPTION
## Summary

- make both built-in general-assistant launch scripts follow the full `SubprocessExecutor` contract
- read tasks from `OMC_TASK_DESCRIPTION_FILE`, with direct and legacy fallbacks
- treat the executor's positional employee directory as a path instead of an iteration count; use `OMC_MAX_ITERATIONS` in executor mode
- safely migrate recognizable existing built-in launchers while leaving custom and non-UTF-8 launchers untouched
- add executable regression coverage for the real executor invocation and migration behavior
- bump package version to 0.7.109

## Root cause

`SubprocessExecutor` delivers the prompt through `OMC_TASK_DESCRIPTION_FILE` and invokes `bash launch.sh <employee_dir>`. The built-in general-assistant launcher still used the older `TASK`/`task.txt` contract and interpreted its first positional argument as a numeric iteration limit. As a result, dispatched tasks either had no prompt or failed in `seq` before the agent loop began.

Existing hires also retained copied launch scripts, so updating only the talent template would not repair already installed built-in assistants.

## Verification

- regression tests reproduce the real `bash launch.sh <employee_dir>` invocation for both packaged script copies
- focused launcher/executor suite: 25 passed
- full suite: 4552 passed, 5 skipped
- pre-commit unit suite: 4526 passed, 2 skipped
- shell syntax and diff checks passed

## Quality checklist

| # | Check | Answer |
|---|---|---|
| 1 | What changed | Built-in launchers now honor task-file and employee-directory inputs; known legacy copies migrate in place |
| 2 | Root cause fix | Yes; the launcher now implements the producer's complete invocation protocol |
| 3 | Single source of truth | Yes; task transport remains owned by `SubprocessExecutor`, with no duplicate state |
| 4 | Test regression | Full suite passed with 4552 passed and 5 skipped |
| 5 | Reuse | Yes; migration reuses exact managed-template fragments and preserves custom scripts |

Fixes #407
