### PR TITLE
fix: repair broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,11 +446,11 @@ See [vibe-coding-guide.md](vibe-coding-guide.md) for coding guidelines.
 
 ## Star History
 
-<a href="https://star-history.com/#1mancompany/OneManCompany&Date">
+<a href="https://star-history.dera.page/#1mancompany/OneManCompany&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=1mancompany/OneManCompany&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=1mancompany/OneManCompany&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=1mancompany/OneManCompany&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=1mancompany/OneManCompany&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=1mancompany/OneManCompany&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=1mancompany/OneManCompany&type=Date" />
  </picture>
 </a>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -457,11 +457,11 @@ npx --yes @1mancompany/onemancompany@latest uninstall
 
 ## Star History
 
-<a href="https://star-history.com/#1mancompany/OneManCompany&Date">
+<a href="https://star-history.dera.page/#1mancompany/OneManCompany&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=1mancompany/OneManCompany&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=1mancompany/OneManCompany&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=1mancompany/OneManCompany&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=1mancompany/OneManCompany&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=1mancompany/OneManCompany&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=1mancompany/OneManCompany&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The Star History chart in the README was broken because the underlying provider relies on the GitHub stargazer API, which is rate limited. This change points the chart at an alternative that uses a different data source, so the chart renders without requiring an API token. The whole chart (both light and dark themes) now works from the same host.