### PR TITLE
v0.7.111 fix(ci): auto-assign-owner must use pull_request_target for fork PRs

### DIFF
--- a/.github/workflows/auto-assign-owner.yml
+++ b/.github/workflows/auto-assign-owner.yml
@@ -1,7 +1,11 @@
 name: Auto-assign owner
 
 on:
-  pull_request:
+  # pull_request_target (not pull_request) so the job runs in the base-repo
+  # context: fork PRs downgrade GITHUB_TOKEN to read-only under pull_request,
+  # which makes addAssignees fail with 403 "Resource not accessible by
+  # integration". Safe here because this job never checks out PR code.
+  pull_request_target:
     types: [opened]
   issues:
     types: [opened]
@@ -16,6 +20,7 @@ jobs:
       OWNER: zhengxuyu
     steps:
       - name: Assign repo owner
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.110",
+  "version": "0.7.111",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.110"
+version = "0.7.111"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
## Problem

The `Auto-assign owner` check fails on every PR opened from a **fork**. Most recently PR #431 (author `Dessalines39394`, `isCrossRepository: true`):

```
POST /repos/1mancompany/OneManCompany/issues/431/assignees
body: {"assignees":["zhengxuyu"]}
403  Resource not accessible by integration
x-accepted-github-permissions: issues=write; pull_requests=write
```

Same failure earlier on run `27491336749`.

## Root cause

For `pull_request` events originating from a fork, GitHub forces `GITHUB_TOKEN` to read-only. The workflow's `permissions: issues: write / pull-requests: write` block cannot raise it — that block only works for same-repo branches. So `addAssignees` is guaranteed to 403 on any fork PR.

This is not an "assign to the wrong person" bug. Same-repo PRs have always passed (runs `26102631459`, `25673200724`, `25660751459` all green).

## Fix

1. `pull_request` → `pull_request_target`. The job then runs in the base-repo context with a writable token, so the `permissions:` block takes effect.

   **Security note:** `pull_request_target` is only dangerous when a workflow checks out and executes PR code. This job does neither — it makes a single `addAssignees` API call and never touches the PR's tree. No injection surface.

2. `continue-on-error: true` on the step, so any unexpected API failure marks only this step rather than turning the whole PR red.

## Caveats

- `pull_request_target` reads the workflow file from the **base branch**, so this only affects PRs opened after it lands on `main`. Existing PR #431 will keep its red X; it does not block merge.
- Verified `zhengxuyu` is a repo collaborator (`GET /collaborators/zhengxuyu` → 204). Worth stating because GitHub *silently ignores* assignees who aren't collaborators — the workflow would go green while assigning nobody.
- If "Require approval for all external contributors" is enabled in Settings → Actions, fork PR runs will sit **pending approval** rather than running. That is a yellow wait, not a failure, and is unrelated to this fix.

## Testing

- YAML parses; triggers resolve to `['pull_request_target', 'issues']`, `continue-on-error: True`.
- `pyproject.toml` and `package.json` both parse after the version bump.
- No Python, JS, or frontend files changed, so the unit suite is unaffected — CI runs it on this PR regardless.
- Real verification is the next fork PR opened after this merges.

## Version

`0.7.110` → `0.7.111` (patch — CI config only), synced across `pyproject.toml` and `package.json` for the CI version gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)