### PR TITLE
v0.7.113 fix(readme): restore Star History chart with a sealed token

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,11 +446,11 @@ See [vibe-coding-guide.md](vibe-coding-guide.md) for coding guidelines.
 
 ## Star History
 
-<a href="https://star-history.com/#1mancompany/OneManCompany&Date">
+<a href="https://www.star-history.com/?repos=1mancompany%2FOneManCompany&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=1mancompany/OneManCompany&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=1mancompany/OneManCompany&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=1mancompany/OneManCompany&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=1mancompany/OneManCompany&type=date&theme=dark&legend=top-left&sealed_token=69KMopaLSYQ037wYSGySXTYgO0zP1H4aNs7vxntM0ADV4hFWqQ4TfmrJimV5xNQ6aVcIpluzrkCFCNOgu65laAWF42Nn8B_wBDZtwrk3rAWwo86zN_-Gqg" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=1mancompany/OneManCompany&type=date&legend=top-left&sealed_token=69KMopaLSYQ037wYSGySXTYgO0zP1H4aNs7vxntM0ADV4hFWqQ4TfmrJimV5xNQ6aVcIpluzrkCFCNOgu65laAWF42Nn8B_wBDZtwrk3rAWwo86zN_-Gqg" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=1mancompany/OneManCompany&type=date&legend=top-left&sealed_token=69KMopaLSYQ037wYSGySXTYgO0zP1H4aNs7vxntM0ADV4hFWqQ4TfmrJimV5xNQ6aVcIpluzrkCFCNOgu65laAWF42Nn8B_wBDZtwrk3rAWwo86zN_-Gqg" />
  </picture>
 </a>
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -457,11 +457,11 @@ npx --yes @1mancompany/onemancompany@latest uninstall
 
 ## Star History
 
-<a href="https://star-history.com/#1mancompany/OneManCompany&Date">
+<a href="https://www.star-history.com/?repos=1mancompany%2FOneManCompany&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=1mancompany/OneManCompany&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=1mancompany/OneManCompany&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=1mancompany/OneManCompany&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=1mancompany/OneManCompany&type=date&theme=dark&legend=top-left&sealed_token=69KMopaLSYQ037wYSGySXTYgO0zP1H4aNs7vxntM0ADV4hFWqQ4TfmrJimV5xNQ6aVcIpluzrkCFCNOgu65laAWF42Nn8B_wBDZtwrk3rAWwo86zN_-Gqg" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=1mancompany/OneManCompany&type=date&legend=top-left&sealed_token=69KMopaLSYQ037wYSGySXTYgO0zP1H4aNs7vxntM0ADV4hFWqQ4TfmrJimV5xNQ6aVcIpluzrkCFCNOgu65laAWF42Nn8B_wBDZtwrk3rAWwo86zN_-Gqg" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=1mancompany/OneManCompany&type=date&legend=top-left&sealed_token=69KMopaLSYQ037wYSGySXTYgO0zP1H4aNs7vxntM0ADV4hFWqQ4TfmrJimV5xNQ6aVcIpluzrkCFCNOgu65laAWF42Nn8B_wBDZtwrk3rAWwo86zN_-Gqg" />
  </picture>
 </a>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1mancompany/onemancompany",
-  "version": "0.7.112",
+  "version": "0.7.113",
   "description": "The AI Operating System for One-Person Companies",
   "bin": {
     "onemancompany": "bin/cli.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onemancompany"
-version = "0.7.112"
+version = "0.7.113"
 description = "A one-man company simulation with pixel art visualization and LangChain AI agents"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
Closes the same problem as #431, but keeps the original star-history.com service instead of switching to a third-party mirror.

## Root cause

Not a dead URL and not a CDN problem. Both the origin and GitHub's camo proxy returned HTTP 200 with a valid SVG the whole time — the SVG itself was the problem:

```
text elements: "GitHub restricted access to star data"
               "GitHub team is looking into it"
               "star-history.com/blog/github-stargazer-api-restriction"
circle: 0   polyline: 0      <- zero data points
```

GitHub [restricted the stargazers API on 2026-06-30](https://star-history.com/blog/github-stargazer-api-restriction) to a repository's own admins and collaborators. star-history.com's servers aren't a collaborator here, so their fetch returns `Not Found` and they serve a notice image. Per their blog this broke README star charts for **essentially every repository**, not just this one.

Confirmed the data is still reachable with a properly scoped token:

```
GET /repos/1mancompany/OneManCompany/stargazers  ->  200, 398 stars
```

## Fix

star-history's supported path for your own repo: pass a sealed (encrypted) token. Their server decrypts it in memory per request, reads stars, discards it.

- `/svg` → `/chart`, plus `&sealed_token=...` on all three URLs
- anchor `href` → current `www.star-history.com/?repos=...` form
- `&legend=top-left` to match the generated embed

Applied identically to `README.md` and `README_zh.md` (scripted replace, asserted exactly one match per file).

## Verification

Fetched both variants before committing:

| variant | http | size | axis | paths | verdict |
|---|---|---|---|---|---|
| light | 200 | 65550 | March–August, 100/200/300 | 7 | real data |
| dark  | 200 | 65556 | March–August, 100/200/300 | 7 | real data |

Versus the old URL, which returned the notice image with 0 circles and 0 polylines.

No Python/JS/frontend files changed, so the unit suite is unaffected; CI runs it anyway.

## Note on the token

The `sealed_token` is encrypted and designed to live in a public README, but the underlying GitHub token carries write access (star-history's docs state the stargazers endpoint now requires `contents: write` for fine-grained tokens, or `public_repo` for classic). Worth scoping it to this repo only, and rotating it if star-history is ever compromised.

## Relationship to #431

#431 fixed the symptom by pointing at `star-history.dera.page`, an unaffiliated third-party domain. That mirror does return real data, but it would have served every README visitor's chart from a domain outside our control. This PR keeps the original service. #431 can be closed.

## Version

`0.7.112` → `0.7.113`, synced across `pyproject.toml` and `package.json` for the CI version gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)